### PR TITLE
Support Yi & StableLM models, change default maximum length of generated tokens for smooth chat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Currently, candle-vllm supports chat serving for the following models.
 | #2 | **Mistral** |✅|70 tks/s (7B)|
 | #3 | **Phi (v1, v1.5, v2)** |✅|97 tks/s (2.7B, F32+BF16)|
 | #4 | **Phi-3 （3.8B, 7B）** |✅|107 tks/s (3.8B)|
-| #5 | Yi |TBD|TBD|
-| #6 | StableLM |TBD|TBD|
+| #5 | **Yi** |✅|TBD|
+| #6 | **StableLM** |✅|TBD|
 | #7 | BigCode/StarCode |TBD|TBD|
 | #8 | ChatGLM |TBD|TBD|
 | #9 | **QWen2 (1.8B, 7B)** |✅|148 tks/s (1.8B)|
@@ -158,8 +158,10 @@ For chat streaming, the `stream` flag in chat request need to be set to `True`.
 You may supply `penalty` and `temperature` to the model to **prevent potential repetitions**, for example:
 
 ```
-cargo run --release -- --port 2000 --weight-path /home/mistral_7b/ mistral --repeat-last-n 32 --penalty 1.1 temperature 0.8
+cargo run --release -- --port 2000 --weight-path /home/mistral_7b/ mistral --repeat-last-n 32 --penalty 1.1 --temperature 0.8
 ```
+
+`--max-gen-tokens` parameter is used to control the maximum output tokens per chat response. The value will be set to 1/5 of max_sequence_len by default.
 
 ## Report issue
 Installing `candle-vllm` is as simple as the following steps. If you have any problems, please create an

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For model-specific help, run `cargo run -- --port 2000 <MODEL_TYPE> --help`
 
 For local model weights, run `cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama --repeat-last-n 64`, change the path when needed.
 
-`MODEL_TYPE` = ["llama", "mistral", "phi2", "phi3", "qwen2", "gemma"]
+`MODEL_TYPE` = ["llama", "mistral", "phi2", "phi3", "qwen2", "gemma", "yi", "stable-lm"]
 
 `WEIGHT_FILE_PATH` = Corresponding weight path for the given model type
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 
     /// Select the phi2 model (default 2.7b).
@@ -33,6 +36,9 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 
     /// Select the phi3 model (default 3.8b).
@@ -52,6 +58,9 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 
     /// Select the qwen model (default 1.8b).
@@ -71,6 +80,9 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 
     /// Select the gemma model (default 2b).
@@ -84,6 +96,9 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 
     /// Select the mistral model (default 7b).
@@ -97,6 +112,41 @@ pub enum ModelSelected {
 
         #[arg(long)]
         penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
+    },
+
+    /// Select the Yi model (default 6b).
+    Yi {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: Option<usize>,
+
+        #[arg(long)]
+        temperature: Option<f32>,
+
+        #[arg(long)]
+        penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
+    },
+
+    /// Select the stable-lm model (default zephyr-3b).
+    StableLM {
+        /// Control the application of repeat penalty for the last n tokens
+        #[arg(long)]
+        repeat_last_n: Option<usize>,
+
+        #[arg(long)]
+        temperature: Option<f32>,
+
+        #[arg(long)]
+        penalty: Option<f32>,
+
+        #[arg(long)]
+        max_gen_tokens: Option<usize>,
     },
 }
 
