### PR TITLE
Support Gemma model & remove repeat_kv (replaced with broadcast matmu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Currently, candle-vllm supports chat serving for the following models.
 
 | Model ID | Model Type | Supported | Speed (A100, BF16)
 |--|--|--|--|
-| #1 | **LLAMA/LLAMA2/LLaMa3** |✅|73 tks/s (7B)|
+| #1 | **LLAMA/LLAMA2/LLaMa3** |✅|74 tks/s (7B)|
 | #2 | Mistral |TBD|TBD|
 | #3 | Phi (v1, v1.5, v2) |TBD|TBD|
-| #4 | **Phi-3 （3.8B, 7B）** |✅|102 tks/s (3.8B)|
+| #4 | **Phi-3 （3.8B, 7B）** |✅|107 tks/s (3.8B)|
 | #5 | Yi |TBD|TBD|
 | #6 | StableLM |TBD|TBD|
 | #7 | BigCode/StarCode |TBD|TBD|
 | #8 | ChatGLM |TBD|TBD|
 | #9 | **QWen2 (1.8B, 7B)** |✅|148 tks/s (1.8B)|
-| #10 | Google Gemma |TBD|TBD|
+| #10 | **Google Gemma** |✅|130 tks/s (2B)|
 | #11 | Blip-large (Multimodal) |TBD|TBD|
 | #12 | Moondream-2 (Multimodal LLM) |TBD|TBD|
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,13 @@ pub enum ModelSelected {
         #[arg(long)]
         repeat_last_n: usize,
     },
+
+    /// Select the gemma model (default 2b).
+    Gemma {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: usize,
+    },
 }
 
 impl ToString for ModelSelected {
@@ -37,6 +44,7 @@ impl ToString for ModelSelected {
             ModelSelected::Llama { repeat_last_n: _ } => "llama".to_string(),
             ModelSelected::Phi3 { repeat_last_n: _ } => "phi3".to_string(),
             ModelSelected::Qwen2 { repeat_last_n: _ } => "qwen2".to_string(),
+            ModelSelected::Gemma { repeat_last_n: _ } => "gemma".to_string(),
         }
     }
 }
@@ -77,6 +85,17 @@ pub fn get_model_loader<'a>(
                 model_id.unwrap()
             } else {
                 "Qwen/Qwen1.5-1.8B-Chat".to_string()
+            },
+        ),
+        ModelSelected::Gemma { repeat_last_n } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(repeat_last_n),
+                "gemma".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "google/gemma-2b-it".to_string()
             },
         ),
     }

--- a/src/openai/conversation/default_conversation.rs
+++ b/src/openai/conversation/default_conversation.rs
@@ -19,6 +19,7 @@ pub enum SeparatorStyle {
     Llama,
     Phi,
     Qwen2,
+    Gemma,
     ChatGLM,
     ChatML,
     ChatIntern,
@@ -287,6 +288,21 @@ impl Conversation for DefaultConversation {
                         accum += &system_prompt;
                     }
                 }
+                accum
+            }
+
+            SeparatorStyle::Gemma => {
+                let mut accum = "".to_string();
+                for (_, message) in self.messages.iter().enumerate() {
+                    let Message((_role, message)) = message;
+                    if let Some(message) = message {
+                        accum +=
+                            &format!("<bos><start_of_turn>{_role}\n {message} <end_of_turn>\n");
+                    } else {
+                        accum += &format!("<start_of_turn>{_role}\n <end_of_turn>\n");
+                    }
+                }
+                accum += "<start_of_turn>model\n";
                 accum
             }
 

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -46,6 +46,7 @@ impl LlamaConfig {
             tie_word_embeddings: false,
             rope_scaling: None,
             original_max_position_embeddings: None,
+            attention_bias: false,
         }
     }
 }
