### PR TITLE
Support Phi2 and Mistral models, fix generation remainder, more sampling parameters, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Currently, candle-vllm supports chat serving for the following models.
 | Model ID | Model Type | Supported | Speed (A100, BF16)
 |--|--|--|--|
 | #1 | **LLAMA/LLAMA2/LLaMa3** |✅|74 tks/s (7B)|
-| #2 | Mistral |TBD|TBD|
-| #3 | Phi (v1, v1.5, v2) |TBD|TBD|
+| #2 | **Mistral** |✅|TBD|
+| #3 | **Phi (v1, v1.5, v2)** |✅|97 tks/s (2.7B, F32+BF16)|
 | #4 | **Phi-3 （3.8B, 7B）** |✅|107 tks/s (3.8B)|
 | #5 | Yi |TBD|TBD|
 | #6 | StableLM |TBD|TBD|
@@ -133,7 +133,7 @@ For model-specific help, run `cargo run -- --port 2000 <MODEL_TYPE> --help`
 
 For local model weights, run `cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama --repeat-last-n 64`, change the path when needed.
 
-`MODEL_TYPE` = ["llama", "phi3", "qwen2", "gemma"]
+`MODEL_TYPE` = ["llama", "mistral", "phi2", "phi3", "qwen2", "gemma"]
 
 `WEIGHT_FILE_PATH` = Corresponding weight path for the given model type
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,27 @@ pub enum ModelSelected {
         repeat_last_n: usize,
     },
 
+    /// Select the phi2 model (default 2.7b).
+    Phi2 {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: usize,
+    },
+
     /// Select the phi3 model (default 3.8b).
     Phi3 {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
         repeat_last_n: usize,
+
+        #[arg(long)]
+        temperature: Option<f64>,
+
+        #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
     },
 
     /// Select the qwen model (default 1.8b).
@@ -28,10 +44,26 @@ pub enum ModelSelected {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
         repeat_last_n: usize,
+
+        #[arg(long)]
+        temperature: Option<f64>,
+
+        #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
     },
 
     /// Select the gemma model (default 2b).
     Gemma {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: usize,
+    },
+
+    /// Select the mistral model (default 7b).
+    Mistral {
         /// Control the application of repeat penalty for the last n tokens
         #[arg(long)]
         repeat_last_n: usize,
@@ -42,9 +74,21 @@ impl ToString for ModelSelected {
     fn to_string(&self) -> String {
         match self {
             ModelSelected::Llama { repeat_last_n: _ } => "llama".to_string(),
-            ModelSelected::Phi3 { repeat_last_n: _ } => "phi3".to_string(),
-            ModelSelected::Qwen2 { repeat_last_n: _ } => "qwen2".to_string(),
+            ModelSelected::Phi2 { repeat_last_n: _ } => "phi2".to_string(),
+            ModelSelected::Phi3 {
+                repeat_last_n: _,
+                temperature: _,
+                top_k: _,
+                top_p: _,
+            } => "phi3".to_string(),
+            ModelSelected::Qwen2 {
+                repeat_last_n: _,
+                temperature: _,
+                top_k: _,
+                top_p: _,
+            } => "qwen2".to_string(),
             ModelSelected::Gemma { repeat_last_n: _ } => "gemma".to_string(),
+            ModelSelected::Mistral { repeat_last_n: _ } => "mistral".to_string(),
         }
     }
 }
@@ -56,7 +100,7 @@ pub fn get_model_loader<'a>(
     match selected_model {
         ModelSelected::Llama { repeat_last_n } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
+                SpecificConfig::new(repeat_last_n, None, None, None),
                 "llama".to_string(),
             )),
             if model_id.is_some() {
@@ -65,9 +109,25 @@ pub fn get_model_loader<'a>(
                 "meta-llama/Llama-2-7b-chat-hf".to_string()
             },
         ),
-        ModelSelected::Phi3 { repeat_last_n } => (
+        ModelSelected::Phi2 { repeat_last_n } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
+                SpecificConfig::new(repeat_last_n, None, None, None),
+                "phi2".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "microsoft/microsoft/phi-2".to_string()
+            },
+        ),
+        ModelSelected::Phi3 {
+            repeat_last_n,
+            temperature,
+            top_k,
+            top_p,
+        } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(repeat_last_n, temperature, top_k, top_p),
                 "phi3".to_string(),
             )),
             if model_id.is_some() {
@@ -76,9 +136,14 @@ pub fn get_model_loader<'a>(
                 "microsoft/Phi-3-mini-4k-instruct".to_string()
             },
         ),