@@ -107,11 +157,13 @@ impl ToString for ModelSelected {
                 repeat_last_n: _,
                 temperature: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "llama".to_string(),
             ModelSelected::Phi2 {
                 repeat_last_n: _,
                 temperature: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "phi2".to_string(),
             ModelSelected::Phi3 {
                 repeat_last_n: _,
@@ -119,6 +171,7 @@ impl ToString for ModelSelected {
                 top_k: _,
                 top_p: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "phi3".to_string(),
             ModelSelected::Qwen2 {
                 repeat_last_n: _,
@@ -126,17 +179,32 @@ impl ToString for ModelSelected {
                 top_k: _,
                 top_p: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "qwen2".to_string(),
             ModelSelected::Gemma {
                 repeat_last_n: _,
                 temperature: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "gemma".to_string(),
             ModelSelected::Mistral {
                 repeat_last_n: _,
                 temperature: _,
                 penalty: _,
+                max_gen_tokens: _,
             } => "mistral".to_string(),
+            ModelSelected::Yi {
+                repeat_last_n: _,
+                temperature: _,
+                penalty: _,
+                max_gen_tokens: _,
+            } => "yi".to_string(),
+            ModelSelected::StableLM {
+                repeat_last_n: _,
+                temperature: _,
+                penalty: _,
+                max_gen_tokens: _,
+            } => "stablelm".to_string(),
         }
     }
 }
@@ -150,9 +218,17 @@ pub fn get_model_loader<'a>(
             repeat_last_n,
             temperature,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, None, None, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "llama".to_string(),
             )),
             if model_id.is_some() {
@@ -165,9 +241,17 @@ pub fn get_model_loader<'a>(
             repeat_last_n,
             temperature,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, None, None, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "phi2".to_string(),
             )),
             if model_id.is_some() {
@@ -182,9 +266,17 @@ pub fn get_model_loader<'a>(
             top_k,
             top_p,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, top_k, top_p, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    top_k,
+                    top_p,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "phi3".to_string(),
             )),
             if model_id.is_some() {
@@ -199,9 +291,17 @@ pub fn get_model_loader<'a>(
             top_k,
             top_p,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, top_k, top_p, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    top_k,
+                    top_p,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "qwen2".to_string(),
             )),
             if model_id.is_some() {
@@ -214,9 +314,17 @@ pub fn get_model_loader<'a>(
             repeat_last_n,
             temperature,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, None, None, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "gemma".to_string(),
             )),
             if model_id.is_some() {
@@ -229,15 +337,71 @@ pub fn get_model_loader<'a>(
             repeat_last_n,
             temperature,
             penalty,
+            max_gen_tokens,
         } => (
             Box::new(DefaultLoader::new(
-                SpecificConfig::new(repeat_last_n, temperature, None, None, penalty),
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
                 "mistral".to_string(),
             )),
             if model_id.is_some() {
                 model_id.unwrap()
             } else {
                 "mistralai/Mistral-7B-Instruct-v0.3".to_string()
+            },
+        ),
+
+        ModelSelected::Yi {
+            repeat_last_n,
+            temperature,
+            penalty,
+            max_gen_tokens,
+        } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
+                "yi".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "01-ai/Yi-6B-Chat".to_string()
+            },
+        ),
+
+        ModelSelected::StableLM {
+            repeat_last_n,
+            temperature,
+            penalty,
+            max_gen_tokens,
+        } => (
+            Box::new(DefaultLoader::new(
+                SpecificConfig::new(
+                    repeat_last_n,
+                    temperature,
+                    None,
+                    None,
+                    penalty,
+                    max_gen_tokens,
+                ),
+                "stablelm".to_string(),
+            )),
+            if model_id.is_some() {
+                model_id.unwrap()
+            } else {
+                "stabilityai/stablelm-zephyr-3b".to_string()
             },
         ),
     }

--- a/src/openai/models/gemma.rs
+++ b/src/openai/models/gemma.rs
@@ -57,6 +57,8 @@ impl GemmaConfig {
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
             kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
         }
     }
 }

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -50,6 +50,8 @@ impl LlamaConfig {
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
             kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
         }
     }
 }

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -4,6 +4,8 @@ pub mod mistral;
 pub mod phi2;
 pub mod phi3;
 pub mod qwen2;
+pub mod stable_lm;
+pub mod yi;
 use candle_core::DType;
 use either::Either;
 use serde::Deserialize;
@@ -35,6 +37,8 @@ pub struct Config {
     pub partial_rotary_factor: Option<f32>,
     pub qk_layer_rms_norm: Option<bool>,
     pub kv_cache_dtype: DType,
+    pub use_qkv_bias: Option<bool>,
+    pub custom_stop_tokens: Option<Vec<String>>,
 }
 
 impl Config {

--- a/src/openai/models/phi2.rs
+++ b/src/openai/models/phi2.rs
@@ -54,6 +54,8 @@ impl Phi2Config {
             partial_rotary_factor: Some(self.partial_rotary_factor),
             qk_layer_rms_norm: Some(self.qk_layernorm),
             kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
         }
     }
 }
@@ -297,7 +299,6 @@ pub struct Phi2 {
     final_layernorm: LayerNorm,
     lm_head: Linear,
     cfg: Config,
-    dtype: DType,
     device: Device,
 }
 
@@ -324,7 +325,6 @@ impl Phi2 {
             final_layernorm,
             lm_head,
             cfg: cfg.clone(),
-            dtype,
             device: device.clone(),
         })
     }

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -55,6 +55,8 @@ impl PhiConfig {
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
             kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
         }
     }
 }

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -52,6 +52,8 @@ impl QwenConfig {
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
             kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
         }
     }
 }

