### PR TITLE
Support qwen2 model, optimize phi3 model, revise model loading strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,9 +1019,12 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ env_logger = "0.10.1"
 tracing = "0.1.40"
 range-checked = { git = "https://github.com/EricLBuehler/range-checked.git", version = "0.1.0" }
 chrono = { version = "0.4.31", features = ["clock"] }
-either = "1.9.0"
+either = { version = "1.13.0", features = ["serde"] }
 dirs = "5.0.1"
 kernels = {path = "./kernels", version="0.1.0"}
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Currently, candle-vllm supports chat serving for the following models.
 
 | Model ID | Model Type | Supported | Speed (A100, BF16)
 |--|--|--|--|
-| #1 | **LLAMA/LLAMA2/LLaMa3** |✅|71 tks/s (7B)|
+| #1 | **LLAMA/LLAMA2/LLaMa3** |✅|73 tks/s (7B)|
 | #2 | Mistral |TBD|TBD|
 | #3 | Phi (v1, v1.5, v2) |TBD|TBD|
-| #4 | **Phi-3 （3.8B, 7B）** |✅|99 tks/s (3.8B)|
+| #4 | **Phi-3 （3.8B, 7B）** |✅|102 tks/s (3.8B)|
 | #5 | Yi |TBD|TBD|
 | #6 | StableLM |TBD|TBD|
 | #7 | BigCode/StarCode |TBD|TBD|
 | #8 | ChatGLM |TBD|TBD|
-| #9 | QWen |TBD|TBD|
+| #9 | **QWen2 (1.8B, 7B)** |✅|148 tks/s (1.8B)|
 | #10 | Google Gemma |TBD|TBD|
 | #11 | Blip-large (Multimodal) |TBD|TBD|
 | #12 | Moondream-2 (Multimodal LLM) |TBD|TBD|