-        ModelSelected::Qwen2 { repeat_last_n } => (
+        ModelSelected::Qwen2 {
+            repeat_last_n,
+            temperature,
+            top_k,
+            top_p,
+        } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
+                SpecificConfig::new(repeat_last_n, temperature, top_k, top_p),
                 "qwen2".to_string(),
             )),
             if model_id.is_some() {
@@ -89,13 +154,24 @@ pub fn get_model_loader<'a>(
         ),
         ModelSelected::Gemma { repeat_last_n } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n),
+                SpecificConfig::new(repeat_last_n, None, None, None),
                 "gemma".to_string(),
             )),
             if model_id.is_some() {
                 model_id.unwrap()
             } else {
                 "google/gemma-2b-it".to_string()
+            },
+        ),
+        ModelSelected::Mistral { repeat_last_n } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(repeat_last_n, None, None, None),
+                "mistral".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "mistralai/Mistral-7B-Instruct-v0.3".to_string()
             },
         ),
     }

--- a/src/openai/conversation/default_conversation.rs
+++ b/src/openai/conversation/default_conversation.rs
@@ -20,6 +20,7 @@ pub enum SeparatorStyle {
     Phi,
     Qwen2,
     Gemma,
+    Mistral,
     ChatGLM,
     ChatML,
     ChatIntern,
@@ -222,7 +223,7 @@ impl Conversation for DefaultConversation {
                 accum
             }
 
-            SeparatorStyle::Llama => {
+            SeparatorStyle::Llama | SeparatorStyle::Mistral => {
                 let mut accum = "".to_string();
                 for (i, message) in self.messages.iter().enumerate() {
                     let Message((_role, message)) = message;

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -27,7 +27,7 @@ fn default_rope() -> f32 {
 }
 
 impl LlamaConfig {
-    pub fn into_config(self, use_flash_attn: bool) -> Config {
+    pub fn into_config(self, use_flash_attn: bool, kv_cache_dtype: DType) -> Config {
         Config {
             hidden_size: self.hidden_size,
             intermediate_size: self.intermediate_size,
@@ -47,6 +47,9 @@ impl LlamaConfig {
             rope_scaling: None,
             original_max_position_embeddings: None,
             attention_bias: false,
+            partial_rotary_factor: None,
+            qk_layer_rms_norm: None,
+            kv_cache_dtype,
         }
     }
 }

--- a/src/openai/models/mistral.rs
+++ b/src/openai/models/mistral.rs
@@ -1,37 +1,31 @@
-// This implementation is based on:
-// https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py
-use super::{Config, RopeScaling};
+use super::Config;
 use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
-use candle_core as candle;
-use candle_nn::VarBuilder;
-use candle_transformers::models::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
-use either::Either;
-use std::collections::HashMap;
+use candle_core::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{Activation, VarBuilder};
+use candle_transformers::models::with_tracing::{linear_no_bias, Linear, RmsNorm};
 use std::iter::zip;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct PhiConfig {
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct MistralConfig {
     pub vocab_size: usize,
-    pub hidden_act: candle_nn::Activation,
     pub hidden_size: usize,
     pub intermediate_size: usize,
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub num_key_value_heads: usize,
+    pub hidden_act: Activation,
+    pub max_position_embeddings: usize,
     pub rms_norm_eps: f64,
     pub rope_theta: f64,
-    pub bos_token_id: Option<u32>,
-    pub eos_token_id: Option<u32>,
-    pub rope_scaling: Option<HashMap<String, RopeScaling>>,
-    pub max_position_embeddings: usize,
-    pub original_max_position_embeddings: Option<usize>,
     pub sliding_window: Option<usize>,
+    pub bos_token_id: usize,
+    pub eos_token_id: usize,
+    pub tie_word_embeddings: Option<bool>,
 }
 
-impl PhiConfig {
+impl MistralConfig {
     pub fn into_config(self, use_flash_attn: bool, kv_cache_dtype: DType) -> Config {
         Config {
             hidden_size: self.hidden_size,
@@ -43,14 +37,14 @@ impl PhiConfig {
             rms_norm_eps: self.rms_norm_eps,
             rope_theta: self.rope_theta,
             use_flash_attn,
-            bos_token_id: self.bos_token_id,
-            eos_token_id: self.eos_token_id,
+            bos_token_id: Some(self.bos_token_id as u32),
+            eos_token_id: Some(self.eos_token_id as u32),
             max_seq_len: self.max_position_embeddings,
             sliding_window: self.sliding_window,
             hidden_act: Some(self.hidden_act),
-            tie_word_embeddings: false,
-            rope_scaling: self.rope_scaling,
-            original_max_position_embeddings: self.original_max_position_embeddings,
+            tie_word_embeddings: self.tie_word_embeddings.unwrap_or(false),
+            rope_scaling: None,
+            original_max_position_embeddings: None,
             attention_bias: false,
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
@@ -63,108 +57,28 @@ impl PhiConfig {
 struct RotaryEmbedding {
     sin: Tensor,
     cos: Tensor,
-    sin_long: Option<Tensor>,
-    cos_long: Option<Tensor>,
-    original_max_position_embeddings: Option<usize>,
 }
 
 impl RotaryEmbedding {
-    fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+        let rope_theta = cfg.rope_theta as f32;
         let dim = cfg.hidden_size / cfg.num_attention_heads;
         let max_seq_len = cfg.max_seq_len;
         let inv_freq: Vec<_> = (0..dim)
             .step_by(2)
-            .map(|i| 1f32 / cfg.rope_theta.powf(i as f64 / dim as f64) as f32)
+            .map(|i| 1f32 / rope_theta.powf(i as f32 / dim as f32))
             .collect();
         let inv_freq_len = inv_freq.len();
-        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
-            .to_dtype(DType::F32)?
+            .to_dtype(dtype)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
-
-        if let Some(rope_scaling) = &cfg.rope_scaling {
-            match (
-                &rope_scaling["short_factor"],
-                &rope_scaling["long_factor"],
-                &rope_scaling["type"],
-            ) {
-                (
-                    RopeScaling(Either::Left(short_factor)),
-                    RopeScaling(Either::Left(long_factor)),
-                    RopeScaling(Either::Right(tp)),
-                ) => {
-                    let scale = cfg.max_seq_len as f64
-                        / cfg.original_max_position_embeddings.unwrap() as f64;
-                    let scaling_factor = if scale <= 1.0 {
-                        1.0
-                    } else {
-                        match tp.as_str() {
-                            "su" | "longrope" => (1.0
-                                + scale.ln()
-                                    / (cfg.original_max_position_embeddings.unwrap() as f64).ln())
-                            .sqrt(),
-                            "yarn" => 0.1 * scale.ln() + 1.0,
-                            _ => 1.0,
-                        }
-                    };
-                    // Calculate inv freqs for short, long
-                    let inv_freq_long = (0..dim)
-                        .step_by(2)
-                        .enumerate()
-                        .map(|(k, i)| {
-                            (1f64 / (long_factor[k] * cfg.rope_theta.powf(i as f64 / dim as f64)))
-                                as f32
-                        })
-                        .collect::<Vec<_>>();
-                    let inv_freq_short = (0..dim)
-                        .step_by(2)
-                        .enumerate()
-                        .map(|(k, i)| {
-                            (1f64 / (short_factor[k] * cfg.rope_theta.powf(i as f64 / dim as f64)))
-                                as f32
-                        })
-                        .collect::<Vec<_>>();
-                    let inv_freq_len = inv_freq_long.len();
-
-                    let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
-                        .to_dtype(DType::F32)?
-                        .reshape((max_seq_len, 1))?;
-
-                    // Calculate sin,cos for long
-                    let inv_freq_long = Tensor::from_vec(inv_freq_long, (1, inv_freq_len), dev)?
-                        .to_dtype(DType::F32)?;
-                    let freqs_long = t.matmul(&inv_freq_long)?;
-                    let long_sin = (freqs_long.sin()? * scaling_factor)?;
-                    let long_cos = (freqs_long.cos()? * scaling_factor)?;
-
-                    // Calculate sin,cos for short
-                    let inv_freq_short = Tensor::from_vec(inv_freq_short, (1, inv_freq_len), dev)?
-                        .to_dtype(DType::F32)?;
-                    let freqs_short = t.matmul(&inv_freq_short)?;
-                    let short_sin = (freqs_short.sin()? * scaling_factor)?;
-                    let short_cos = (freqs_short.cos()? * scaling_factor)?;
-
-                    return Ok(Self {
-                        sin: short_sin,
-                        cos: short_cos,
-                        sin_long: Some(long_sin),
-                        cos_long: Some(long_cos),
-                        original_max_position_embeddings: cfg.original_max_position_embeddings,
-                    });
-                }
-                _ => {
-                    panic!("Unknown config for rope scaling!")
-                }
-            }
-        }
+        let freqs = Tensor::cat(&[&freqs, &freqs], D::Minus1)?;
 
         Ok(Self {
             sin: freqs.sin()?,
             cos: freqs.cos()?,
-            sin_long: None,
-            cos_long: None,
-            original_max_position_embeddings: None,
         })
     }
 
@@ -175,61 +89,80 @@ impl RotaryEmbedding {
         seqlen_offset: usize,
     ) -> Result<(Tensor, Tensor)> {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
-
-        let (cos, sin) = if self.sin_long.as_ref().is_some()
-            && self.cos_long.as_ref().is_some()
-            && self.original_max_position_embeddings.is_some()
-            && seqlen_offset > self.original_max_position_embeddings.unwrap()
-        {
-            let cos = self
-                .cos_long
-                .as_ref()
-                .unwrap()
-                .narrow(0, seqlen_offset, seq_len)?;
-            let sin = self
-                .sin_long
-                .as_ref()
-                .unwrap()
-                .narrow(0, seqlen_offset, seq_len)?;
-            (cos, sin)
-        } else {
-            let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
-            let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-            (cos, sin)
-        };
+        let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
+        let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
         let q_embed = candle_nn::rotary_emb::rope(&q, &cos, &sin)?;
         let k_embed = candle_nn::rotary_emb::rope(&k, &cos, &sin)?;
         Ok((q_embed, k_embed))
     }
 }
 
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+struct MLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl MLP {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let intermediate_sz = cfg.intermediate_size;
+        let gate_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(intermediate_sz, hidden_sz, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn: cfg.hidden_act.unwrap_or(Activation::Silu),
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let lhs = xs.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = xs.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
 struct Attention {
-    qkv_proj: Linear,
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
     o_proj: Linear,
     num_heads: usize,
     num_kv_heads: usize,
-    hidden_size: usize,
     head_dim: usize,
+    hidden_size: usize,
     rotary_emb: Arc<RotaryEmbedding>,
     attn: PagedAttention,
 }
 
 impl Attention {
     fn new(rotary_emb: Arc<RotaryEmbedding>, cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
-        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
-        let op_size = num_heads * head_dim + 2 * num_kv_heads * head_dim;
-        let qkv_proj = linear(cfg.hidden_size, op_size, vb.pp("qkv_proj"))?;
-        let o_proj = linear(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let head_dim = hidden_sz / num_heads;
+        let q_proj = linear_no_bias(hidden_sz, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj = linear_no_bias(hidden_sz, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear_no_bias(hidden_sz, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj = linear_no_bias(num_heads * head_dim, hidden_sz, vb.pp("o_proj"))?;
         Ok(Self {
-            qkv_proj,
+            q_proj,
+            k_proj,
+            v_proj,
             o_proj,
-            rotary_emb,
             num_heads,
             num_kv_heads,
             head_dim,
-            hidden_size: cfg.hidden_size,
+            hidden_size: hidden_sz,
+            rotary_emb,
             attn: PagedAttention::new(
                 cfg.num_attention_heads,
                 head_dim,
@@ -252,17 +185,9 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = xs.dims3()?;
 
-        let qkv = self.qkv_proj.forward(xs)?;
-        let query_pos = self.num_heads * self.head_dim;
-        let query_states = qkv.narrow(D::Minus1, 0, query_pos)?;
-        let key_states = qkv.narrow(D::Minus1, query_pos, self.num_kv_heads * self.head_dim)?;
-        let value_states = qkv
-            .narrow(
-                D::Minus1,
-                query_pos + self.num_kv_heads * self.head_dim,
-                self.num_kv_heads * self.head_dim,
-            )?
-            .contiguous()?;
+        let query_states = self.q_proj.forward(xs)?;
+        let key_states = self.k_proj.forward(xs)?;
+        let value_states = self.v_proj.forward(xs)?;
 
         let (q, k, v) = if seq_len == 1 {
             //no need transpose for seq_len == 1, change reshape dim
@@ -283,14 +208,9 @@ impl Attention {
             (q, k, v.contiguous()?)
         };
 
-        //preserve the precision with F32 type
-        let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            seqlen_offset,
-        )?;
-        let q = q.to_dtype(v.dtype())?;
-        let k = k.to_dtype(v.dtype())?;
+        let (q, k) = self
+            .rotary_emb
+            .apply_rotary_emb_qkv(&q, &k, seqlen_offset)?;
 
         let y = self.attn.forward(
             &q,
@@ -313,42 +233,9 @@ impl Attention {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Mlp {
-    gate_up_proj: Linear,
-    down_proj: Linear,
-    act_fn: candle_nn::Activation,
-    i_size: usize,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
-        let hidden_size = cfg.hidden_size;
-        let i_size = cfg.intermediate_size;
-        let gate_up_proj = linear(hidden_size, 2 * i_size, vb.pp("gate_up_proj"))?;
-        let down_proj = linear(i_size, hidden_size, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap(),
-            i_size,
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let up_states = xs.apply(&self.gate_up_proj)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states = (up_states * gate.apply(&self.act_fn))?;
-        up_states.apply(&self.down_proj)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
-    mlp: Mlp,
+    mlp: MLP,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
@@ -356,7 +243,7 @@ struct DecoderLayer {
 impl DecoderLayer {
     fn new(rotary_emb: Arc<RotaryEmbedding>, cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"))?;
-        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        let mlp = MLP::new(cfg, vb.pp("mlp"))?;
         let input_layernorm =
             RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let post_attention_layernorm = RmsNorm::new(
@@ -392,22 +279,23 @@ impl DecoderLayer {
     }
 }
 
-pub struct Phi {
+pub struct Mistral {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
     lm_head: Linear,
+    sliding_window: Option<usize>,
     device: Device,
     dtype: DType,
     cfg: Config,
 }
 
-impl Phi {
+impl Mistral {
     pub fn new(vb: VarBuilder, cfg: &Config, dtype: DType, device: &Device) -> Result<Self> {
         let vb_m = vb.pp("model");
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, vb_m.device())?);
+        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, device)?);
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         for layer_idx in 0..cfg.num_hidden_layers {
@@ -415,12 +303,13 @@ impl Phi {
             layers.push(layer)
         }
         let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
-        let lm_head = linear(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?;
+        let lm_head = linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?;
         Ok(Self {
             embed_tokens,
             layers,
             norm,
             lm_head,
+            sliding_window: cfg.sliding_window,
             device: device.clone(),
             dtype: dtype,
             cfg: cfg.clone(),
@@ -429,12 +318,20 @@ impl Phi {
 
     fn prepare_decoder_attention_mask(
         &self,
-        b_size: usize,
         tgt_len: usize,
         seqlen_offset: usize,
     ) -> Result<Tensor> {
+        let sliding_window = self.sliding_window.unwrap_or(tgt_len + 1);
         let mask: Vec<_> = (0..tgt_len)
-            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
+            .flat_map(|i| {
+                (0..tgt_len).map(move |j| {
+                    if i < j || j + sliding_window < i {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.
+                    }
+                })
+            })
             .collect();
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
@@ -443,7 +340,7 @@ impl Phi {
         } else {
             mask
         };
-        mask.expand((b_size, 1, tgt_len, tgt_len + seqlen_offset))?
+        mask.expand((1, 1, tgt_len, tgt_len + seqlen_offset))?
             .to_dtype(self.dtype)
     }
 
@@ -454,15 +351,14 @@ impl Phi {
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &mut InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
+        let (_b_size, seq_len) = input_ids.dims2()?;
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = self.prepare_decoder_attention_mask(b_size, seq_len, seqlen_offset)?;
+            let mask = self.prepare_decoder_attention_mask(seq_len, seqlen_offset)?;
             Some(mask)
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
-
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter_mut()) {
                 xs = layer.forward(
@@ -486,10 +382,7 @@ impl Phi {
         }
         xs.narrow(1, seq_len - 1, 1)?
             .apply(&self.norm)?
-            .apply(&self.lm_head)?
-            .i((.., 0, ..))?
-            .squeeze(0)?
-            .to_dtype(DType::F32)
+            .apply(&self.lm_head)
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -1,7 +1,10 @@
 pub mod gemma;
 pub mod llama;
+pub mod mistral;
+pub mod phi2;
 pub mod phi3;
 pub mod qwen2;
+use candle_core::DType;
 use either::Either;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -29,6 +32,9 @@ pub struct Config {
     pub rope_scaling: Option<HashMap<String, RopeScaling>>,
     pub original_max_position_embeddings: Option<usize>,
     pub attention_bias: bool,
+    pub partial_rotary_factor: Option<f32>,
+    pub qk_layer_rms_norm: Option<bool>,
+    pub kv_cache_dtype: DType,
 }
 
 impl Config {

--- a/src/openai/models/phi2.rs
+++ b/src/openai/models/phi2.rs
@@ -1,0 +1,397 @@
+use super::Config;
+use crate::paged_attention::input_metadata::InputMetadata;
+use crate::paged_attention::PagedAttention;
+use candle_core::{DType, Device, IndexOp, Module, Result, Tensor, D};
+use candle_nn::{Activation, VarBuilder};
+use candle_transformers::models::with_tracing::{
+    layer_norm, linear_no_bias as linear, Embedding, LayerNorm, Linear,
+};
+use serde::Deserialize;
+use std::iter::zip;
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Phi2Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: Option<usize>,
+    pub hidden_act: Activation,
+    pub max_position_embeddings: usize,
+    pub layer_norm_eps: f64,
+    pub tie_word_embeddings: bool,
+    pub rope_theta: f64,
+    pub partial_rotary_factor: f32,
+    pub qk_layernorm: bool,
+    pub bos_token_id: Option<u32>,
+    pub eos_token_id: Option<u32>,
+    pub sliding_window: Option<usize>,
+    pub original_max_position_embeddings: Option<usize>,
+}
+
+impl Phi2Config {
+    pub fn into_config(self, use_flash_attn: bool, kv_cache_dtype: DType) -> Config {
+        Config {
+            hidden_size: self.hidden_size,
+            intermediate_size: self.intermediate_size,
+            vocab_size: self.vocab_size,
+            num_hidden_layers: self.num_hidden_layers,
+            num_attention_heads: self.num_attention_heads,
+            num_key_value_heads: self.num_key_value_heads.unwrap_or(self.num_attention_heads),
+            rms_norm_eps: self.layer_norm_eps,
+            rope_theta: self.rope_theta,
+            bos_token_id: self.bos_token_id,
+            eos_token_id: self.eos_token_id,
+            max_seq_len: self.max_position_embeddings,
+            sliding_window: self.sliding_window,
+            hidden_act: Some(self.hidden_act),
+            tie_word_embeddings: false,
+            rope_scaling: None,
+            use_flash_attn,
+            original_max_position_embeddings: self.original_max_position_embeddings,
+            attention_bias: false,
+            partial_rotary_factor: Some(self.partial_rotary_factor),
+            qk_layer_rms_norm: Some(self.qk_layernorm),
+            kv_cache_dtype,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RotaryEmbedding {
+    dim: usize,
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(cfg: &Config, _dtype: DType, dev: &Device) -> Result<Self> {
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+        let dim = (cfg.partial_rotary_factor.unwrap() * head_dim as f32) as usize;
+        let inv_freq: Vec<_> = (0..dim)
+            .step_by(2)
+            .map(|i| (1f64 / cfg.rope_theta.powf(i as f64 / dim as f64)) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
+        let t = Tensor::arange(0u32, cfg.max_seq_len as u32, dev)?
+            .to_dtype(DType::F32)?
+            .reshape((cfg.max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            dim,
+            sin: freqs.sin()?,
+            cos: freqs.cos()?,
+        })
+    }
+
+    fn apply_rotary_emb(&self, xs: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (_b_size, _num_heads, seq_len, _headdim) = xs.dims4()?;
+        let xs_rot = xs.i((.., .., .., ..self.dim))?.contiguous()?;
+        let xs_pass = xs.i((.., .., .., self.dim..))?;
+        let c = self.cos.narrow(0, seqlen_offset, seq_len)?;
+        let s = self.sin.narrow(0, seqlen_offset, seq_len)?;
+        let xs_rot = candle_nn::rotary_emb::rope(&xs_rot, &c, &s)?;
+        Tensor::cat(&[&xs_rot, &xs_pass], D::Minus1)?.contiguous()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+struct MLP {
+    fc1: Linear,
+    fc2: Linear,
+    act: Activation,
+}
+
+impl MLP {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let fc1 = linear(cfg.hidden_size, cfg.intermediate_size, vb.pp("fc1"))?;
+        let fc2 = linear(cfg.intermediate_size, cfg.hidden_size, vb.pp("fc2"))?;
+        Ok(Self {
+            fc1,
+            fc2,
+            // This does not match the mixformers implementation where Gelu is used rather than
+            // GeluNew.
+            act: cfg.hidden_act.unwrap_or(Activation::Silu),
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.apply(&self.fc1)?.apply(&self.act)?.apply(&self.fc2)
+    }
+}
+
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    dense: Linear,
+    q_layernorm: Option<LayerNorm>,
+    k_layernorm: Option<LayerNorm>,
+    rotary_emb: RotaryEmbedding,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    hidden_size: usize,
+    attn: PagedAttention,
+}
+
+impl Attention {
+    fn new(cfg: &Config, dtype: DType, vb: VarBuilder) -> Result<Self> {
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+        let q_proj = linear(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj = linear(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let dense = linear(num_heads * head_dim, cfg.hidden_size, vb.pp("dense"))?;
+        // Alternative rope scalings are not supported.
+        let rotary_emb = RotaryEmbedding::new(cfg, dtype, vb.device())?;
+        let (q_layernorm, k_layernorm) = if cfg.qk_layer_rms_norm.unwrap() {
+            let q_layernorm = layer_norm(head_dim, cfg.rms_norm_eps, vb.pp("q_layernorm"))?;
+            let k_layernorm = layer_norm(head_dim, cfg.rms_norm_eps, vb.pp("k_layernorm"))?;
+            (Some(q_layernorm), Some(k_layernorm))
+        } else {
+            (None, None)
+        };
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            dense,
+            q_layernorm,
+            k_layernorm,
+            rotary_emb,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            hidden_size: cfg.hidden_size,
+            attn: PagedAttention::new(
+                cfg.num_attention_heads,
+                head_dim,
+                1. / ((head_dim as f32).sqrt()),
+                Some(cfg.num_key_value_heads),
+                None,
+                vb.device().clone(),
+                None,
+            )?,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        seqlen_offset: usize,
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_size, seq_len, _n_embd) = xs.dims3()?;
+        let query_states = self.q_proj.forward(xs)?;
+        let key_states = self.k_proj.forward(xs)?;
+        let value_states = self.v_proj.forward(xs)?;
+
+        let query_states = match &self.q_layernorm {
+            None => query_states,
+            Some(ln) => query_states.apply(ln)?,
+        };
+        let key_states = match &self.k_layernorm {
+            None => key_states,
+            Some(ln) => key_states.apply(ln)?,
+        };
+        let dtype = value_states.dtype();
+        let (q, k, v) = if seq_len == 1 {
+            //no need transpose for seq_len == 1, change reshape dim
+            let q = query_states.reshape((b_size, self.num_heads, seq_len, self.head_dim))?;
+            let k = key_states.reshape((b_size, self.num_kv_heads, seq_len, self.head_dim))?;
+            let v = value_states.reshape((b_size, self.num_kv_heads, seq_len, self.head_dim))?;
+            (q, k, v)
+        } else {
+            let q = query_states
+                .reshape((b_size, seq_len, self.num_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = key_states
+                .reshape((b_size, seq_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = value_states
+                .reshape((b_size, seq_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            (q, k, v)
+        };
+
+        let q = self
+            .rotary_emb
+            .apply_rotary_emb(&q.to_dtype(DType::F32)?, seqlen_offset)?;
+        let k = self
+            .rotary_emb
+            .apply_rotary_emb(&k.to_dtype(DType::F32)?, seqlen_offset)?;
+        let v = v.to_dtype(DType::F32)?;
+
+        let y = self.attn.forward(
+            &q,
+            &k,
+            &v,
+            attention_mask,
+            cache.map(|(k_, _)| k_.clone()),
+            cache.map(|(_, v_)| v_.clone()),
+            input_metadata,
+        )?;
+
+        let y = if attention_mask.is_some() {
+            y.transpose(1, 2)?
+                .reshape(&[b_size, seq_len, self.hidden_size])?
+        } else {
+            y.reshape(&[b_size, seq_len, self.hidden_size])?
+        };
+        y.to_dtype(dtype)?.apply(&self.dense)
+    }
+}
+
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: MLP,
+    input_layernorm: LayerNorm,
+    span: tracing::Span,
+}
+
+impl DecoderLayer {
+    fn new(cfg: &Config, dtype: DType, vb: VarBuilder) -> Result<Self> {
+        let self_attn = Attention::new(cfg, dtype, vb.pp("self_attn"))?;
+        let mlp = MLP::new(cfg, vb.pp("mlp"))?;
+        let input_layernorm =
+            layer_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            span: tracing::span!(tracing::Level::TRACE, "block"),
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        mask: Option<&Tensor>,
+        seqlen_offset: usize,
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let residual = xs;
+        let xs = xs.apply(&self.input_layernorm)?;
+        let attn_outputs =
+            self.self_attn
+                .forward(&xs, mask, seqlen_offset, cache, input_metadata)?;
+        let feed_forward_hidden_states = self.mlp.forward(&xs)?;
+        attn_outputs + feed_forward_hidden_states + residual
+    }
+}
+
+pub struct Phi2 {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    final_layernorm: LayerNorm,
+    lm_head: Linear,
+    cfg: Config,
+    dtype: DType,
+    device: Device,
+}
+
+impl Phi2 {
+    pub fn new(vb: VarBuilder, cfg: &Config, dtype: DType, device: &Device) -> Result<Self> {
+        let vb_m = vb.pp("model");
+        let embed_tokens =
+            Embedding::new(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
+        let final_layernorm = layer_norm(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb_m.pp("final_layernorm"),
+        )?;
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_m = vb_m.pp("layers");
+        for layer_idx in 0..cfg.num_hidden_layers {
+            let layer = DecoderLayer::new(cfg, dtype, vb_m.pp(layer_idx))?;
+            layers.push(layer)
+        }
+        let lm_head = linear(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?;
+        Ok(Self {
+            embed_tokens,
+            layers,
+            final_layernorm,
+            lm_head,
+            cfg: cfg.clone(),
+            dtype,
+            device: device.clone(),
+        })
+    }
+
+    fn prepare_decoder_attention_mask(
+        &self,
+        b_size: usize,
+        tgt_len: usize,
+        seqlen_offset: usize,
+    ) -> Result<Tensor> {
+        let mask: Vec<_> = (0..tgt_len)
+            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
+            .collect();
+        let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
+        let mask = if seqlen_offset > 0 {
+            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, &self.device)?;
+            Tensor::cat(&[&mask0, &mask], D::Minus1)?
+        } else {
+            mask
+        };
+        mask.expand((b_size, 1, tgt_len, tgt_len + seqlen_offset))?
+            .to_dtype(DType::F32)
+    }
+
+    pub fn forward(
+        &mut self,
+        xs: &Tensor,
+        seqlen_offset: usize,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_size, seq_len) = xs.dims2()?;
+        let mut xs = xs.apply(&self.embed_tokens)?;
+        let attention_mask = if seq_len <= 1 {
+            None
+        } else {
+            let mask = self.prepare_decoder_attention_mask(b_size, seq_len, seqlen_offset)?;
+            Some(mask)
+        };
+        if let Some(kv_caches) = kv_caches {
+            for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter_mut()) {
+                xs = layer.forward(
+                    &xs,
+                    attention_mask.as_ref(),
+                    seqlen_offset,
+                    Some((k_cache, v_cache)),
+                    input_metadata,
+                )?
+            }
+        } else {
+            for layer in self.layers.iter_mut() {
+                xs = layer.forward(
+                    &xs,
+                    attention_mask.as_ref(),
+                    seqlen_offset,
+                    None,
+                    input_metadata,
+                )?
+            }
+        }
+        xs.apply(&self.final_layernorm)?
+            .narrow(1, seq_len - 1, 1)?
+            .apply(&self.lm_head)?
+            .squeeze(1)
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
+    }
+}

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -29,7 +29,7 @@ pub struct QwenConfig {
 }
 
 impl QwenConfig {
-    pub fn into_config(self, use_flash_attn: bool) -> Config {
+    pub fn into_config(self, use_flash_attn: bool, kv_cache_dtype: DType) -> Config {
         Config {
             hidden_size: self.hidden_size,
             intermediate_size: self.intermediate_size,
@@ -49,6 +49,9 @@ impl QwenConfig {
             rope_scaling: None,
             original_max_position_embeddings: None,
             attention_bias: false,
+            partial_rotary_factor: None,
+            qk_layer_rms_norm: None,
+            kv_cache_dtype,
         }
     }
 }

--- a/src/openai/pipelines/mod.rs
+++ b/src/openai/pipelines/mod.rs
@@ -47,6 +47,8 @@ pub trait ModulePipeline<'s>: Send + Sync {
     fn get_dtype(&self) -> DType;
 
     fn device(&self) -> &Device;
+
+    fn reset_decoder(&mut self) -> Option<String>;
 }
 
 // TODO(EricLBuehler): Ensure the padding token matches tokenizer

--- a/src/scheduler/cache_engine.rs
+++ b/src/scheduler/cache_engine.rs
@@ -17,6 +17,7 @@ pub struct CacheConfig {
     pub num_gpu_blocks: Option<usize>, // Set after profiling init
     pub num_cpu_blocks: Option<usize>, // Set after profiling init
     pub fully_init: bool,
+    pub dtype: DType,
 }
 
 impl CacheConfig {


### PR DESCRIPTION
Key changes in this PR:

1. Phi2 and Mistral models are supported.
2. The problem of having generation remainer, e.g., ".", is fixed.
3. More sampling parameters, such as temperature, top-k, top-p, added for Phi3 and QWen2 models.
4. The kv cache can now use different data type other than that of used for model forward.