@@ -136,9 +137,6 @@ impl CausalSelfAttention {
 
         let q = self.apply_rotary_emb(&q, index_pos)?;
         let k = self.apply_rotary_emb(&k, index_pos)?;
-
-        let k = self.repeat_kv(k)?;
-        let v = self.repeat_kv(v)?;
 
         let y = self.attn.forward(
             &q,

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod gemma;
 pub mod llama;
 pub mod phi3;
 pub mod qwen2;
@@ -27,6 +28,7 @@ pub struct Config {
     pub tie_word_embeddings: bool,
     pub rope_scaling: Option<HashMap<String, RopeScaling>>,
     pub original_max_position_embeddings: Option<usize>,
+    pub attention_bias: bool,
 }
 
 impl Config {

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -51,6 +51,7 @@ impl PhiConfig {
             tie_word_embeddings: false,
             rope_scaling: self.rope_scaling,
             original_max_position_embeddings: self.original_max_position_embeddings,
+            attention_bias: false,
         }
     }
 }
@@ -290,8 +291,6 @@ impl Attention {
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
-        let k = candle_transformers::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
-        let v = candle_transformers::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
         let y = self.attn.forward(
             &q,
             &k,

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -9,6 +9,7 @@ use crate::{
             Conversation,
         },
         models::{
+            gemma::{Gemma, GemmaConfig},
             llama::{Llama, LlamaConfig},
             phi3::{Phi, PhiConfig},
             qwen2::{Qwen2, QwenConfig},
@@ -50,6 +51,7 @@ enum LLMModel {
     LLAMA(Llama),
     Phi3(Phi),
     Qwen2(Qwen2),
+    Gemma(Gemma),
 }
 /// top-p, multinomial, and argmax sampling are implemented. Beam search is not implemented.
 pub struct DefaultPipeline {
@@ -159,6 +161,12 @@ impl<'a> ModelLoader<'a> for DefaultLoader {
                 ),));
                 config.into_config(false)
             }
+            "gemma" => {
+                let config: GemmaConfig = try_api!(serde_json::from_slice(&try_api!(
+                    std::fs::read(paths.get_config_filename())
+                ),));
+                config.into_config(false)
+            }
             _ => panic!(""),
         };
 
@@ -186,6 +194,10 @@ impl<'a> ModelLoader<'a> for DefaultLoader {
                 LLMModel::Qwen2(try_api!(Qwen2::new(vb, &config, dtype, &device))),
                 SeparatorStyle::Qwen2,
             ),
+            "gemma" => (
+                LLMModel::Gemma(try_api!(Gemma::new(vb, &config, dtype, &device))),
+                SeparatorStyle::Gemma,
+            ),
             _ => panic!(""),
         };
 
@@ -210,11 +222,6 @@ impl<'a> ModelLoader<'a> for DefaultLoader {
         };
 
         println!("{:?}", pipeline_config);
-
-        let eos_token = match tokenizer.get_token("<|endoftext|>") {
-            Some(token) => token,
-            None => tokenizer.tokenizer().token_to_id(EOS_TOKEN).unwrap(),
-        };
 
         let eos_token = match tokenizer.get_token("<|endoftext|>") {
             Some(token) => token,
@@ -289,6 +296,16 @@ impl<'s> ModulePipeline<'s> for DefaultPipeline {
                 )
                 .map_err(APIError::from),
             LLMModel::Qwen2(qwen2) => qwen2
+                .forward(
+                    &input_tokens
+                        .reshape((1, input_tokens.shape().dims()[0]))
+                        .unwrap(),
+                    self.cur_idx,
+                    kv_cache,
+                    &mut input_metadata,
+                )
+                .map_err(APIError::from),
+            LLMModel::Gemma(gemma) => gemma
                 .forward(
                     &input_tokens
                         .reshape((1, input_tokens.shape().dims()[0]))
@@ -388,6 +405,7 @@ impl<'s> ModulePipeline<'s> for DefaultPipeline {
             LLMModel::LLAMA(llama) => llama.get_config().clone(),
             LLMModel::Phi3(phi) => phi.get_config().clone(),
             LLMModel::Qwen2(qwen2) => qwen2.get_config().clone(),
+            LLMModel::Gemma(gemma) => gemma.get_config().clone(),
         }
     }
 


### PR DESCRIPTION
Key features in this PR:

1. Support Google Gemma model
2. Repeat_kv method is removed since we performed broadcasted matmul in the prefiling stage, while, the decoding stage used paged-attention which also does not need kv stacking (to match query dim).