--- a/src/openai/models/stable_lm.rs
+++ b/src/openai/models/stable_lm.rs
@@ -2,30 +2,34 @@ use super::Config;
 use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
 use candle_core::{DType, Device, Module, Result, Tensor, D};
-use candle_nn::{Activation, VarBuilder};
-use candle_transformers::models::with_tracing::{linear_no_bias, Linear, RmsNorm};
+use candle_nn::{Activation, LayerNorm, VarBuilder};
+use candle_transformers::models::with_tracing::{linear, linear_no_bias, Linear};
 use std::iter::zip;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-pub struct MistralConfig {
+pub struct StableLMConfig {
     pub vocab_size: usize,
-    pub hidden_size: usize,
     pub intermediate_size: usize,
+    pub hidden_size: usize,
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub num_key_value_heads: usize,
     pub hidden_act: Activation,
-    pub max_position_embeddings: usize,
-    pub rms_norm_eps: f64,
     pub rope_theta: f64,
-    pub sliding_window: Option<usize>,
+    pub max_position_embeddings: usize,
+    pub norm_eps: f64,
+    pub use_cache: bool,
+    pub use_qkv_bias: Option<bool>, // Used in StableLM-2
+    pub partial_rotary_factor: Option<f32>,
+    pub rope_pct: Option<f32>,
+    pub tie_word_embeddings: Option<bool>,
     pub bos_token_id: usize,
     pub eos_token_id: usize,
-    pub tie_word_embeddings: Option<bool>,
+    pub sliding_window: Option<usize>,
 }
 
-impl MistralConfig {
+impl StableLMConfig {
     pub fn into_config(self, use_flash_attn: bool, kv_cache_dtype: DType) -> Config {
         Config {
             hidden_size: self.hidden_size,
@@ -34,7 +38,7 @@ impl MistralConfig {
             num_hidden_layers: self.num_hidden_layers,
             num_attention_heads: self.num_attention_heads,
             num_key_value_heads: self.num_key_value_heads,
-            rms_norm_eps: self.rms_norm_eps,
+            rms_norm_eps: self.norm_eps,
             rope_theta: self.rope_theta,
             use_flash_attn,
             bos_token_id: Some(self.bos_token_id as u32),
@@ -46,29 +50,38 @@ impl MistralConfig {
             rope_scaling: None,
             original_max_position_embeddings: None,
             attention_bias: false,
-            partial_rotary_factor: None,
+            partial_rotary_factor: Some(
+                self.partial_rotary_factor
+                    .unwrap_or(self.rope_pct.unwrap_or(0.25)),
+            ),
             qk_layer_rms_norm: None,
             kv_cache_dtype,
-            use_qkv_bias: None,
+            use_qkv_bias: Some(self.use_qkv_bias.unwrap_or(false)),
             custom_stop_tokens: None,
         }
     }
 }
 
-#[derive(Debug, Clone)]
-struct RotaryEmbedding {
+#[derive(Debug)]
+pub(crate) struct RotaryEmbedding {
     sin: Tensor,
     cos: Tensor,
+    dim: usize,
+}
+
+fn rotate_half(xs: &Tensor) -> Result<Tensor> {
+    let xs = xs.chunk(2, D::Minus1)?;
+    Tensor::cat(&[&xs[1].neg()?, &xs[0]], D::Minus1)
 }
 
 impl RotaryEmbedding {
-    fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
-        let rope_theta = cfg.rope_theta as f32;
-        let dim = cfg.hidden_size / cfg.num_attention_heads;
+    pub(crate) fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+        let dim = (cfg.partial_rotary_factor.unwrap() * head_dim as f32) as usize;
         let max_seq_len = cfg.max_seq_len;
         let inv_freq: Vec<_> = (0..dim)
             .step_by(2)
-            .map(|i| 1f32 / rope_theta.powf(i as f32 / dim as f32))
+            .map(|i| 1f32 / cfg.rope_theta.powf(i as f64 / dim as f64) as f32)
             .collect();
         let inv_freq_len = inv_freq.len();
         let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
@@ -76,35 +89,32 @@ impl RotaryEmbedding {
             .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
-
         Ok(Self {
             sin: freqs.sin()?,
             cos: freqs.cos()?,
+            dim,
         })
     }
 
-    fn apply_rotary_emb_qkv(
-        &self,
-        q: &Tensor,
-        k: &Tensor,
-        seqlen_offset: usize,
-    ) -> Result<(Tensor, Tensor)> {
-        let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
-        let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
-        let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-        let q_embed = candle_nn::rotary_emb::rope(&q, &cos, &sin)?;
-        let k_embed = candle_nn::rotary_emb::rope(&k, &cos, &sin)?;
-        Ok((q_embed, k_embed))
+    fn apply_rotary_emb(&self, xs: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (_b_size, _num_heads, seq_len, _headdim) = xs.dims4()?;
+        let xs_rot = xs.narrow(3, 0, self.dim)?.contiguous()?;
+        let xs_pass = xs.narrow(3, self.dim, _headdim - self.dim)?;
+        let c = self.cos.narrow(0, seqlen_offset, seq_len)?;
+        let s = self.sin.narrow(0, seqlen_offset, seq_len)?;
+        let xs_rot = candle_nn::rotary_emb::rope(&xs_rot, &c, &s)?;
+        Tensor::cat(&[&xs_rot, &xs_pass], D::Minus1)
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[allow(clippy::upper_case_acronyms)]
 struct MLP {
     gate_proj: Linear,
     up_proj: Linear,
     down_proj: Linear,
     act_fn: Activation,
+    span: tracing::Span,
 }
 
 impl MLP {
@@ -119,12 +129,14 @@ impl MLP {
             up_proj,
             down_proj,
             act_fn: cfg.hidden_act.unwrap_or(Activation::Silu),
+            span: tracing::span!(tracing::Level::TRACE, "mlp"),
         })
     }
 }
 
 impl Module for MLP {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
         let lhs = xs.apply(&self.gate_proj)?.apply(&self.act_fn)?;
         let rhs = xs.apply(&self.up_proj)?;
         (lhs * rhs)?.apply(&self.down_proj)
@@ -150,9 +162,16 @@ impl Attention {
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
         let head_dim = hidden_sz / num_heads;
-        let q_proj = linear_no_bias(hidden_sz, num_heads * head_dim, vb.pp("q_proj"))?;
-        let k_proj = linear_no_bias(hidden_sz, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-        let v_proj = linear_no_bias(hidden_sz, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+
+        let linear_layer = if cfg.use_qkv_bias.unwrap_or(false) {
+            linear
+        } else {
+            linear_no_bias
+        };
+
+        let q_proj = linear_layer(hidden_sz, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj = linear_layer(hidden_sz, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear_layer(hidden_sz, num_kv_heads * head_dim, vb.pp("v_proj"))?;
         let o_proj = linear_no_bias(num_heads * head_dim, hidden_sz, vb.pp("o_proj"))?;
         Ok(Self {
             q_proj,
@@ -209,11 +228,13 @@ impl Attention {
             (q, k, v.contiguous()?)
         };
 
-        let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            seqlen_offset,
-        )?;
+        let q = self
+            .rotary_emb
+            .apply_rotary_emb(&q.to_dtype(DType::F32)?, seqlen_offset)?;
+
+        let k = self
+            .rotary_emb
+            .apply_rotary_emb(&k.to_dtype(DType::F32)?, seqlen_offset)?;
 
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
@@ -242,8 +263,8 @@ impl Attention {
 struct DecoderLayer {
     self_attn: Attention,
     mlp: MLP,
-    input_layernorm: RmsNorm,
-    post_attention_layernorm: RmsNorm,
+    input_layernorm: LayerNorm,
+    post_attention_layernorm: LayerNorm,
 }
 
 impl DecoderLayer {
@@ -251,8 +272,8 @@ impl DecoderLayer {
         let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"))?;
         let mlp = MLP::new(cfg, vb.pp("mlp"))?;
         let input_layernorm =
-            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
-        let post_attention_layernorm = RmsNorm::new(
+            candle_nn::layer_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = candle_nn::layer_norm(
             cfg.hidden_size,
             cfg.rms_norm_eps,
             vb.pp("post_attention_layernorm"),
@@ -285,37 +306,35 @@ impl DecoderLayer {
     }
 }
 
-pub struct Mistral {
+pub struct StableLM {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<DecoderLayer>,
-    norm: RmsNorm,
+    norm: LayerNorm,
     lm_head: Linear,
-    sliding_window: Option<usize>,
     device: Device,
     dtype: DType,
     cfg: Config,
 }
 
-impl Mistral {
+impl StableLM {
     pub fn new(vb: VarBuilder, cfg: &Config, dtype: DType, device: &Device) -> Result<Self> {
         let vb_m = vb.pp("model");
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, device)?);
+        let rotary_emb = Arc::new(RotaryEmbedding::new(vb.dtype(), cfg, vb_m.device())?);
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         for layer_idx in 0..cfg.num_hidden_layers {
             let layer = DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx))?;
             layers.push(layer)
         }
-        let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
+        let norm = candle_nn::layer_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
         let lm_head = linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?;
         Ok(Self {
             embed_tokens,
             layers,
             norm,
             lm_head,
-            sliding_window: cfg.sliding_window,
             device: device.clone(),
             dtype: dtype,
             cfg: cfg.clone(),
@@ -324,20 +343,13 @@ impl Mistral {
 
     fn prepare_decoder_attention_mask(
         &self,
+        b_size: usize,
         tgt_len: usize,
         seqlen_offset: usize,
     ) -> Result<Tensor> {
-        let sliding_window = self.sliding_window.unwrap_or(tgt_len + 1);
+        // Sliding window mask?
         let mask: Vec<_> = (0..tgt_len)
-            .flat_map(|i| {
-                (0..tgt_len).map(move |j| {
-                    if i < j || j + sliding_window < i {
-                        f32::NEG_INFINITY
-                    } else {
-                        0.
-                    }
-                })
-            })
+            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
             .collect();
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
@@ -346,7 +358,7 @@ impl Mistral {
         } else {
             mask
         };
-        mask.expand((1, 1, tgt_len, tgt_len + seqlen_offset))?
+        mask.expand((b_size, 1, tgt_len, tgt_len + seqlen_offset))?
             .to_dtype(self.dtype)
     }
 
@@ -357,11 +369,11 @@ impl Mistral {
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &mut InputMetadata,
     ) -> Result<Tensor> {
-        let (_b_size, seq_len) = input_ids.dims2()?;
+        let (b_size, seq_len) = input_ids.dims2()?;
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = self.prepare_decoder_attention_mask(seq_len, seqlen_offset)?;
+            let mask = self.prepare_decoder_attention_mask(b_size, seq_len, seqlen_offset)?;
             Some(mask)
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
@@ -386,13 +398,11 @@ impl Mistral {
                 )?
             }
         }
-        let logits = xs
-            .narrow(1, seq_len - 1, 1)?
+        xs.narrow(1, seq_len - 1, 1)?
             .apply(&self.norm)?
-            .apply(&self.lm_head)?;
-
-        //TODO: do not squeeze for batched streaming
-        logits.squeeze(0)?.to_dtype(DType::F32)
+            .apply(&self.lm_head)?
+            .squeeze(0)?
+            .to_dtype(DType::F32)
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/stable_lm.rs
+++ b/src/openai/models/stable_lm.rs
@@ -69,11 +69,6 @@ pub(crate) struct RotaryEmbedding {
     dim: usize,
 }
 
-fn rotate_half(xs: &Tensor) -> Result<Tensor> {
-    let xs = xs.chunk(2, D::Minus1)?;
-    Tensor::cat(&[&xs[1].neg()?, &xs[0]], D::Minus1)
-}
-
 impl RotaryEmbedding {
     pub(crate) fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
         let head_dim = cfg.hidden_size / cfg.num_attention_heads;

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -32,7 +32,6 @@ use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use either::Either::{Left, Right};
-use futures::TryFutureExt;
 use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use std::{iter::zip, path::PathBuf, sync::Arc};
 use tokenizers::Tokenizer;
@@ -92,7 +91,7 @@ pub struct DefaultPipeline {
     dtype: DType,
     device: Device,
     cur_idx: usize,
-    config: Config,
+    _config: Config,
     stop_token_ids: Vec<u32>,
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ async fn test_llama() -> Result<(), APIError> {
         ModelSelected::Llama {
             repeat_last_n: Some(64),
             penalty: Some(1.1),
+            temperature: None,
         },
         Some("meta-llama/Llama-2-7b-chat-hf".to_string()),
     );


### PR DESCRIPTION
Key changes in this PR:

1. Support Yi & StableLM models
2. The maximum length of generated tokens changed to 1/5 of max_seq_len by default, this will enalbe smooth chat with minimal breaks. Users are allowed to set max_gen_tokens for the model throught parameters.

Tested cases:

```
cargo run --release -- --port 2000 --weight-path /home/stablelm-zephyr-3b/ stable-lm --repeat-last-n 32
```

```
cargo run --release -- --port 2000 --weight-path /home/yi-6b/ yi --repeat-last-n 32
```