### PR TITLE
Applying the optimization options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ cudnn = ["candle-core/cudnn"]
 flash-attn = ["cuda", "candle-transformers/flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]
 nccl = ["cuda", "cudarc/nccl"]
+
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
## Change Log

I made changes to the optimization option for release. I don't have any GPU to test the performance gains but these settings are usually good for the speed and the binary size while taking a bit more build time. So, I assume it'd be great to set.

- `codegen-units` to 1
- `lto` to `fat`