@@ -47,7 +47,12 @@ sudo apt install libssl-dev
 sudo apt install pkg-config
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
-cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama7b --repeat-last-n 64
+cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama --repeat-last-n 64
+```
+
+You may also run specific model using huggingface model-id, e.g.,
+```
+cargo run --release -- --port 2000 --model-id meta-llama/Llama-2-7b-chat-hf llama --repeat-last-n 64
 ```
 
 ### Step 2:
@@ -105,7 +110,7 @@ openai.api_key = "EMPTY"
 openai.base_url = "http://localhost:2000/v1/"
 
 completion = openai.chat.completions.create(
-    model="llama7b",
+    model="llama",
     messages=[
         {
             "role": "user",
@@ -124,9 +129,25 @@ After the `candle-vllm` service is running, run the Python script and enjoy effi
 ## Usage Help
 For general configuration help, run `cargo run -- --help`.
 
-For model-specific help, run `cargo run -- --port 1234 <MODEL NAME> --help`
+For model-specific help, run `cargo run -- --port 2000 <MODEL_TYPE> --help`
 
-For local model weights, run `cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama7b --repeat-last-n 64`, change the path when needed.
+For local model weights, run `cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama --repeat-last-n 64`, change the path when needed.
+
+`MODEL_TYPE` = ["llama", "phi3", "qwen2"]
+
+`WEIGHT_FILE_PATH` = Corresponding weight path for the given model type
+
+```
+cargo run --release --features gcu -- --port 2000 --weight-path <WEIGHT_FILE_PATH> <MODEL_TYPE> --repeat-last-n 64
+```
+
+or
+
+`MODEL_ID` = Huggingface model id
+
+```
+cargo run --release --features gcu -- --port 2000 --model-id <MODEL_ID> <MODEL_TYPE> --repeat-last-n 64
+```
 
 For kvcache configuration, set `kvcache_mem_cpu` and `kvcache_mem_gpu`, default 4GB CPU memory and 4GB GPU memory for kvcache. 
 
@@ -134,6 +155,7 @@ For chat history settings, set `record_conversation` to `true` to let candle-vll
 
 For chat streaming, the `stream` flag in chat request need to be set to `True`.
 
+You may revise `repetition_penalty` and `temperature` flag in chat request (http post).
 
 ## Report issue
 Installing `candle-vllm` is as simple as the following steps. If you have any problems, please create an

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,7 +2,6 @@ mod cache;
 mod paged_attention;
 
 const COPY_BLOCKS_KERNEL_NAME: &str = "copy_blocks_kernel";
-const RESHAPE_AND_CACHE_KERNEL_NAME: &str = "reshape_and_cache_kernel";
 
 pub fn get_or_load_func(
     ptx_file: &'static str,
@@ -58,34 +57,11 @@ unsafe impl<'a, T, R> DeviceRepr for Conjoined<'a, T, R> {
     }
 }
 
-fn dispatch_get_cuda_pointer(tensor: Tensor) -> u64 {
-    match tensor.dtype() {
-        DType::BF16 => get_cuda_pointer::<bf16>(tensor),
-        DType::F16 => get_cuda_pointer::<f16>(tensor),
-        DType::U8 => get_cuda_pointer::<u8>(tensor),
-        DType::U32 => get_cuda_pointer::<u32>(tensor),
-        DType::I64 => get_cuda_pointer::<i64>(tensor),
-        DType::F32 => get_cuda_pointer::<f32>(tensor),
-        DType::F64 => get_cuda_pointer::<f64>(tensor),
-    }
-}
-
-fn get_cuda_pointer<T: CudaDType>(tensor: Tensor) -> u64 {
-    match &*tensor.storage_and_layout().0 {
-        Storage::Cuda(cuda_storage) => *cuda_storage.as_cuda_slice::<T>().unwrap().device_ptr(),
-        other => panic!("Unsupported storage `{:?}`", other),
-    }
-}
-
 pub use cache::*;
 use candle_core::{
-    cuda_backend::{
-        cudarc::driver::{CudaFunction, DevicePtr, DeviceRepr},
-        CudaDType,
-    },
-    CudaDevice, DType, Storage, Tensor,
+    cuda_backend::cudarc::driver::{CudaFunction, DeviceRepr},
+    CudaDevice, DType,
 };
-use half::{bf16, f16};
 pub use paged_attention::*;
 pub use std::ops::Deref;
 use std::{

--- a/src/backend/paged_attention.rs
+++ b/src/backend/paged_attention.rs
@@ -1,5 +1,4 @@
 // use candle_core::{cuda_backend::cudarc::driver::CudaFunction, DType, Tensor};
-use crate::openai::responses::APIError;
 use candle::backend::BackendStorage;
 use candle::cuda_backend::cudarc::driver::DevicePtr;
 use candle::cuda_backend::WrapErr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,29 +9,22 @@ use openai::pipelines::{
 
 #[derive(Debug, Subcommand)]
 pub enum ModelSelected {
-    /// Select the llama7b model.
-    Llama7b {
+    /// Select the llama model (default llama2-7b).
+    Llama {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
         repeat_last_n: usize,
     },
 
-    /// Select the llama13b model.
-    Llama13b {
-        /// Control the application of repeat penalty for the last n tokens
-        #[arg(long)]
-        repeat_last_n: usize,
-    },
-
-    /// Select the llama70b model.
-    Llama70b {
-        /// Control the application of repeat penalty for the last n tokens
-        #[arg(long)]
-        repeat_last_n: usize,
-    },
-
-    /// Select the phi3 3.8b model.
+    /// Select the phi3 model (default 3.8b).
     Phi3 {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: usize,
+    },
+
+    /// Select the qwen model (default 1.5b).
+    Qwen2 {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
         repeat_last_n: usize,
@@ -41,43 +34,50 @@ pub enum ModelSelected {
 impl ToString for ModelSelected {
     fn to_string(&self) -> String {
         match self {
-            ModelSelected::Llama7b { repeat_last_n: _ } => "llama7b".to_string(),
-            ModelSelected::Llama13b { repeat_last_n: _ } => "llama13b".to_string(),
-            ModelSelected::Llama70b { repeat_last_n: _ } => "llama70b".to_string(),
+            ModelSelected::Llama { repeat_last_n: _ } => "llama".to_string(),
             ModelSelected::Phi3 { repeat_last_n: _ } => "phi3".to_string(),
+            ModelSelected::Qwen2 { repeat_last_n: _ } => "qwen2".to_string(),
         }
     }
 }
 
-pub fn get_model_loader<'a>(selected_model: ModelSelected) -> (Box<dyn ModelLoader<'a>>, String) {
+pub fn get_model_loader<'a>(
+    selected_model: ModelSelected,
+    model_id: Option<String>,
+) -> (Box<dyn ModelLoader<'a>>, String) {
     match selected_model {
-        ModelSelected::Llama7b { repeat_last_n } => (
+        ModelSelected::Llama { repeat_last_n } => (
             Box::new(DefaultLoader::new(
                 SpecificConfig::new(repeat_last_n),
-                "llama7b".to_string(),
+                "llama".to_string(),
             )),
-            "meta-llama/Llama-2-7b-chat-hf".to_string(),
-        ),
-        ModelSelected::Llama13b { repeat_last_n } => (
-            Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
-                "llama13b".to_string(),
-            )),
-            "meta-llama/Llama-2-13b-chat-hf".to_string(),
-        ),
-        ModelSelected::Llama70b { repeat_last_n } => (
-            Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
-                "llama70b".to_string(),
-            )),
-            "meta-llama/Llama-2-70b-chat-hf".to_string(),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "meta-llama/Llama-2-7b-chat-hf".to_string()
+            },
         ),
         ModelSelected::Phi3 { repeat_last_n } => (
             Box::new(DefaultLoader::new(
                 SpecificConfig::new(repeat_last_n),
                 "phi3".to_string(),
             )),
-            "microsoft/Phi-3-mini-4k-instruct".to_string(),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "microsoft/Phi-3-mini-4k-instruct".to_string()
+            },
+        ),
+        ModelSelected::Qwen2 { repeat_last_n } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(repeat_last_n),
+                "qwen2".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "Qwen/Qwen2-1.5B-Instruct".to_string()
+            },
         ),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub enum ModelSelected {
         repeat_last_n: usize,
     },
 
-    /// Select the qwen model (default 1.5b).
+    /// Select the qwen model (default 1.8b).
     Qwen2 {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
@@ -76,7 +76,7 @@ pub fn get_model_loader<'a>(
             if model_id.is_some() {
                 model_id.unwrap()
             } else {
-                "Qwen/Qwen2-1.5B-Instruct".to_string()
+                "Qwen/Qwen1.5-1.8B-Chat".to_string()
             },
         ),
     }

--- a/src/openai/conversation/default_conversation.rs
+++ b/src/openai/conversation/default_conversation.rs
@@ -16,8 +16,9 @@ pub enum SeparatorStyle {
     NoColonSingle,
     NoColonTwo,
     AddNewLineSingle,
-    Llama2,
+    Llama,
     Phi,
+    Qwen2,
     ChatGLM,
     ChatML,
     ChatIntern,
@@ -220,7 +221,7 @@ impl Conversation for DefaultConversation {
                 accum
             }
 
-            SeparatorStyle::Llama2 => {
+            SeparatorStyle::Llama => {
                 let mut accum = "".to_string();
                 for (i, message) in self.messages.iter().enumerate() {
                     let Message((_role, message)) = message;
@@ -258,6 +259,29 @@ impl Conversation for DefaultConversation {
                         //assistant message
                         if let Some(message) = message {
                             accum += &format!("<|assistant|>{message}<|end|>");
+                        }
+                    } else if i == 0 && !system_prompt.is_empty() {
+                        accum += &system_prompt;
+                    }
+                }
+                accum
+            }
+
+            SeparatorStyle::Qwen2 => {
+                let mut accum = "".to_string();
+                for (i, message) in self.messages.iter().enumerate() {
+                    let Message((_role, message)) = message;
+                    if _role.clone() == self.roles.0 {
+                        //user message
+                        if let Some(message) = message {
+                            accum += &format!("<|im_start|>user\n {message} <|im_end|>");
+                        } else {
+                            accum += &format!("<|im_start|> <|im_end|>");
+                        }
+                    } else if _role.clone() == self.roles.1 {
+                        //assistant message
+                        if let Some(message) = message {
+                            accum += &format!("<|im_start|>assistant\n {message} <|im_end|>");
                         }
                     } else if i == 0 && !system_prompt.is_empty() {
                         accum += &system_prompt;

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -37,13 +37,14 @@ impl LlamaConfig {
             num_attention_heads: self.num_attention_heads,
             num_key_value_heads: self.num_key_value_heads.unwrap_or(self.num_attention_heads),
             rms_norm_eps: self.rms_norm_eps,
-            rope_theta: self.rope_theta,
+            rope_theta: self.rope_theta as f64,
             use_flash_attn,
             bos_token_id: self.bos_token_id,
             eos_token_id: self.eos_token_id,
             max_seq_len: MAX_SEQ_LEN,
             sliding_window: None,
             hidden_act: None,
+            tie_word_embeddings: false,
         }
     }
 }
@@ -62,7 +63,7 @@ impl Cache {
         let n_elem = config.hidden_size / config.num_attention_heads;
         let theta: Vec<_> = (0..n_elem)
             .step_by(2)
-            .map(|i| 1f32 / config.rope_theta.powf(i as f32 / n_elem as f32))
+            .map(|i| 1f32 / config.rope_theta.powf(i as f64 / n_elem as f64) as f32)
             .collect();
         let theta = Tensor::new(theta.as_slice(), device)?;
         let idx_theta = Tensor::arange(0, config.max_seq_len as u32, device)?

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -44,6 +44,8 @@ impl LlamaConfig {
             sliding_window: None,
             hidden_act: None,
             tie_word_embeddings: false,
+            rope_scaling: None,
+            original_max_position_embeddings: None,
         }
     }
 }

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod llama;
 pub mod phi3;
+pub mod qwen2;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -11,12 +12,13 @@ pub struct Config {
     pub num_key_value_heads: usize,
     pub use_flash_attn: bool,
     pub rms_norm_eps: f64,
-    pub rope_theta: f32,
+    pub rope_theta: f64,
     pub bos_token_id: Option<u32>,
     pub eos_token_id: Option<u32>,
     pub max_seq_len: usize,
     pub sliding_window: Option<usize>,
     pub hidden_act: Option<candle_nn::Activation>,
+    pub tie_word_embeddings: bool,
 }
 
 impl Config {

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -1,6 +1,12 @@
 pub mod llama;
 pub mod phi3;
 pub mod qwen2;
+use either::Either;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct RopeScaling(#[serde(with = "either::serde_untagged")] pub Either<Vec<f64>, String>);
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -19,6 +25,8 @@ pub struct Config {
     pub sliding_window: Option<usize>,
     pub hidden_act: Option<candle_nn::Activation>,
     pub tie_word_embeddings: bool,
+    pub rope_scaling: Option<HashMap<String, RopeScaling>>,
+    pub original_max_position_embeddings: Option<usize>,
 }
 
 impl Config {

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -5,7 +5,6 @@ use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
 use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_core as candle;
-use candle_nn::LayerNorm;
 use candle_nn::VarBuilder;
 use candle_transformers::models::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
 use std::iter::zip;
@@ -59,7 +58,7 @@ struct RotaryEmbedding {
 }
 
 impl RotaryEmbedding {
-    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+    fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
         let dim = cfg.hidden_size / cfg.num_attention_heads;
         let max_seq_len = cfg.max_seq_len;
         let inv_freq: Vec<_> = (0..dim)
@@ -72,7 +71,6 @@ impl RotaryEmbedding {
             .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
-        let cos_sin = Tensor::cat(&[&freqs.cos()?, &freqs.sin()?], D::Minus1)?.contiguous()?; //must be contiguous tensor;
         Ok(Self {
             sin: freqs.sin()?,
             cos: freqs.cos()?,

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -3,7 +3,6 @@ use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
 use candle::{DType, Device, Module, Result, Tensor, D};
 use candle_core as candle;
-use candle_nn::LayerNorm;
 use candle_nn::VarBuilder;
 use candle_transformers::models::with_tracing::{linear, linear_no_bias, Linear, RmsNorm};
 use std::iter::zip;
@@ -58,7 +57,7 @@ struct RotaryEmbedding {
 }
 
 impl RotaryEmbedding {
-    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+    fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
         let dim = cfg.hidden_size / cfg.num_attention_heads;
         let max_seq_len = cfg.max_seq_len;
         let inv_freq: Vec<_> = (0..dim)

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -46,6 +46,8 @@ impl QwenConfig {
             sliding_window: Some(self.sliding_window),
             hidden_act: Some(self.hidden_act),
             tie_word_embeddings: self.tie_word_embeddings,
+            rope_scaling: None,
+            original_max_position_embeddings: None,
         }
     }
 }

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -1,36 +1,35 @@
-// This implementation is based on:
-// https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py
 use super::Config;
 use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
+use candle::{DType, Device, Module, Result, Tensor, D};
 use candle_core as candle;
 use candle_nn::LayerNorm;
 use candle_nn::VarBuilder;
-use candle_transformers::models::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
+use candle_transformers::models::with_tracing::{linear, linear_no_bias, Linear, RmsNorm};
 use std::iter::zip;
 use std::sync::Arc;
 
-// https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/config.json
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct PhiConfig {
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct QwenConfig {
     pub vocab_size: usize,
-    pub hidden_act: candle_nn::Activation,
     pub hidden_size: usize,
     pub intermediate_size: usize,
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub num_key_value_heads: usize,
-    pub rms_norm_eps: f64,
-    pub rope_theta: f64,
-    pub bos_token_id: Option<u32>,
-    pub eos_token_id: Option<u32>,
-    pub rope_scaling: Option<String>,
     pub max_position_embeddings: usize,
-    pub sliding_window: Option<usize>,
+    pub sliding_window: usize,
+    pub max_window_layers: usize,
+    pub tie_word_embeddings: bool, //shared weights between input/output embeddings
+    pub rope_theta: f64,
+    pub rms_norm_eps: f64,
+    pub use_sliding_window: bool,
+    pub hidden_act: candle_nn::Activation,
+    pub bos_token_id: usize,
+    pub eos_token_id: usize,
 }
 
-impl PhiConfig {
+impl QwenConfig {
     pub fn into_config(self, use_flash_attn: bool) -> Config {
         Config {
             hidden_size: self.hidden_size,
@@ -42,12 +41,12 @@ impl PhiConfig {
             rms_norm_eps: self.rms_norm_eps,
             rope_theta: self.rope_theta,
             use_flash_attn,
-            bos_token_id: self.bos_token_id,
-            eos_token_id: self.eos_token_id,
+            bos_token_id: Some(self.bos_token_id as u32),
+            eos_token_id: Some(self.eos_token_id as u32),
             max_seq_len: self.max_position_embeddings,
-            sliding_window: self.sliding_window,
+            sliding_window: Some(self.sliding_window),
             hidden_act: Some(self.hidden_act),
-            tie_word_embeddings: false,
+            tie_word_embeddings: self.tie_word_embeddings,
         }
     }
 }
@@ -72,7 +71,6 @@ impl RotaryEmbedding {
             .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
-        let cos_sin = Tensor::cat(&[&freqs.cos()?, &freqs.sin()?], D::Minus1)?.contiguous()?; //must be contiguous tensor;
         Ok(Self {
             sin: freqs.sin()?,
             cos: freqs.cos()?,
@@ -94,35 +92,75 @@ impl RotaryEmbedding {
     }
 }
 
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+struct MLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: candle_nn::Activation,
+}
+
+impl MLP {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let intermediate_sz = cfg.intermediate_size;
+        let gate_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(intermediate_sz, hidden_sz, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn: cfg.hidden_act.unwrap(),
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let lhs = xs.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = xs.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
 struct Attention {
-    qkv_proj: Linear,
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
     o_proj: Linear,
     num_heads: usize,
     num_kv_heads: usize,
     num_kv_groups: usize,
-    hidden_size: usize,
     head_dim: usize,
+    hidden_size: usize,
     rotary_emb: Arc<RotaryEmbedding>,
     attn: PagedAttention,
 }
 
 impl Attention {
     fn new(rotary_emb: Arc<RotaryEmbedding>, cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
-        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
-        let op_size = num_heads * head_dim + 2 * num_kv_heads * head_dim;
-        let qkv_proj = linear(cfg.hidden_size, op_size, vb.pp("qkv_proj"))?;
-        let o_proj = linear(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let num_kv_groups = num_heads / num_kv_heads;
+        let head_dim = hidden_sz / num_heads;
+        let q_proj = linear(hidden_sz, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj = linear(hidden_sz, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear(hidden_sz, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj = linear_no_bias(num_heads * head_dim, hidden_sz, vb.pp("o_proj"))?;
         Ok(Self {
-            qkv_proj,
+            q_proj,
+            k_proj,
+            v_proj,
             o_proj,
-            rotary_emb,
             num_heads,
             num_kv_heads,
-            num_kv_groups: num_heads / num_kv_heads,
+            num_kv_groups,
             head_dim,
-            hidden_size: cfg.hidden_size,
+            hidden_size: hidden_sz,
+            rotary_emb,
             attn: PagedAttention::new(
                 cfg.num_attention_heads,
                 head_dim,
@@ -145,17 +183,9 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = xs.dims3()?;
 
-        let qkv = self.qkv_proj.forward(xs)?;
-        let query_pos = self.num_heads * self.head_dim;
-        let query_states = qkv.narrow(D::Minus1, 0, query_pos)?;
-        let key_states = qkv.narrow(D::Minus1, query_pos, self.num_kv_heads * self.head_dim)?;
-        let value_states = qkv
-            .narrow(
-                D::Minus1,
-                query_pos + self.num_kv_heads * self.head_dim,
-                self.num_kv_heads * self.head_dim,
-            )?
-            .contiguous()?;
+        let query_states = self.q_proj.forward(xs)?;
+        let key_states = self.k_proj.forward(xs)?;
+        let value_states = self.v_proj.forward(xs)?;
 
         let (q, k, v) = if seq_len == 1 {
             //no need transpose for seq_len == 1, change reshape dim
@@ -176,7 +206,6 @@ impl Attention {
             (q, k, v.contiguous()?)
         };
 
-        //preserve the precision with F32 type
         let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(
             &q.to_dtype(DType::F32)?,
             &k.to_dtype(DType::F32)?,
@@ -187,6 +216,7 @@ impl Attention {
 
         let k = candle_transformers::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
         let v = candle_transformers::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+
         let y = self.attn.forward(
             &q,
             &k,
@@ -208,42 +238,9 @@ impl Attention {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Mlp {
-    gate_up_proj: Linear,
-    down_proj: Linear,
-    act_fn: candle_nn::Activation,
-    i_size: usize,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
-        let hidden_size = cfg.hidden_size;
-        let i_size = cfg.intermediate_size;
-        let gate_up_proj = linear(hidden_size, 2 * i_size, vb.pp("gate_up_proj"))?;
-        let down_proj = linear(i_size, hidden_size, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap(),
-            i_size,
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let up_states = xs.apply(&self.gate_up_proj)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states = (up_states * gate.apply(&self.act_fn))?;
-        up_states.apply(&self.down_proj)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
-    mlp: Mlp,
+    mlp: MLP,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
@@ -251,7 +248,7 @@ struct DecoderLayer {
 impl DecoderLayer {
     fn new(rotary_emb: Arc<RotaryEmbedding>, cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"))?;
-        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        let mlp = MLP::new(cfg, vb.pp("mlp"))?;
         let input_layernorm =
             RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let post_attention_layernorm = RmsNorm::new(
@@ -287,22 +284,23 @@ impl DecoderLayer {
     }
 }
 
-pub struct Phi {
+pub struct Qwen2 {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
     lm_head: Linear,
+    sliding_window: Option<usize>,
     device: Device,
     dtype: DType,
     cfg: Config,
 }
 
-impl Phi {
+impl Qwen2 {
     pub fn new(vb: VarBuilder, cfg: &Config, dtype: DType, device: &Device) -> Result<Self> {
         let vb_m = vb.pp("model");
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, vb_m.device())?);
+        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, device)?);
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         for layer_idx in 0..cfg.num_hidden_layers {
@@ -310,12 +308,21 @@ impl Phi {
             layers.push(layer)
         }
         let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
-        let lm_head = linear(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?;
+        let lm_head = linear_no_bias(
+            cfg.hidden_size,
+            cfg.vocab_size,
+            if cfg.tie_word_embeddings {
+                vb_m.pp("embed_tokens")
+            } else {
+                vb.pp("lm_head")
+            },
+        )?;
         Ok(Self {
             embed_tokens,
             layers,
             norm,
             lm_head,
+            sliding_window: cfg.sliding_window,
             device: device.clone(),
             dtype: dtype,
             cfg: cfg.clone(),
@@ -328,9 +335,26 @@ impl Phi {
         tgt_len: usize,
         seqlen_offset: usize,
     ) -> Result<Tensor> {
-        let mask: Vec<_> = (0..tgt_len)
-            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
-            .collect();
+        // Sliding window mask?
+        let mask: Vec<_> = if self.sliding_window.is_some() {
+            let sliding_window = self.sliding_window.unwrap();
+            (0..tgt_len)
+                .flat_map(|i| {
+                    (0..tgt_len).map(move |j| {
+                        if i < j || j + sliding_window < i {
+                            f32::NEG_INFINITY
+                        } else {
+                            0.
+                        }
+                    })
+                })
+                .collect()
+        } else {
+            (0..tgt_len)
+                .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
+                .collect()
+        };
+
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
             let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, &self.device)?;
@@ -379,10 +403,10 @@ impl Phi {
                 )?
             }
         }
+
         xs.narrow(1, seq_len - 1, 1)?
             .apply(&self.norm)?
             .apply(&self.lm_head)?
-            .i((.., 0, ..))?
             .squeeze(0)?
             .to_dtype(DType::F32)
     }

--- a/src/openai/openai_server.rs
+++ b/src/openai/openai_server.rs
@@ -151,7 +151,7 @@ async fn chat_completions(
         request.best_of,
         request.presence_penalty.unwrap_or(0.0),
         request.frequency_penalty.unwrap_or(0.0),
-        1.0,
+        request.repetition_penalty.unwrap_or(1.1),
         request.temperature.unwrap_or(0.7),
         request.top_p.unwrap_or(1.0),
         request.top_k.unwrap_or(-1),
@@ -161,7 +161,7 @@ async fn chat_completions(
         request.stop.clone(),
         request.stop_token_ids.clone().unwrap_or_default(),
         request.ignore_eos.unwrap_or(false),
-        request.max_tokens.unwrap_or(512),
+        request.max_tokens.unwrap_or(1024),
         None,
         None,
         request.skip_special_tokens.unwrap_or(true),
@@ -215,7 +215,12 @@ async fn chat_completions(
                 "\r\n Decoding: {} tokens processed in {} seconds ({} tokens/s)",
                 usage.completion_tokens,
                 usage.completion_time_costs / 1000,
-                usage.completion_tokens * 1000 / usage.completion_time_costs
+                usage.completion_tokens * 1000
+                    / if usage.completion_time_costs > 0 {
+                        usage.completion_time_costs
+                    } else {
+                        1
+                    }
             );
         });
 

--- a/src/openai/openai_server.rs
+++ b/src/openai/openai_server.rs
@@ -1,5 +1,3 @@
-use std::thread;
-
 use super::requests::ChatCompletionRequest;
 use super::requests::Messages;
 use super::responses::{APIError, ChatCompletionResponse, ChatCompletionUsageResponse};
@@ -7,9 +5,7 @@ use super::sampling_params::{EarlyStoppingCondition, SamplingParams};
 use super::streaming::new_streaming_conn;
 use super::utils::get_created_time_secs;
 use super::OpenAIServerData;
-use actix_web::web::Bytes;
 use actix_web::{post, web, Either, HttpResponse};
-use std::time::{Duration, Instant};
 use tokenizers::Encoding;
 use uuid::Uuid;
 
@@ -107,7 +103,7 @@ async fn chat_completions(
     data: web::Data<OpenAIServerData<'static>>,
     request: web::Json<ChatCompletionRequest>,
 ) -> Either<Result<web::Json<ChatCompletionResponse>, APIError>, HttpResponse> {
-    let model_name = &request.model;
+    // let model_name = &request.model;
     // let res = verify_model(&data, model_name);
     // if res.is_err() {
     //     return Either::Left(Err(res.err().unwrap()));

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -195,7 +195,11 @@ impl<'a> LLMEngine<'a> {
                                 Some(logprobs.bytes.clone()),
                                 None,
                             );
-                            let _ = sender.send(Ok(Bytes::from(str_response))).await;
+                            if token_len > 1 {
+                                //do not send the first generated token in prompt stage
+                            } else {
+                                let _ = sender.send(Ok(Bytes::from(str_response))).await;
+                            }
                         };
                         print!("{}", logprobs.bytes.clone());
                         seq.deref_mut().add_token(logprobs);

--- a/src/openai/pipelines/mod.rs
+++ b/src/openai/pipelines/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     conversation::Conversation, models::Config, responses::APIError,
-    sampling_params::SamplingParams, PipelineConfig, TokenizerWrapper,
+    sampling_params::SamplingParams, PipelineConfig,
 };
 use candle_examples::token_output_stream::TokenOutputStream;
 /// The LLMEngine is effectively a wrapper around a ModulePipeline. It contains a Scheduler and a CacheEngine

--- a/src/openai/requests.rs
+++ b/src/openai/requests.rs
@@ -54,4 +54,6 @@ pub struct ChatCompletionRequest {
     pub stop_token_ids: Option<Vec<usize>>, //[]
     #[serde(default)]
     pub logprobs: Option<bool>, //false
+    #[serde(default)]
+    pub repetition_penalty: Option<f32>, //1.1
 }

--- a/src/openai/sampling_params.rs
+++ b/src/openai/sampling_params.rs
@@ -1,9 +1,6 @@
+use super::{requests::StopTokens, responses::APIError};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
-// use candle_sampling::logits_processor::{LogitsProcessor, SamplingMethod};
-use tokenizers::Tokenizer;
-
-use super::{requests::StopTokens, responses::APIError};
 
 const SAMPLING_EPS: f32 = 1e-5;
 

--- a/src/openai/streaming.rs
+++ b/src/openai/streaming.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 pub(crate) type SenderError = Arc<dyn Error + Send + Sync>;
 
 pub(crate) fn new_streaming_conn() -> (Sender<Result<Bytes, SenderError>>, Client) {
-    let (tx, rx) = channel(5);
+    let (tx, rx) = channel(1);
     (tx, Client(rx))
 }
 

--- a/src/paged_attention/mod.rs
+++ b/src/paged_attention/mod.rs
@@ -107,7 +107,7 @@ impl PagedAttention {
                 .reshape(((), attention_heads, head_size))?;
             (q, k, v)
         } else {
-            //avoid unneccesary transpose for decoding
+            //avoid unnecessary transpose for decoding
             let q = query.reshape(((), attention_heads, head_size))?;
             let k = key.reshape(((), key_value_heads, head_size))?;
             let v = value.reshape(((), key_value_heads, head_size))?;

--- a/src/paged_attention/mod.rs
+++ b/src/paged_attention/mod.rs
@@ -1,10 +1,6 @@
-use candle_core::{DType, Device, Result, Tensor, D};
+use candle_core::{Device, Result, Tensor};
 
-use crate::{
-    backend::{paged_attention, reshape_and_cache},
-    openai::responses::APIError,
-    try_api,
-};
+use crate::backend::{paged_attention, reshape_and_cache};
 
 use self::input_metadata::InputMetadata;
 mod attn_bias;

--- a/src/scheduler/block_engine.rs
+++ b/src/scheduler/block_engine.rs
@@ -79,7 +79,7 @@ struct GPUAllocator;
 struct CPUAllocator;
 
 struct GPUAllocatorWrapper(usize);
-struct CPUAllocatorWrapper(usize);
+// struct CPUAllocatorWrapper(usize);
 
 impl Deref for GPUAllocatorWrapper {
     type Target = usize;
@@ -89,13 +89,13 @@ impl Deref for GPUAllocatorWrapper {
     }
 }
 
-impl Deref for CPUAllocatorWrapper {
-    type Target = usize;
+// impl Deref for CPUAllocatorWrapper {
+//     type Target = usize;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
 
 struct Allocator<T> {
     free_blocks: BlockTable,

--- a/src/scheduler/sequence.rs
+++ b/src/scheduler/sequence.rs
@@ -259,7 +259,7 @@ impl SequenceGroup {
         // }
         for seq in self.seqs.values() {
             // Lock each sequence individually and set the status
-            if let Ok(mut seq_guard) = seq.0.write() {
+            if let Ok(seq_guard) = seq.0.write() {
                 seq_guard.deref_mut().set_status(status.clone());
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -14,7 +14,10 @@ use std::{collections::HashMap, sync::Arc};
 
 #[actix_web::test]
 async fn test_llama() -> Result<(), APIError> {
-    let (loader, model_id) = get_model_loader(ModelSelected::Llama7b { repeat_last_n: 64 });
+    let (loader, model_id) = get_model_loader(
+        ModelSelected::Llama { repeat_last_n: 64 },
+        Some("meta-llama/Llama-2-7b-chat-hf".to_string()),
+    );
     let paths = loader.download_model(
         model_id,
         None,
@@ -83,6 +86,7 @@ async fn test_llama() -> Result<(), APIError> {
             ignore_eos: None,
             stop_token_ids: None,
             logprobs: None,
+            repetition_penalty: None,
         })
         .to_request();
 


### PR DESCRIPTION
Key changes for #44 :

1. QWen2 model added
2. Performance of Phi3 optimized
3. Redundant transpose removed in decoding stage for paged attention
4. Model loading strategy changed: given a model type, specify the local weight path or concret model id, this enables loading of different models under the same model architecture, for example, llama3 for model type of "llama"
5. ReadMe updated to reflect newly supported models and corresponding usage

Tested case:

```
cargo run --release -- --port 2000 --weight-path /home/qwen2-1.8b/ qwen2 --repeat-last-n 64
```

or

```
cargo run --release -- --port 2000 --model-id Qwen/Qwen1.5-1.8B-Chat qwen2 --repeat-last-n 64
```

Around 150 tokens/s achieved for qwen2 1.8B on A100 (mixed precision of FP32 and BF16).
