### PR TITLE
Error prompt for requested message exceeds model capacity

### DIFF
--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -31,9 +31,10 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PipelineConfig {
     pub max_model_len: usize,
+    pub default_max_tokens: usize,
 }
 
 #[derive(Clone)]

--- a/src/openai/responses.rs
+++ b/src/openai/responses.rs
@@ -1,5 +1,5 @@
 use crate::openai::sampling_params::Logprobs;
-use actix_web::error;
+use actix_web::{error, HttpResponse};
 use derive_more::{Display, Error};
 
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,14 @@ pub struct APIError {
     data: String,
 }
 
-impl error::ResponseError for APIError {}
+impl error::ResponseError for APIError {
+    fn error_response(&self) -> HttpResponse {
+        //pack error to json so that client can handle it
+        HttpResponse::BadRequest()
+            .content_type("application/json")
+            .json(self.data.to_string())
+    }
+}
 
 impl APIError {
     pub fn new(data: String) -> Self {


### PR DESCRIPTION
Error respone when requested message exceeds model capacity (maximum context length), the client will receive the error message like this (ChatUI also requires updates):

![image](https://github.com/EricLBuehler/candle-vllm/assets/27915071/7fb7256b-525e-4aa4-bc19-14f819be3cce)

