### PR TITLE
Support Mac/Metal devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,8 @@ dependencies = [
  "hyper 0.14.29",
  "intel-mkl-src",
  "kernels",
+ "metal 0.27.0",
+ "metal-kernels",
  "rand",
  "range-checked",
  "rayon",
@@ -1906,6 +1908,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal-kernels"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "metal 0.27.0",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "onig"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ kernels = {path = "./kernels", version="0.1.0", optional = true}
 metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
 
 [features]
-default = ["cuda"]
+#default = ["metal"]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:kernels"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels", "dep:metal"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,14 +43,15 @@ tracing = "0.1.40"
 range-checked = { git = "https://github.com/EricLBuehler/range-checked.git", version = "0.1.0" }
 either = { version = "1.13.0", features = ["serde"] }
 dirs = "5.0.1"
+metal = { version = "0.27.0", features = ["mps"] }
 kernels = {path = "./kernels", version="0.1.0", optional = true}
-#metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
+metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
 
 [features]
 default = ["cuda"]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:kernels"]
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
+metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels"]
 cudnn = ["candle-core/cudnn"]
 flash-attn = ["cuda", "candle-transformers/flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1.40"
 range-checked = { git = "https://github.com/EricLBuehler/range-checked.git", version = "0.1.0" }
 either = { version = "1.13.0", features = ["serde"] }
 dirs = "5.0.1"
-metal = { version = "0.27.0", features = ["mps"] }
+metal = { version = "0.27.0", features = ["mps"], optional = true }
 kernels = {path = "./kernels", version="0.1.0", optional = true}
 metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
 
@@ -51,7 +51,7 @@ metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
 default = ["cuda"]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:kernels"]
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels"]
+metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels", "dep:metal"]
 cudnn = ["candle-core/cudnn"]
 flash-attn = ["cuda", "candle-transformers/flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]

--- a/README.md
+++ b/README.md
@@ -51,18 +51,12 @@ sudo apt install libssl-dev
 sudo apt install pkg-config
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
-cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama
+cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --temperature 0. --penalty 1.0
 ```
 
 You may also run specific model using huggingface model-id, e.g.,
 ```shell
 cargo run --release -- --port 2000 --model-id meta-llama/Llama-2-7b-chat-hf llama
-```
-
-Run latest LLaMa3.1 using local weights
-
-```shell
-cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --temperature 0. --penalty 1.0
 ```
 
 Run models on Mac/Metal devices (assume gguf model downloaded in `/Users/Downloads`)
@@ -76,8 +70,24 @@ cargo run --release --features metal -- --port 2000 --dtype bf16 --weight-path /
 __Refer to Marlin quantization below for running quantized GPTQ models.__
 
 ### Step 2:
+#### Option 1: Chat with Chat.py (recommended)
+Install API and chatbot dependencies (openai package is only used for local chat with candle-vllm)
 
-#### Option 1: Chat with ChatUI (recommended)
+```shell
+python3 -m pip install openai
+python3 -m pip install rich
+```
+
+Chat with the mini chatbot
+```shell
+python3 examples/chat.py
+```
+
+Chat demo on GPU (A100, LLaMa3.1 8B)
+
+<img src="res/LLaMa3.1-8B-Chatbot-A100.gif" width="65%" height="65%" >
+
+#### Option 2: Chat with ChatUI
 Install ChatUI and its dependencies:
 
 ```
@@ -101,7 +111,7 @@ pnpm run dev # run the ChatUI
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
-#### Option 2: Chat completion request with HTTP post
+#### Option 3: Chat completion request with HTTP post
 
 ``` shell
 curl -X POST "http://127.0.0.1:2000/v1/chat/completions" \
@@ -123,7 +133,7 @@ Sample response:
 {"id":"cmpl-53092967-c9cf-40e0-ae26-d7ac786d59e8","choices":[{"message":{"content":" Learning any programming language requires a combination of theory, practice, and dedication. Here are some steps and resources to help you learn Rust effectively:\n\n1. Start with the basics:\n\t* Understand the syntax and basic structure of Rust programs.\n\t* Learn about variables, data types, loops, and control structures.\n\t* Familiarize yourself with Rust's ownership system and borrowing mechanism.\n2. Read the Rust book:\n\t* The Rust book is an official resource that provides a comprehensive introduction to the language.\n\t* It covers topics such","role":"[INST]"},"finish_reason":"length","index":0,"logprobs":null}],"created":1718784498,"model":"llama7b","object":"chat.completion","usage":{"completion_tokens":129,"prompt_tokens":29,"total_tokens":158}}
 ```
 
-#### Option 3: Chat completion with with openai package
+#### Option 4: Chat completion with with openai package
 
 In your terminal, install the `openai` Python package by running `pip install openai`. I use version `1.3.5`.
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ python3 examples/chat.py
 
 Chat demo on GPU (A100, LLaMa3.1 8B)
 
-<img src="res/LLaMa3.1-8B-Chatbot-A100.gif" width="65%" height="65%" >
+<img src="res/LLaMa3.1-8B-Chatbot-A100.gif" width="75%" height="75%" >
 
 Chat demo on Apple M4 (Phi3 3.8B)
 
-<img src="res/Phi3-3.8B-Chatbot-Apple-M4.gif" width="65%" height="65%" >
+<img src="res/Phi3-3.8B-Chatbot-Apple-M4.gif" width="75%" height="75%" >
 
 #### Option 2: Chat with ChatUI
 Install ChatUI and its dependencies:
@@ -234,7 +234,7 @@ asyncio.run(benchmark())
 Candle-vllm now supports GPTQ (Marlin kernel), you may supply the `quant` (marlin) parameter if you have `Marlin` format quantized weights, such as:
 
 ```
-cargo run --release -- --port 2000 --dtype f16 --weight-path /home/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4-Marlin/ llama3 --quant marlin --temperature 0. --penalty 1.
+cargo run --release --features cuda -- --port 2000 --dtype f16 --weight-path /home/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4-Marlin/ llama3 --quant marlin --temperature 0. --penalty 1.
 ```
 You may also use `AutoGPTQ` to transform a model to marlin format by loading the (quantized) model, supplying the `use_marlin=True` in `AutoGPTQ` and resaving it with "save_pretrained". 
 
@@ -269,9 +269,11 @@ Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", 
 ## Usage Help
 For general configuration help, run `cargo run -- --help`.
 
-For model-specific help, run `cargo run --features <PLATFORM> -- --port 2000 <MODEL_TYPE> --help`
+For model-specific help, run `cargo run --<MODE> --features <PLATFORM> -- --port 2000 <MODEL_TYPE> --help`
 
 For local model weights, run `cargo run --release --features cuda -- --port 2000 --weight-path /home/llama2_7b/ llama`, change the path when needed.
+
+`MODE`=["debug", "release"]
 
 `PLATFORM`=["cuda", "metal"]
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Efficient, easy-to-use platform for inference and serving local LLMs including a
 - Continuous batching.
 - `In-situ` quantization (and `In-situ` marlin format conversion)
 - `GPTQ/Marlin` format quantization (4-bit)
+- Support `Mac/Metal` devices
 
 ## Develop Status
 
@@ -54,15 +55,23 @@ cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama
 ```
 
 You may also run specific model using huggingface model-id, e.g.,
-```
+```shell
 cargo run --release -- --port 2000 --model-id meta-llama/Llama-2-7b-chat-hf llama
 ```
 
 Run latest LLaMa3.1 using local weights
 
-```
+```shell
 cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --temperature 0. --penalty 1.0
 ```
+
+Run models on Mac/Metal devices (assume gguf model downloaded in `/Users/Downloads`)
+
+```shell
+cargo run --release --features metal -- --port 2000 --dtype bf16 --weight-path /Users/Downloads --weight-file Phi-3.5-mini-instruct-Q4_K_M.gguf phi3 --quant gguf --temperature 0. --penalty 1.0
+```
+
+**Note:** `dtype` in gguf/ggml mode is used for kv cache and attention, you may choose `f32` or `bf16`, while, `f16` is not recommended.
 
 __Refer to Marlin quantization below for running quantized GPTQ models.__
 
@@ -232,13 +241,15 @@ For quantized 4-bit GPTQ model:
 cargo run --release -- --port 2000 --weight-path /home/mistral_7b-int4/ mistral --quant marlin
 ```
 
-Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin"]
+Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml"]
 
 **Please note**:
 
 1) It may takes few minutes to load F32/F16/BF16 models into quantized;
 
-2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`).
+2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`);
+
+3) Marlin format only supported in CUDA platform.
 
 ## Usage Help
 For general configuration help, run `cargo run -- --help`.
@@ -283,7 +294,7 @@ For `consumer GPUs`, it is suggested to run the models under GGML formats (or Ma
 cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --quant q4k
 ```
 
-where `quant` is one of ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin"].
+where `quant` is one of ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml"].
 
 ## Report issue
 Installing `candle-vllm` is as simple as the following steps. If you have any problems, please create an

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ sudo apt install libssl-dev
 sudo apt install pkg-config
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
-cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --temperature 0. --penalty 1.0
+cargo run --release --features cuda -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --temperature 0. --penalty 1.0
 ```
 
 You may also run specific model using huggingface model-id, e.g.,
 ```shell
-cargo run --release -- --port 2000 --model-id meta-llama/Llama-2-7b-chat-hf llama
+cargo run --release --features cuda -- --port 2000 --model-id meta-llama/Llama-2-7b-chat-hf llama
 ```
 
 Run models on Mac/Metal devices (assume gguf model downloaded in `/Users/Downloads`)
@@ -76,6 +76,7 @@ Install API and chatbot dependencies (openai package is only used for local chat
 ```shell
 python3 -m pip install openai
 python3 -m pip install rich
+python3 -m pip install click
 ```
 
 Chat with the mini chatbot
@@ -86,6 +87,10 @@ python3 examples/chat.py
 Chat demo on GPU (A100, LLaMa3.1 8B)
 
 <img src="res/LLaMa3.1-8B-Chatbot-A100.gif" width="65%" height="65%" >
+
+Chat demo on Apple M4 (Phi3 3.8B)
+
+<img src="res/Phi3-3.8B-Chatbot-Apple-M4.gif" width="65%" height="65%" >
 
 #### Option 2: Chat with ChatUI
 Install ChatUI and its dependencies:
@@ -242,13 +247,13 @@ Candle-vllm now supports in-situ quantization, allowing the transformation of de
 For unquantized models:
 
 ```
-cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --quant q4k
+cargo run --release --features cuda -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --quant q4k
 ```
 
 For quantized 4-bit GPTQ model:
 
 ```
-cargo run --release -- --port 2000 --weight-path /home/mistral_7b-int4/ mistral --quant marlin
+cargo run --release --features cuda -- --port 2000 --weight-path /home/mistral_7b-int4/ mistral --quant marlin
 ```
 
 Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml"]
@@ -264,16 +269,18 @@ Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", 
 ## Usage Help
 For general configuration help, run `cargo run -- --help`.
 
-For model-specific help, run `cargo run -- --port 2000 <MODEL_TYPE> --help`
+For model-specific help, run `cargo run --features <PLATFORM> -- --port 2000 <MODEL_TYPE> --help`
 
-For local model weights, run `cargo run --release -- --port 2000 --weight-path /home/llama2_7b/ llama`, change the path when needed.
+For local model weights, run `cargo run --release --features cuda -- --port 2000 --weight-path /home/llama2_7b/ llama`, change the path when needed.
+
+`PLATFORM`=["cuda", "metal"]
 
 `MODEL_TYPE` = ["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "gemma", "yi", "stable-lm"]
 
 `WEIGHT_FILE_PATH` = Corresponding weight path for the given model type
 
 ```
-cargo run --release -- --port 2000 --weight-path <WEIGHT_FILE_PATH> <MODEL_TYPE>
+cargo run --release --features cuda -- --port 2000 --weight-path <WEIGHT_FILE_PATH> <MODEL_TYPE>
 ```
 
 or
@@ -281,7 +288,7 @@ or
 `MODEL_ID` = Huggingface model id
 
 ```
-cargo run --release -- --port 2000 --model-id <MODEL_ID> <MODEL_TYPE>
+cargo run --release --features cuda -- --port 2000 --model-id <MODEL_ID> <MODEL_TYPE>
 ```
 
 For kvcache configuration, set `kvcache_mem_cpu` and `kvcache_mem_gpu`, default 4GB CPU memory and 4GB GPU memory for kvcache. 
@@ -293,7 +300,7 @@ For chat streaming, the `stream` flag in chat request need to be set to `True`.
 You may supply `penalty` and `temperature` to the model to **prevent potential repetitions**, for example:
 
 ```
-cargo run --release -- --port 2000 --weight-path /home/mistral_7b/ mistral --repeat-last-n 64 --penalty 1.1 --temperature 0.7
+cargo run --release --features cuda -- --port 2000 --weight-path /home/mistral_7b/ mistral --repeat-last-n 64 --penalty 1.1 --temperature 0.7
 ```
 
 `--max-gen-tokens` parameter is used to control the maximum output tokens per chat response. The value will be set to 1/5 of max_sequence_len by default.
@@ -301,7 +308,7 @@ cargo run --release -- --port 2000 --weight-path /home/mistral_7b/ mistral --rep
 For `consumer GPUs`, it is suggested to run the models under GGML formats (or Marlin format), e.g.,
 
 ```
-cargo run --release -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --quant q4k
+cargo run --release --features cuda -- --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct/ llama3 --quant q4k
 ```
 
 where `quant` is one of ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml"].

--- a/kernels/src/ffi.rs
+++ b/kernels/src/ffi.rs
@@ -1,7 +1,7 @@
 use core::ffi::{c_int, c_long, c_void};
 
 extern "C" {
-    pub fn reshape_and_cache(
+    pub fn call_reshape_and_cache(
         key: *const c_void,
         value: *const c_void,
         key_cache: *const c_void,

--- a/kernels/src/reshape_and_cache_kernel.cu
+++ b/kernels/src/reshape_and_cache_kernel.cu
@@ -75,7 +75,7 @@ __global__ void reshape_and_cache_kernel(
 
 } // namespace vllm
 
-extern "C" void reshape_and_cache(
+extern "C" void call_reshape_and_cache(
   void *key,              // [num_tokens, num_heads, head_size]
   void *value,            // [num_tokens, num_heads, head_size]
   void *key_cache,        // [num_blocks, num_heads, head_size/x, block_size, x]

--- a/metal-kernels/Cargo.toml
+++ b/metal-kernels/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "metal-kernels"
+version = "0.1.0"
+edition = "2021"
+description = "Paged attention kernels for candle-vllm on Metal device"
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+metal = { version = "0.27.0", features = ["mps"] }
+thiserror = "1"
+once_cell = "1.20.2"
+candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.8.1" }
+
+[build-dependencies]
+anyhow = { version = "1", features = ["backtrace"] }

--- a/metal-kernels/src/copy_blocks.metal
+++ b/metal-kernels/src/copy_blocks.metal
@@ -1,0 +1,306 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#if defined(__HAVE_BFLOAT__)
+
+typedef bfloat bfloat16_t;
+
+#else
+
+/////////////////////////////////////////////////////////////////////////////
+// Helpers
+/////////////////////////////////////////////////////////////////////////////
+
+constexpr METAL_FUNC uint16_t float_to_bfloat_bits(float x) {
+  // Check for nan
+  if ((as_type<uint32_t>(x) & ~_fp_encoding_traits<float>::sign_mask) >
+      _fp_encoding_traits<float>::inf_mask) {
+    return uint16_t(as_type<uint32_t>(0x7FC0));
+  }
+  // Take bits
+  uint32_t float_bits = as_type<uint32_t>(x);
+
+  // Round to nearest even
+  float_bits += ((float_bits >> 16) & 1) + as_type<uint32_t>(0x7FFF);
+
+  // Take upper 16 bits
+  return float_bits >> 16;
+}
+
+constexpr METAL_FUNC float bfloat_bits_to_float(uint16_t x) {
+  // Upper 16 bits are the data and lower 16 bits are 0s
+  return as_type<float>((uint32_t)x << 16);
+}
+
+struct _MLX_BFloat16;
+
+template <typename T>
+static constexpr constant bool can_convert_to_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<T, float>;
+
+template <typename T>
+static constexpr constant bool can_convert_from_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<float, T>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat struct
+/////////////////////////////////////////////////////////////////////////////
+
+struct _MLX_BFloat16 {
+  /////////////////////////////////////////////////////////////////////////////
+  // Constructors
+  uint16_t bits_;
+  _MLX_BFloat16() thread = default;
+  _MLX_BFloat16() threadgroup = default;
+  _MLX_BFloat16() device = default;
+  _MLX_BFloat16() constant = default;
+
+  struct bits_to_bfloat_struct {};
+  static constexpr METAL_FUNC bits_to_bfloat_struct bits_to_bfloat() {
+    return bits_to_bfloat_struct();
+  }
+  constexpr METAL_FUNC _MLX_BFloat16(uint16_t bits, bits_to_bfloat_struct)
+      : bits_(bits) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions to bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) thread
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) threadgroup
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) device
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) constant
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions from bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const thread {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const threadgroup {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const device {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const constant {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat operators
+/////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////
+// Unary ops
+constexpr METAL_FUNC _MLX_BFloat16 operator-(_MLX_BFloat16 x) {
+  return -static_cast<float>(x);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Binary operators
+#define bfloat_binop_base(__op__, __operator__, otype, atype, btype, ctype) \
+  constexpr METAL_FUNC otype __operator__(atype lhs, btype rhs) {           \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);          \
+  }
+
+#define bfloat_binop_helper(__op__, __operator__, otype, itype, ctype)    \
+  constexpr METAL_FUNC otype __operator__(_MLX_BFloat16 lhs, itype rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }                                                                       \
+  constexpr METAL_FUNC otype __operator__(itype lhs, _MLX_BFloat16 rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }
+
+/////////////////////////////////////////////////////////////////////////////
+// Arithmetic Operators
+#define bfloat_binop(_op_, _operator_)                                       \
+  bfloat_binop_base(                                                         \
+      _op_, _operator_, _MLX_BFloat16, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(_op_, _operator_, float, float, float);                \
+  bfloat_binop_helper(_op_, _operator_, float, half, float);                 \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int32_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint32_t, float);     \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int64_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint64_t, float);
+
+bfloat_binop(+, operator+);
+bfloat_binop(-, operator-);
+bfloat_binop(*, operator*);
+bfloat_binop(/, operator/);
+
+/////////////////////////////////////////////////////////////////////////////
+// Comparison ops
+#define bfloat_compop(__op__, __operator__)                             \
+  bfloat_binop_base(                                                    \
+      __op__, __operator__, bool, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(__op__, __operator__, bool, float, float);        \
+  bfloat_binop_helper(__op__, __operator__, bool, half, float);         \
+  bfloat_binop_helper(__op__, __operator__, bool, int32_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint32_t, float);     \
+  bfloat_binop_helper(__op__, __operator__, bool, int64_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint64_t, float);
+
+bfloat_compop(>, operator>);
+bfloat_compop(<, operator<);
+bfloat_compop(>=, operator>=);
+bfloat_compop(<=, operator<=);
+bfloat_compop(==, operator==);
+bfloat_compop(!=, operator!=);
+
+#undef bfloat_compop
+#undef bfloat_binop_base
+#undef bfloat_binop_helper
+#undef bfloat_binop
+
+/////////////////////////////////////////////////////////////////////////////
+// Inplace Operators
+#define bfloat_inplace_op_helper(__op__, __operator__, itype, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(            \
+      addr_space _MLX_BFloat16& lhs, itype rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }                                                                       \
+  constexpr METAL_FUNC addr_space itype& __operator__(                    \
+      addr_space itype& lhs, _MLX_BFloat16 rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__, itype) \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, threadgroup);
+
+#define bfloat_inplace_op(itype)                             \
+  bfloat_inplace_op_addr_space_helper(+, operator+=, itype); \
+  bfloat_inplace_op_addr_space_helper(-, operator-=, itype); \
+  bfloat_inplace_op_addr_space_helper(*, operator*=, itype); \
+  bfloat_inplace_op_addr_space_helper(/, operator/=, itype);
+
+bfloat_inplace_op(float);
+bfloat_inplace_op(half);
+bfloat_inplace_op(int16_t);
+bfloat_inplace_op(int32_t);
+bfloat_inplace_op(int64_t);
+bfloat_inplace_op(uint16_t);
+bfloat_inplace_op(uint32_t);
+bfloat_inplace_op(uint64_t);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+#undef bfloat_inplace_op
+
+#define bfloat_inplace_op_helper(__op__, __operator__, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(     \
+      addr_space _MLX_BFloat16& lhs, _MLX_BFloat16 rhs) {          \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);  \
+    return lhs;                                                    \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__) \
+  bfloat_inplace_op_helper(__op__, __operator__, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, threadgroup);
+
+bfloat_inplace_op_addr_space_helper(+, operator+=);
+bfloat_inplace_op_addr_space_helper(-, operator-=);
+bfloat_inplace_op_addr_space_helper(*, operator*=);
+bfloat_inplace_op_addr_space_helper(/, operator/=);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat typedef
+/////////////////////////////////////////////////////////////////////////////
+
+typedef struct _MLX_BFloat16 bfloat16_t;
+
+#endif
+
+
+
+
+
+template<typename T>
+[[kernel]] void copy_blocks(
+    device T* key_cache [[buffer(0)]],
+    device T* value_cache [[buffer(1)]],
+    const device int64_t* block_mapping [[buffer(2)]],
+    device const int& numel_per_block,
+    uint gid [[thread_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]])
+{
+    const int pair_idx = gid;
+    
+    int64_t src_block_number = block_mapping[2 * pair_idx];
+    int64_t dst_block_number = block_mapping[2 * pair_idx + 1];
+    
+    const int64_t src_block_offset = src_block_number * numel_per_block;
+    const int64_t dst_block_offset = dst_block_number * numel_per_block;
+    
+    // Copy key cache blocks
+    for (int i = tid; i < numel_per_block; i += threads_per_threadgroup) {
+        int64_t src_offset = src_block_offset + i;
+        int64_t dst_offset = dst_block_offset + i;
+        key_cache[dst_offset] = key_cache[src_offset];
+    }
+    
+    // Copy value cache blocks
+    for (int i = tid; i < numel_per_block; i += threads_per_threadgroup) {
+        int64_t src_offset = src_block_offset + i;
+        int64_t dst_offset = dst_block_offset + i;
+        value_cache[dst_offset] = value_cache[src_offset];
+    }
+}
+
+#define instantiate_copy_blocks(type)                           \
+  template [[host_name("copy_blocks_" #type)]]                  \
+  [[kernel]] void copy_blocks<type>(                  \
+    device type* key_cache_ptrs [[buffer(0)]],                  \
+    device type * value_cache_ptrs [[buffer(1)]],                  \
+    const device int64_t* block_mapping [[buffer(2)]],                  \
+    device const int& numel_per_block,                  \
+    uint gid [[thread_position_in_grid]],                  \
+    uint tid [[thread_position_in_threadgroup]],                  \
+    uint threads_per_threadgroup [[threads_per_threadgroup]]);
+
+instantiate_copy_blocks(float)
+instantiate_copy_blocks(bfloat16_t)
+instantiate_copy_blocks(half)

--- a/metal-kernels/src/lib.rs
+++ b/metal-kernels/src/lib.rs
@@ -1,0 +1,659 @@
+use candle_core::{DType, MetalStorage};
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, Function,
+    FunctionConstantValues, Library, MTLDataType, MTLSize, NSUInteger,
+};
+use once_cell::sync::OnceCell;
+use std::sync::RwLock;
+use std::{collections::HashMap, ffi::c_void};
+
+pub mod utils;
+use utils::EncoderProvider;
+
+#[derive(Debug)]
+pub enum PagedAttentionDType {
+    F16 = 0,
+    BF16 = 1,
+    F32 = 2,
+}
+
+const COPY_BLOCKS: &str = include_str!("copy_blocks.metal");
+const RESHAPE_AND_CACHE: &str = include_str!("reshape_and_cache.metal");
+const PAGEDATTENTION: &str = include_str!("pagedattention.metal");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Source {
+    CopyBlocks,
+    ReshapeAndCache,
+    PagedAttention,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MetalKernelError {
+    #[error("Could not lock kernel map: {0}")]
+    LockError(String),
+    #[error("Error while loading library: {0}")]
+    LoadLibraryError(String),
+    #[error("Error while loading function: {0:?}")]
+    LoadFunctionError(String),
+    #[error("Failed to create pipeline")]
+    FailedToCreatePipeline(String),
+    #[error("dtype mismatch, got {got:?}, expected {expected:?}")]
+    DTypeMismatch { expected: Vec<DType>, got: DType },
+}
+
+impl<T> From<std::sync::PoisonError<T>> for MetalKernelError {
+    fn from(e: std::sync::PoisonError<T>) -> Self {
+        Self::LockError(e.to_string())
+    }
+}
+
+type Libraries = HashMap<Source, Library>;
+type Pipelines = HashMap<(String, Option<ConstantValues>), ComputePipelineState>;
+
+#[derive(Debug)]
+pub struct Kernels {
+    libraries: RwLock<Libraries>,
+    pipelines: RwLock<Pipelines>,
+}
+
+pub(crate) static G_KERNEL: OnceCell<Kernels> = OnceCell::new();
+
+impl Kernels {
+    pub fn default() -> &'static Kernels {
+        G_KERNEL.get_or_init(Kernels::new)
+    }
+
+    pub fn new() -> Self {
+        let libraries = RwLock::new(Libraries::new());
+        let pipelines = RwLock::new(Pipelines::new());
+        Self {
+            libraries,
+            pipelines,
+        }
+    }
+
+    fn get_library_source(&self, source: Source) -> &'static str {
+        match source {
+            Source::CopyBlocks => COPY_BLOCKS,
+            Source::ReshapeAndCache => RESHAPE_AND_CACHE,
+            Source::PagedAttention => PAGEDATTENTION,
+        }
+    }
+
+    /// Load the give library from its [`source`].
+    /// If this has been previously loaded it will just fetch it from cache.
+    pub fn load_library(
+        &self,
+        device: &Device,
+        source: Source,
+    ) -> Result<Library, MetalKernelError> {
+        let mut libraries = self.libraries.write()?;
+        if let Some(lib) = libraries.get(&source) {
+            Ok(lib.clone())
+        } else {
+            let lib = {
+                let source_content = self.get_library_source(source);
+                device
+                    .new_library_with_source(source_content, &CompileOptions::new())
+                    .map_err(|e| MetalKernelError::LoadLibraryError(e.to_string()))?
+            };
+            libraries.insert(source, lib.clone());
+            Ok(lib)
+        }
+    }
+
+    fn load_function(
+        &self,
+        device: &Device,
+        source: Source,
+        name: String,
+        constants: Option<FunctionConstantValues>,
+    ) -> Result<Function, MetalKernelError> {
+        let func = self
+            .load_library(device, source)?
+            .get_function(&name, constants)
+            .map_err(|e| MetalKernelError::LoadFunctionError(e.to_string()))?;
+        Ok(func)
+    }
+
+    /// Load the give pipeline
+    /// loads the library from source, then gets the function [`name`] from
+    /// that source
+    fn load_pipeline_with_constants(
+        &self,
+        device: &Device,
+        source: Source,
+        name: String,
+        constants: Option<ConstantValues>,
+    ) -> Result<ComputePipelineState, MetalKernelError> {
+        let mut pipelines = self.pipelines.write()?;
+        let key = (name, constants);
+        if let Some(pipeline) = pipelines.get(&key) {
+            Ok(pipeline.clone())
+        } else {
+            let (name, constants) = key;
+            let func = self.load_function(
+                device,
+                source,
+                name.clone(),
+                constants.as_ref().map(|c| c.function_constant_values()),
+            )?;
+            let pipeline = device
+                .new_compute_pipeline_state_with_function(&func)
+                .map_err(|e| MetalKernelError::FailedToCreatePipeline(e.to_string()))?;
+            pipelines.insert((name, constants), pipeline.clone());
+
+            Ok(pipeline)
+        }
+    }
+
+    /// Load the give pipeline
+    /// loads the library from source, then gets the function [`name`] from
+    /// that source (without constants)
+    pub fn load_pipeline(
+        &self,
+        device: &Device,
+        source: Source,
+        name: String,
+    ) -> Result<ComputePipelineState, MetalKernelError> {
+        self.load_pipeline_with_constants(device, source, name, None)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn call_copy_blocks(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: DType,
+    key_cache: &Buffer,
+    key_cache_offset: usize,
+    value_cache: &Buffer,
+    value_cache_offset: usize,
+    block_mapping: &Buffer,
+    block_mapping_offset: usize,
+    num_pairs: u64,
+    numel_per_block: u64,
+) -> Result<(), MetalKernelError> {
+    let name = match ty {
+        DType::F32 => "copy_blocks_float",
+        DType::BF16 => "copy_blocks_bfloat16_t",
+        DType::F16 => "copy_blocks_half",
+        other => {
+            return Err(MetalKernelError::DTypeMismatch {
+                expected: vec![DType::F32, DType::F16, DType::BF16],
+                got: other,
+            })
+        }
+    };
+    let pipeline = kernels.load_pipeline(device, Source::CopyBlocks, name.to_string())?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    set_params!(
+        encoder,
+        (
+            (key_cache, key_cache_offset),
+            (value_cache, value_cache_offset),
+            (block_mapping, block_mapping_offset),
+            numel_per_block
+        )
+    );
+
+    let thread_groups_count = MTLSize {
+        width: num_pairs,
+        height: 1,
+        depth: 1,
+    };
+    let thread_group_size = MTLSize {
+        width: numel_per_block.min(1024),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(thread_groups_count, thread_group_size);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn call_reshape_and_cache(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: PagedAttentionDType,
+    key: &Buffer,
+    key_offset: usize,
+    value: &Buffer,
+    value_offset: usize,
+    key_cache: &Buffer,
+    key_cache_offset: usize,
+    value_cache: &Buffer,
+    value_cache_offset: usize,
+    slot_mapping: &Buffer,
+    slot_mapping_offset: usize,
+    num_tokens: i32,
+    num_heads: i32,
+    head_size: i32,
+    block_size: i32,
+    x: i32,
+    key_stride: i32,
+    value_stride: i32,
+) -> Result<(), MetalKernelError> {
+    let name = match ty {
+        PagedAttentionDType::F32 => "reshape_and_cache_float",
+        PagedAttentionDType::BF16 => "reshape_and_cache_bfloat16_t",
+        PagedAttentionDType::F16 => "reshape_and_cache_half",
+    };
+    let pipeline = kernels.load_pipeline(device, Source::ReshapeAndCache, name.to_string())?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    set_params!(
+        encoder,
+        (
+            (key, key_offset),
+            (value, value_offset),
+            (key_cache, key_cache_offset),
+            (value_cache, value_cache_offset),
+            (slot_mapping, slot_mapping_offset),
+            key_stride,
+            value_stride,
+            num_heads,
+            head_size,
+            block_size,
+            x
+        )
+    );
+
+    let thread_groups_count = MTLSize {
+        width: num_tokens as u64,
+        height: 1,
+        depth: 1,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: (num_heads * head_size).min(512) as u64,
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    Bool(bool),
+}
+
+impl std::hash::Hash for Value {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Value::Bool(v) => v.hash(state),
+        }
+    }
+}
+
+impl Value {
+    fn data_type(&self) -> MTLDataType {
+        match self {
+            Value::Bool(_) => MTLDataType::Bool,
+        }
+    }
+}
+
+/// Not true, good enough for our purposes.
+impl Eq for Value {}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+struct ConstantValues(Vec<(usize, Value)>);
+
+impl ConstantValues {
+    pub fn new(values: Vec<(usize, Value)>) -> Self {
+        Self(values)
+    }
+
+    fn function_constant_values(&self) -> FunctionConstantValues {
+        let f = FunctionConstantValues::new();
+        for (index, value) in &self.0 {
+            let ty = value.data_type();
+            match value {
+                Value::Bool(v) => {
+                    f.set_constant_value_at_index(
+                        v as *const bool as *const c_void,
+                        ty,
+                        *index as u64,
+                    );
+                }
+            }
+        }
+        f
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_v1(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: PagedAttentionDType,
+    q: &Buffer,
+    q_offset: usize,
+    k_cache: &Buffer,
+    k_cache_offset: usize,
+    v_cache: &Buffer,
+    v_cache_offset: usize,
+    block_tables: &Buffer,
+    block_tables_offset: usize,
+    context_lens: &Buffer,
+    context_lens_offset: usize,
+    alibi_storage_and_offset: Option<(MetalStorage, usize)>,
+    output: &Buffer,
+    num_kv_heads: i32,
+    scale: f32,
+    softcapping: f32,
+    block_size: i32,
+    max_context_len: i32,
+    num_seqs: i32,
+    num_heads: i32,
+    head_size: i32,
+    max_num_blocks_per_seq: i32,
+    q_stride: i32,
+    kv_block_stride: i32,
+    kv_head_stride: i32,
+) -> Result<(), MetalKernelError> {
+    const NUM_THREADS: u64 = 256;
+    const NUM_SIMD_LANES: u64 = 32;
+
+    let name = match ty {
+        PagedAttentionDType::F32 => "paged_attention_float",
+        PagedAttentionDType::BF16 => "paged_attention_bfloat16_t",
+        PagedAttentionDType::F16 => "paged_attention_half",
+    };
+    let mut name = name.to_string();
+    name.push_str(&format!("_hs{head_size}"));
+    name.push_str(&format!("_bs{block_size}"));
+    name.push_str(&format!("_nt{NUM_THREADS}"));
+    name.push_str(&format!("_nsl{}", NUM_SIMD_LANES));
+    // v1 has no partition
+    name.push_str(&format!("_ps{}", 0));
+
+    // v1 has no partition.
+    // Handle alibi
+    let constants = Some(ConstantValues::new(vec![
+        (10, Value::Bool(/* use_partitioning */ false)),
+        (
+            20,
+            Value::Bool(/* use_alibi */ alibi_storage_and_offset.is_some()),
+        ),
+    ]));
+
+    let pipeline =
+        kernels.load_pipeline_with_constants(device, Source::PagedAttention, name, constants)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    assert_eq!(pipeline.thread_execution_width(), NUM_SIMD_LANES);
+
+    let num_simds = NUM_THREADS / NUM_SIMD_LANES;
+    let padded_max_context_len = ((max_context_len + block_size - 1) / block_size) * block_size;
+    let logits_size = padded_max_context_len * std::mem::size_of::<f32>() as i32;
+    let outputs_size = (num_simds as i32 / 2) * head_size * std::mem::size_of::<f32>() as i32;
+    let shared_mem_size = logits_size.max(outputs_size);
+    encoder.set_threadgroup_memory_length(0, shared_mem_size as u64);
+
+    encoder.set_buffer(2, Some(output), 0 as NSUInteger);
+    encoder.set_buffer(3, Some(q), q_offset as NSUInteger);
+    encoder.set_buffer(4, Some(k_cache), k_cache_offset as NSUInteger);
+    encoder.set_buffer(5, Some(v_cache), v_cache_offset as NSUInteger);
+    encoder.set_bytes(
+        6,
+        core::mem::size_of_val(&num_kv_heads) as u64,
+        &num_kv_heads as *const _ as *const c_void,
+    );
+    encoder.set_bytes(
+        7,
+        core::mem::size_of_val(&scale) as u64,
+        &scale as *const _ as *const c_void,
+    );
+    encoder.set_bytes(
+        8,
+        core::mem::size_of_val(&softcapping) as u64,
+        &softcapping as *const _ as *const c_void,
+    );
+    encoder.set_buffer(9, Some(block_tables), block_tables_offset as NSUInteger);
+    encoder.set_buffer(10, Some(context_lens), context_lens_offset as NSUInteger);
+    encoder.set_bytes(
+        11,
+        core::mem::size_of_val(&max_num_blocks_per_seq) as u64,
+        &max_num_blocks_per_seq as *const _ as *const c_void,
+    );
+    if let Some((alibi, alibi_offset)) = alibi_storage_and_offset {
+        encoder.set_buffer(12, Some(alibi.buffer()), alibi_offset as NSUInteger);
+    }
+    encoder.set_bytes(
+        13,
+        core::mem::size_of_val(&q_stride) as u64,
+        &q_stride as *const _ as *const c_void,
+    );
+    encoder.set_bytes(
+        14,
+        core::mem::size_of_val(&kv_block_stride) as u64,
+        &kv_block_stride as *const _ as *const c_void,
+    );
+    encoder.set_bytes(
+        15,
+        core::mem::size_of_val(&kv_head_stride) as u64,
+        &kv_head_stride as *const _ as *const c_void,
+    );
+
+    let thread_groups_count = MTLSize {
+        width: num_heads as u64,
+        height: num_seqs as u64,
+        depth: 1,
+    };
+    let thread_group_size = MTLSize {
+        width: NUM_THREADS,
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(thread_groups_count, thread_group_size);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention_v2(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: PagedAttentionDType,
+    exp_sums: &Buffer,
+    max_logits: &Buffer,
+    q: &Buffer,
+    q_offset: usize,
+    k_cache: &Buffer,
+    k_cache_offset: usize,
+    v_cache: &Buffer,
+    v_cache_offset: usize,
+    block_tables: &Buffer,
+    block_tables_offset: usize,
+    context_lens: &Buffer,
+    context_lens_offset: usize,
+    alibi_storage_and_offset: Option<(MetalStorage, usize)>,
+    tmp_out: &Buffer,
+    output: &Buffer,
+    num_kv_heads: i32,
+    scale: f32,
+    softcapping: f32,
+    block_size: i32,
+    max_context_len: i32,
+    num_seqs: i32,
+    num_heads: i32,
+    head_size: i32,
+    max_num_blocks_per_seq: i32,
+    q_stride: i32,
+    kv_block_stride: i32,
+    kv_head_stride: i32,
+) -> Result<(), MetalKernelError> {
+    const NUM_THREADS: u64 = 256;
+    const PARTITION_SIZE: u64 = 512;
+    const NUM_SIMD_LANES: u64 = 32;
+
+    // Initial paged attention kernel
+    {
+        let name = match ty {
+            PagedAttentionDType::F32 => "paged_attention_float",
+            PagedAttentionDType::BF16 => "paged_attention_bfloat16_t",
+            PagedAttentionDType::F16 => "paged_attention_half",
+        };
+        let mut name = name.to_string();
+        name.push_str(&format!("_hs{head_size}"));
+        name.push_str(&format!("_bs{block_size}"));
+        name.push_str(&format!("_nt{NUM_THREADS}"));
+        name.push_str(&format!("_nsl{}", NUM_SIMD_LANES));
+        // v2 has partition.
+        name.push_str(&format!("_ps{}", PARTITION_SIZE));
+
+        // v2 has partition.
+        // Handle alibi
+        let constants = Some(ConstantValues::new(vec![
+            (10, Value::Bool(/* use_partitioning */ true)),
+            (
+                20,
+                Value::Bool(/* use_alibi */ alibi_storage_and_offset.is_some()),
+            ),
+        ]));
+
+        let pipeline = kernels.load_pipeline_with_constants(
+            device,
+            Source::PagedAttention,
+            name,
+            constants,
+        )?;
+
+        let encoder = ep.encoder();
+        let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        assert_eq!(pipeline.thread_execution_width(), NUM_SIMD_LANES);
+
+        let num_simds = NUM_THREADS / NUM_SIMD_LANES;
+        let max_num_partitions =
+            (max_context_len + PARTITION_SIZE as i32 - 1) / PARTITION_SIZE as i32;
+        let logits_size = PARTITION_SIZE as i32 * std::mem::size_of::<f32>() as i32;
+        let outputs_size = (num_simds as i32 / 2) * head_size * std::mem::size_of::<f32>() as i32;
+        let shared_mem_size = logits_size.max(outputs_size);
+        encoder.set_threadgroup_memory_length(0, shared_mem_size as u64);
+
+        encoder.set_buffer(0, Some(exp_sums), 0 as NSUInteger);
+        encoder.set_buffer(1, Some(max_logits), 0 as NSUInteger);
+        encoder.set_buffer(2, Some(tmp_out), 0 as NSUInteger);
+        encoder.set_buffer(3, Some(q), q_offset as NSUInteger);
+        encoder.set_buffer(4, Some(k_cache), k_cache_offset as NSUInteger);
+        encoder.set_buffer(5, Some(v_cache), v_cache_offset as NSUInteger);
+        encoder.set_bytes(
+            6,
+            core::mem::size_of_val(&num_kv_heads) as u64,
+            &num_kv_heads as *const _ as *const c_void,
+        );
+        encoder.set_bytes(
+            7,
+            core::mem::size_of_val(&scale) as u64,
+            &scale as *const _ as *const c_void,
+        );
+        encoder.set_bytes(
+            8,
+            core::mem::size_of_val(&softcapping) as u64,
+            &softcapping as *const _ as *const c_void,
+        );
+        encoder.set_buffer(9, Some(block_tables), block_tables_offset as NSUInteger);
+        encoder.set_buffer(10, Some(context_lens), context_lens_offset as NSUInteger);
+        encoder.set_bytes(
+            11,
+            core::mem::size_of_val(&max_num_blocks_per_seq) as u64,
+            &max_num_blocks_per_seq as *const _ as *const c_void,
+        );
+        if let Some((alibi, alibi_offset)) = alibi_storage_and_offset {
+            encoder.set_buffer(12, Some(alibi.buffer()), alibi_offset as NSUInteger);
+        }
+        encoder.set_bytes(
+            13,
+            core::mem::size_of_val(&q_stride) as u64,
+            &q_stride as *const _ as *const c_void,
+        );
+        encoder.set_bytes(
+            14,
+            core::mem::size_of_val(&kv_block_stride) as u64,
+            &kv_block_stride as *const _ as *const c_void,
+        );
+        encoder.set_bytes(
+            15,
+            core::mem::size_of_val(&kv_head_stride) as u64,
+            &kv_head_stride as *const _ as *const c_void,
+        );
+
+        let thread_groups_count = MTLSize {
+            width: num_heads as u64,
+            height: num_seqs as u64,
+            depth: max_num_partitions as u64,
+        };
+        let thread_group_size = MTLSize {
+            width: NUM_THREADS,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_thread_groups(thread_groups_count, thread_group_size);
+    }
+
+    // Paged attention reduce kernel
+    {
+        let name = match ty {
+            PagedAttentionDType::F32 => "paged_attention_v2_reduce_float",
+            PagedAttentionDType::BF16 => "paged_attention_v2_reduce_bfloat16_t",
+            PagedAttentionDType::F16 => "paged_attention_v2_reduce_half",
+        };
+        let mut name = name.to_string();
+        name.push_str(&format!("_hs{head_size}"));
+        name.push_str(&format!("_nt{NUM_THREADS}"));
+        name.push_str(&format!("_nsl{}", NUM_SIMD_LANES));
+        name.push_str(&format!("_ps{}", PARTITION_SIZE));
+
+        let pipeline = kernels.load_pipeline(device, Source::PagedAttention, name)?;
+
+        let encoder = ep.encoder();
+        let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        assert_eq!(pipeline.thread_execution_width(), NUM_SIMD_LANES);
+
+        let max_num_partitions =
+            (max_context_len + PARTITION_SIZE as i32 - 1) / PARTITION_SIZE as i32;
+        let reduce_shared_mem_size = 2 * max_num_partitions * std::mem::size_of::<f32>() as i32;
+        encoder.set_threadgroup_memory_length(0, reduce_shared_mem_size as u64);
+
+        encoder.set_buffer(0, Some(output), 0 as NSUInteger);
+        encoder.set_buffer(1, Some(exp_sums), 0 as NSUInteger);
+        encoder.set_buffer(2, Some(max_logits), 0 as NSUInteger);
+        encoder.set_buffer(3, Some(tmp_out), 0 as NSUInteger);
+        encoder.set_buffer(4, Some(context_lens), context_lens_offset as NSUInteger);
+        encoder.set_bytes(
+            5,
+            core::mem::size_of_val(&max_num_partitions) as u64,
+            &max_num_partitions as *const _ as *const c_void,
+        );
+
+        let thread_groups_count = MTLSize {
+            width: num_heads as u64,
+            height: num_seqs as u64,
+            depth: 1,
+        };
+        let thread_group_size = MTLSize {
+            width: NUM_THREADS,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_thread_groups(thread_groups_count, thread_group_size);
+    }
+    Ok(())
+}

--- a/metal-kernels/src/pagedattention.metal
+++ b/metal-kernels/src/pagedattention.metal
@@ -1,0 +1,1480 @@
+// Updated from MLX commit has f70764a
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+
+using namespace metal;
+
+#if defined(__HAVE_BFLOAT__)
+
+typedef bfloat bfloat16_t;
+
+#else
+
+/////////////////////////////////////////////////////////////////////////////
+// Helpers
+/////////////////////////////////////////////////////////////////////////////
+
+constexpr METAL_FUNC uint16_t float_to_bfloat_bits(float x) {
+  // Check for nan
+  if ((as_type<uint32_t>(x) & ~_fp_encoding_traits<float>::sign_mask) >
+      _fp_encoding_traits<float>::inf_mask) {
+    return uint16_t(as_type<uint32_t>(0x7FC0));
+  }
+  // Take bits
+  uint32_t float_bits = as_type<uint32_t>(x);
+
+  // Round to nearest even
+  float_bits += ((float_bits >> 16) & 1) + as_type<uint32_t>(0x7FFF);
+
+  // Take upper 16 bits
+  return float_bits >> 16;
+}
+
+constexpr METAL_FUNC float bfloat_bits_to_float(uint16_t x) {
+  // Upper 16 bits are the data and lower 16 bits are 0s
+  return as_type<float>((uint32_t)x << 16);
+}
+
+struct _MLX_BFloat16;
+
+template <typename T>
+static constexpr constant bool can_convert_to_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<T, float>;
+
+template <typename T>
+static constexpr constant bool can_convert_from_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<float, T>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat struct
+/////////////////////////////////////////////////////////////////////////////
+
+struct _MLX_BFloat16 {
+  /////////////////////////////////////////////////////////////////////////////
+  // Constructors
+  uint16_t bits_;
+  _MLX_BFloat16() thread = default;
+  _MLX_BFloat16() threadgroup = default;
+  _MLX_BFloat16() device = default;
+  _MLX_BFloat16() constant = default;
+
+  struct bits_to_bfloat_struct {};
+  static constexpr METAL_FUNC bits_to_bfloat_struct bits_to_bfloat() {
+    return bits_to_bfloat_struct();
+  }
+  constexpr METAL_FUNC _MLX_BFloat16(uint16_t bits, bits_to_bfloat_struct)
+      : bits_(bits) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions to bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) thread
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) threadgroup
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) device
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) constant
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions from bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const thread {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const threadgroup {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const device {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const constant {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat operators
+/////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////
+// Unary ops
+constexpr METAL_FUNC _MLX_BFloat16 operator-(_MLX_BFloat16 x) {
+  return -static_cast<float>(x);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Binary operators
+#define bfloat_binop_base(__op__, __operator__, otype, atype, btype, ctype) \
+  constexpr METAL_FUNC otype __operator__(atype lhs, btype rhs) {           \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);          \
+  }
+
+#define bfloat_binop_helper(__op__, __operator__, otype, itype, ctype)    \
+  constexpr METAL_FUNC otype __operator__(_MLX_BFloat16 lhs, itype rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }                                                                       \
+  constexpr METAL_FUNC otype __operator__(itype lhs, _MLX_BFloat16 rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }
+
+/////////////////////////////////////////////////////////////////////////////
+// Arithmetic Operators
+#define bfloat_binop(_op_, _operator_)                                       \
+  bfloat_binop_base(                                                         \
+      _op_, _operator_, _MLX_BFloat16, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(_op_, _operator_, float, float, float);                \
+  bfloat_binop_helper(_op_, _operator_, float, half, float);                 \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int32_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint32_t, float);     \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int64_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint64_t, float);
+
+bfloat_binop(+, operator+);
+bfloat_binop(-, operator-);
+bfloat_binop(*, operator*);
+bfloat_binop(/, operator/);
+
+/////////////////////////////////////////////////////////////////////////////
+// Comparison ops
+#define bfloat_compop(__op__, __operator__)                             \
+  bfloat_binop_base(                                                    \
+      __op__, __operator__, bool, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(__op__, __operator__, bool, float, float);        \
+  bfloat_binop_helper(__op__, __operator__, bool, half, float);         \
+  bfloat_binop_helper(__op__, __operator__, bool, int32_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint32_t, float);     \
+  bfloat_binop_helper(__op__, __operator__, bool, int64_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint64_t, float);
+
+bfloat_compop(>, operator>);
+bfloat_compop(<, operator<);
+bfloat_compop(>=, operator>=);
+bfloat_compop(<=, operator<=);
+bfloat_compop(==, operator==);
+bfloat_compop(!=, operator!=);
+
+#undef bfloat_compop
+#undef bfloat_binop_base
+#undef bfloat_binop_helper
+#undef bfloat_binop
+
+/////////////////////////////////////////////////////////////////////////////
+// Inplace Operators
+#define bfloat_inplace_op_helper(__op__, __operator__, itype, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(            \
+      addr_space _MLX_BFloat16& lhs, itype rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }                                                                       \
+  constexpr METAL_FUNC addr_space itype& __operator__(                    \
+      addr_space itype& lhs, _MLX_BFloat16 rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__, itype) \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, threadgroup);
+
+#define bfloat_inplace_op(itype)                             \
+  bfloat_inplace_op_addr_space_helper(+, operator+=, itype); \
+  bfloat_inplace_op_addr_space_helper(-, operator-=, itype); \
+  bfloat_inplace_op_addr_space_helper(*, operator*=, itype); \
+  bfloat_inplace_op_addr_space_helper(/, operator/=, itype);
+
+bfloat_inplace_op(float);
+bfloat_inplace_op(half);
+bfloat_inplace_op(int16_t);
+bfloat_inplace_op(int32_t);
+bfloat_inplace_op(int64_t);
+bfloat_inplace_op(uint16_t);
+bfloat_inplace_op(uint32_t);
+bfloat_inplace_op(uint64_t);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+#undef bfloat_inplace_op
+
+#define bfloat_inplace_op_helper(__op__, __operator__, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(     \
+      addr_space _MLX_BFloat16& lhs, _MLX_BFloat16 rhs) {          \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);  \
+    return lhs;                                                    \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__) \
+  bfloat_inplace_op_helper(__op__, __operator__, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, threadgroup);
+
+bfloat_inplace_op_addr_space_helper(+, operator+=);
+bfloat_inplace_op_addr_space_helper(-, operator-=);
+bfloat_inplace_op_addr_space_helper(*, operator*=);
+bfloat_inplace_op_addr_space_helper(/, operator/=);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat typedef
+/////////////////////////////////////////////////////////////////////////////
+
+typedef struct _MLX_BFloat16 bfloat16_t;
+
+#endif
+
+// ========================================== Generic vector types
+
+// A vector type to store Q, K, V elements.
+template<typename T, int VEC_SIZE>
+struct Vec {};
+
+// A vector type to store FP32 accumulators.
+template<typename T>
+struct FloatVec {};
+
+// Template vector operations.
+template<typename Acc, typename A, typename B>
+inline Acc mul(A a, B b);
+
+template<typename T>
+inline float sum(T v);
+
+template<typename T>
+inline float dot(T a, T b) {
+  return sum(mul<T, T, T>(a, b));
+}
+
+template<typename A, typename T>
+inline float dot(T a, T b) {
+  return sum(mul<A, T, T>(a, b));
+}
+
+
+
+// FP32 vector data types.
+struct Float8_ {
+  float4 x;
+  float4 y;
+};
+
+template<>
+struct Vec<float, 1> {
+  using Type = float;
+};
+template<>
+struct Vec<float, 2> {
+  using Type = float2;
+};
+template<>
+struct Vec<float, 4> {
+  using Type = float4;
+};
+template<>
+struct Vec<float, 8> {
+  using Type = Float8_;
+};
+
+template<>
+struct FloatVec<float> {
+  using Type = float;
+};
+template<>
+struct FloatVec<float2> {
+  using Type = float2;
+};
+template<>
+struct FloatVec<float4> {
+  using Type = float4;
+};
+template<>
+struct FloatVec<Float8_> {
+  using Type = Float8_;
+};
+
+template<>
+inline float mul(float a, float b) {
+  return a*b;
+}
+
+template<>
+inline float2 mul(float2 a, float2 b) {
+  return a*b;
+}
+
+template<>
+inline float4 mul(float4 a, float4 b) {
+  return a*b;
+}
+
+template<>
+inline Float8_ mul(Float8_ a, Float8_ b) {
+  Float8_ c;
+  c.x = a.x * b.x;
+  c.y = a.y * b.y;
+  return c;
+}
+
+template<>
+inline float sum(float a) {
+  return a;
+}
+
+template<>
+inline float sum(float2 a) {
+  return a.x + a.y;
+}
+
+template<>
+inline float sum(float4 a) {
+  return a.x + a.y + a.z + a.w;
+}
+
+template<>
+inline float sum(Float8_ a) {
+  return sum(a.x) + sum(a.y);
+}
+
+inline Float8_ fma(Float8_ a, Float8_ b, Float8_ c) {
+  Float8_ res;
+  res.x = fma(a.x, b.x, c.x);
+  res.y = fma(a.y, b.y, c.y);
+  return res;
+}
+
+inline void from_float(thread float& dst, float src) {
+  dst = src;
+}
+inline void from_float(thread float2& dst, float2 src) {
+  dst = src;
+}
+inline void from_float(thread float4& dst, float4 src) {
+  dst = src;
+}
+inline void from_float(thread Float8_& dst, Float8_ src) {
+  dst = src;
+}
+
+
+
+
+// BF16 vector data types.
+// #if defined(__HAVE_BFLOAT__)
+
+// struct Bfloat8_ {
+//   bfloat4 x;
+//   bfloat4 y;
+// };
+
+// template<>
+// struct Vec<bfloat, 1> {
+//   using Type = bfloat;
+// };
+// template<>
+// struct Vec<bfloat, 2> {
+//   using Type = bfloat2;
+// };
+// template<>
+// struct Vec<bfloat, 4> {
+//   using Type = bfloat4;
+// };
+// template<>
+// struct Vec<bfloat, 8> {
+//   using Type = Bfloat8_;
+// };
+
+// template<>
+// struct FloatVec<bfloat> {
+//   using Type = float;
+// };
+// template<>
+// struct FloatVec<bfloat2> {
+//   using Type = float2;
+// };
+// template<>
+// struct FloatVec<bfloat4> {
+//   using Type = float4;
+// };
+// template<>
+// struct FloatVec<Bfloat8_> {
+//   using Type = Float8_;
+// };
+
+// template<>
+// inline float mul(bfloat a, bfloat b) {
+//   return (float)a * (float)b;
+// }
+// template<>
+// inline bfloat mul(bfloat a, bfloat b) {
+//   return a*b;
+// }
+
+// template<>
+// inline float2 mul(bfloat2 a, bfloat2 b) {
+//   return (float2)a * (float2)b;
+// }
+// template<>
+// inline bfloat2 mul(bfloat2 a, bfloat2 b) {
+//   return a * b;
+// }
+
+// template<>
+// inline float4 mul(bfloat4 a, bfloat4 b) {
+//   return (float4)a * (float4)b;
+// }
+// template<>
+// inline bfloat4 mul(bfloat4 a, bfloat4 b) {
+//   return a * b;
+// }
+
+// template<>
+// inline Float8_ mul(Bfloat8_ a, Bfloat8_ b) {
+//   Float8_ c;
+//   c.x = mul<float4, bfloat4, bfloat4>(a.x, b.x);
+//   c.y = mul<float4, bfloat4, bfloat4>(a.y, b.y);
+//   return c;
+// }
+// template<>
+// inline Bfloat8_ mul(Bfloat8_ a, Bfloat8_ b) {
+//   Bfloat8_ c;
+//   c.x = mul<bfloat4, bfloat4, bfloat4>(a.x, b.x);
+//   c.y = mul<bfloat4, bfloat4, bfloat4>(a.y, b.y);
+//   return c;
+// }
+
+// template<>
+// inline float sum(bfloat a) {
+//   return (float)a;
+// }
+
+// template<>
+// inline float sum(bfloat2 a) {
+//   return (float)a.x + (float)a.y;
+// }
+
+// template<>
+// inline float sum(bfloat4 a) {
+//   return sum(a.x) + sum(a.y);
+// }
+
+// template<>
+// inline float sum(Bfloat8_ a) {
+//   return sum(a.x) + sum(a.y);
+// }
+
+// inline float fma(bfloat a, bfloat b, float c) {
+//   return (float)a * (float)b + c;
+// }
+
+// inline float2 fma(bfloat2 a, bfloat2 b, float2 c) {
+//   return (float2)a * (float2)b + c;
+// }
+
+// inline float4 fma(bfloat4 a, bfloat4 b, float4 c) {
+//   return (float4)a * (float4)b + c;
+// }
+
+// inline Float8_ fma(Bfloat8_ a, Bfloat8_ b, Float8_ c) {
+//   Float8_ res;
+//   res.x = fma((float4)a.x, (float4)b.x, (float4)c.x);
+//   res.y = fma((float4)a.y, (float4)b.y, (float4)c.y);
+//   return res;
+// }
+// inline Bfloat8_ fma(Bfloat8_ a, Bfloat8_ b, Bfloat8_ c) {
+//   Bfloat8_ res;
+//   res.x = (bfloat4)fma((float4)a.x, (float4)b.x, (float4)c.x);
+//   res.y = (bfloat4)fma((float4)a.y, (float4)b.x, (float4)c.y);
+//   return c;
+// }
+
+// inline void from_float(thread bfloat& dst, float src) {
+//   dst = static_cast<bfloat>(src);
+// }
+// inline void from_float(thread bfloat2& dst, float2 src) {
+//   dst.x = static_cast<bfloat>(src.x);
+//   dst.y = static_cast<bfloat>(src.y);
+// }
+// inline void from_float(thread bfloat4& dst, float4 src) {
+//   dst.x = static_cast<bfloat>(src.x);
+//   dst.y = static_cast<bfloat>(src.y);
+//   dst.z = static_cast<bfloat>(src.z);
+//   dst.w = static_cast<bfloat>(src.w);
+// }
+// inline void from_float(thread Bfloat8_& dst, Float8_ src) {
+//   bfloat4 x;
+//   bfloat4 y;
+//   from_float(x, src.x);
+//   from_float(y, src.y);
+//   dst.x = x;
+//   dst.y = y;
+// }
+
+// #else
+
+struct Bfloat2_ {
+  bfloat16_t x;
+  bfloat16_t y;
+};
+
+struct Bfloat4_ {
+  Bfloat2_ x;
+  Bfloat2_ y;
+};
+
+struct Bfloat8_ {
+  Bfloat4_ x;
+  Bfloat4_ y;
+};
+
+template<>
+struct Vec<bfloat16_t, 1> {
+  using Type = bfloat16_t;
+};
+template<>
+struct Vec<bfloat16_t, 2> {
+  using Type = Bfloat2_;
+};
+template<>
+struct Vec<bfloat16_t, 4> {
+  using Type = Bfloat4_;
+};
+template<>
+struct Vec<bfloat16_t, 8> {
+  using Type = Bfloat8_;
+};
+
+template<>
+struct FloatVec<bfloat16_t> {
+  using Type = float;
+};
+template<>
+struct FloatVec<Bfloat2_> {
+  using Type = float2;
+};
+template<>
+struct FloatVec<Bfloat4_> {
+  using Type = float4;
+};
+template<>
+struct FloatVec<Bfloat8_> {
+  using Type = Float8_;
+};
+
+template<>
+inline float mul(bfloat16_t a, bfloat16_t b) {
+  return (float)a * (float)b;
+}
+template<>
+inline bfloat16_t mul(bfloat16_t a, bfloat16_t b) {
+  return a*b;
+}
+
+template<>
+inline float2 mul(Bfloat2_ a, Bfloat2_ b) {
+  float2 a_f((float)a.x, (float)a.y);
+  float2 b_f((float)b.x, (float)b.y);
+  return a_f * b_f;
+}
+template<>
+inline Bfloat2_ mul(Bfloat2_ a, Bfloat2_ b) {
+  Bfloat2_ c;
+  c.x = a.x * b.x;
+  c.y = a.y * b.y;
+  return c;
+}
+
+template<>
+inline float4 mul(Bfloat4_ a, Bfloat4_ b) {
+  float2 x = mul<float2, Bfloat2_, Bfloat2_>(a.x, b.x);
+  float2 y = mul<float2, Bfloat2_, Bfloat2_>(a.y, b.y);
+  float4 c;
+  c.x = x.x;
+  c.y = x.y;
+  c.z = y.x;
+  c.w = y.y;
+  return c;
+}
+template<>
+inline Bfloat4_ mul(Bfloat4_ a, Bfloat4_ b) {
+  Bfloat4_ c;
+  c.x = mul<Bfloat2_, Bfloat2_, Bfloat2_>(a.x, b.x);
+  c.y = mul<Bfloat2_, Bfloat2_, Bfloat2_>(a.y, b.y);
+  return c;
+}
+
+template<>
+inline Float8_ mul(Bfloat8_ a, Bfloat8_ b) {
+  Float8_ c;
+  c.x = mul<float4, Bfloat4_, Bfloat4_>(a.x, b.x);
+  c.y = mul<float4, Bfloat4_, Bfloat4_>(a.y, b.y);
+  return c;
+}
+template<>
+inline Bfloat8_ mul(Bfloat8_ a, Bfloat8_ b) {
+  Bfloat8_ c;
+  c.x = mul<Bfloat4_, Bfloat4_, Bfloat4_>(a.x, b.x);
+  c.y = mul<Bfloat4_, Bfloat4_, Bfloat4_>(a.y, b.y);
+  return c;
+}
+
+template<>
+inline float sum(bfloat16_t a) {
+  return (float)a;
+}
+
+template<>
+inline float sum(Bfloat2_ a) {
+  return (float)a.x + (float)a.y;
+}
+
+template<>
+inline float sum(Bfloat4_ a) {
+  return sum(a.x) + sum(a.y);
+}
+
+template<>
+inline float sum(Bfloat8_ a) {
+  return sum(a.x) + sum(a.y);
+}
+
+inline float fma(bfloat16_t a, bfloat16_t b, float c) {
+  return (float)a * (float)b + c;
+}
+inline bfloat16_t fma(bfloat16_t a, bfloat16_t b, bfloat16_t c) {
+  return a*b+c;
+}
+
+inline float2 fma(Bfloat2_ a, Bfloat2_ b, float2 c) {
+  float2 a_f((float)a.x, (float)a.y);
+  float2 b_f((float)b.x, (float)b.y);
+  return a_f * b_f + c;
+}
+inline Bfloat2_ fma(Bfloat2_ a, Bfloat2_ b, Bfloat2_ c) {
+  Bfloat2_ res;
+  res.x = a.x * b.x + c.x;
+  res.y = a.y * b.y + c.y;
+  return res;
+}
+
+inline float4 fma(Bfloat4_ a, Bfloat4_ b, float4 c) {
+  float4 res;
+  res.x = fma(a.x.x, b.x.x, c.x);
+  res.y = fma(a.x.y, b.x.y, c.y);
+  res.z = fma(a.y.x, b.y.x, c.z);
+  res.w = fma(a.y.y, b.y.y, c.w);
+  return res;
+}
+inline Bfloat4_ fma(Bfloat4_ a, Bfloat4_ b, Bfloat4_ c) {
+  Bfloat4_ res;
+  res.x = fma(a.x, b.x, c.x);
+  res.y = fma(a.y, b.y, c.y);
+  return res;
+}
+
+inline Float8_ fma(Bfloat8_ a, Bfloat8_ b, Float8_ c) {
+  float4 x = fma(a.x, b.x, c.x);
+  float4 y = fma(a.y, b.y, c.y);
+  Float8_ res;
+  res.x = x;
+  res.y = y;
+  return res;
+}
+inline Bfloat8_ fma(Bfloat8_ a, Bfloat8_ b, Bfloat8_ c) {
+  Bfloat8_ res;
+  res.x = fma(a.x, b.x, c.x);
+  res.y = fma(a.y, b.x, c.y);
+  return c;
+}
+
+inline void from_float(thread bfloat16_t& dst, float src) {
+  dst = static_cast<bfloat16_t>(src);
+}
+inline void from_float(thread Bfloat2_& dst, float2 src) {
+  dst.x = static_cast<bfloat16_t>(src.x);
+  dst.y = static_cast<bfloat16_t>(src.y);
+}
+inline void from_float(thread Bfloat4_& dst, float4 src) {
+  dst.x.x = static_cast<bfloat16_t>(src.x);
+  dst.x.y = static_cast<bfloat16_t>(src.y);
+  dst.y.x = static_cast<bfloat16_t>(src.z);
+  dst.y.y = static_cast<bfloat16_t>(src.w);
+}
+inline void from_float(thread Bfloat8_& dst, Float8_ src) {
+  Bfloat4_ x;
+  Bfloat4_ y;
+  from_float(x, src.x);
+  from_float(y, src.y);
+  dst.x = x;
+  dst.y = y;
+}
+
+// #endif
+
+
+
+
+
+// FP16 vector data types.
+struct Half8_ {
+  half4 x;
+  half4 y;
+};
+
+template<>
+struct Vec<half, 1> {
+  using Type = half;
+};
+template<>
+struct Vec<half, 2> {
+  using Type = half2;
+};
+template<>
+struct Vec<half, 4> {
+  using Type = half4;
+};
+template<>
+struct Vec<half, 8> {
+  using Type = Half8_;
+};
+
+template<>
+struct FloatVec<half> {
+  using Type = float;
+};
+template<>
+struct FloatVec<half2> {
+  using Type = float2;
+};
+template<>
+struct FloatVec<half4> {
+  using Type = float4;
+};
+template<>
+struct FloatVec<Half8_> {
+  using Type = Float8_;
+};
+
+template<>
+inline float mul(half a, half b) {
+  return (float)a * (float)b;
+}
+template<>
+inline half mul(half a, half b) {
+  return a*b;
+}
+
+template<>
+inline float2 mul(half2 a, half2 b) {
+  return (float2)a * (float2)b;
+}
+template<>
+inline half2 mul(half2 a, half2 b) {
+  return a * b;
+}
+
+template<>
+inline float4 mul(half4 a, half4 b) {
+  return (float4)a * (float4)b;
+}
+template<>
+inline half4 mul(half4 a, half4 b) {
+  return a * b;
+}
+
+template<>
+inline Float8_ mul(Half8_ a, Half8_ b) {
+  float4 x = mul<float4, half4, half4>(a.x, b.x);
+  float4 y = mul<float4, half4, half4>(a.y, b.y);
+  Float8_ c;
+  c.x = x;
+  c.y = y;
+  return c;
+}
+template<>
+inline Half8_ mul(Half8_ a, Half8_ b) {
+  Half8_ c;
+  c.x = mul<half4, half4, half4>(a.x, b.x);
+  c.y = mul<half4, half4, half4>(a.y, b.y);
+  return c;
+}
+
+template<>
+inline float sum(half a) {
+  return (float)a;
+}
+
+template<>
+inline float sum(half2 a) {
+  return (float)a.x + (float)a.y;
+}
+
+template<>
+inline float sum(half4 a) {
+  return sum(a.x) + sum(a.y);
+}
+
+template<>
+inline float sum(Half8_ a) {
+  return sum(a.x) + sum(a.y);
+}
+
+inline float fma(half a, half b, float c) {
+  return (float)a * (float)b + c;
+}
+
+inline float2 fma(half2 a, half2 b, float2 c) {
+  return (float2)a * (float2)b + c;
+}
+
+inline float4 fma(half4 a, half4 b, float4 c) {
+  return (float4)a * (float4)b + c;
+}
+
+inline Float8_ fma(Half8_ a, Half8_ b, Float8_ c) {
+  float4 x = fma(a.x, b.x, c.x);
+  float4 y = fma(a.y, b.y, c.y);
+  Float8_ res;
+  res.x = x;
+  res.y = y;
+  return res;
+}
+inline Half8_ fma(Half8_ a, Half8_ b, Half8_ c) {
+  Half8_ res;
+  res.x = fma(a.x, b.x, c.x);
+  res.y = fma(a.y, b.x, c.y);
+  return c;
+}
+
+inline void from_float(thread half& dst, float src) {
+  dst = static_cast<half>(src);
+}
+inline void from_float(thread half2& dst, float2 src) {
+  dst.x = static_cast<half>(src.x);
+  dst.y = static_cast<half>(src.y);
+}
+inline void from_float(thread half4& dst, float4 src) {
+  dst.x = static_cast<half>(src.x);
+  dst.y = static_cast<half>(src.y);
+  dst.z = static_cast<half>(src.z);
+  dst.w = static_cast<half>(src.w);
+}
+inline void from_float(thread Half8_& dst, Float8_ src) {
+  half4 x;
+  half4 y;
+  from_float(x, src.x);
+  from_float(y, src.y);
+  dst.x = x;
+  dst.y = y;
+}
+
+// ========================================== Dot product utilities
+
+// TODO(EricLBuehler): optimize with vectorization
+template<int THREAD_GROUP_SIZE, typename Vec, int N>
+inline float qk_dot_(const threadgroup Vec (&q)[N], const thread Vec (&k)[N]) {
+  // Compute the parallel products for Q*K^T (treat vector lanes separately).
+  using A_vec = typename FloatVec<Vec>::Type;
+  A_vec qk_vec = mul<A_vec, Vec, Vec>(q[0], k[0]);
+#pragma unroll
+  for (int ii = 1; ii < N; ++ii) {
+    qk_vec = fma(q[ii], k[ii], qk_vec);
+  }
+
+  // Finalize the reduction across lanes.
+  float qk = sum(qk_vec);
+#pragma unroll
+  for (int mask = THREAD_GROUP_SIZE / 2; mask >= 1; mask /= 2) {
+    qk += simd_shuffle_xor(qk, mask);
+  }
+  return qk;
+}
+
+template<typename T, int THREAD_GROUP_SIZE>
+struct Qk_dot {
+  template<typename Vec, int N>
+  static inline float dot(const threadgroup Vec (&q)[N], const thread Vec (&k)[N]) {
+    return qk_dot_<THREAD_GROUP_SIZE>(q, k);
+  }
+};
+
+// ========================================== Block sum utility
+
+// Utility function for attention softmax.
+template<int NUM_WARPS, int NUM_SIMD_LANES>
+inline float block_sum(threadgroup float* red_smem, float sum, uint simd_tid, uint simd_lid) {
+  // Compute the sum per simdgroup.
+#pragma unroll
+  for (int mask = NUM_SIMD_LANES / 2; mask >= 1; mask /= 2) {
+    sum += simd_shuffle_xor(sum, mask);
+  }
+
+  // Simd leaders store the data to shared memory.
+  if (simd_lid == 0) {
+    red_smem[simd_tid] = sum;
+  }
+
+  // Make sure the data is in shared memory.
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // The warps compute the final sums.
+  if (simd_lid < NUM_WARPS) {
+    sum = red_smem[simd_lid];
+  }
+
+  // Parallel reduction inside the simd group.
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    sum += simd_shuffle_xor(sum, mask);
+  }
+
+  // Broadcast to other threads.
+  return simd_shuffle(sum, 0);
+}
+
+// ========================================== Paged Attention kernel
+
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define DIVIDE_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
+
+constant bool use_partitioning [[function_constant(10)]];
+constant bool use_alibi [[function_constant(20)]];
+
+template <typename T, int HEAD_SIZE, int BLOCK_SIZE, int NUM_THREADS, int NUM_SIMD_LANES, int PARTITION_SIZE = 0>
+[[kernel]] void paged_attention(
+    device float* exp_sums [[buffer(0), function_constant(use_partitioning)]],         // [num_seqs, num_heads, max_num_partitions]
+    device float* max_logits [[buffer(1), function_constant(use_partitioning)]],       // [num_seqs, num_heads, max_num_partitions]
+    device T* out [[buffer(2)]],              // [num_seqs, num_heads, max_num_partitions, head_size]
+    device const T* q [[buffer(3)]],          // [num_seqs, num_heads, head_size]
+    device const T* k_cache [[buffer(4)]],    // [num_blocks, num_kv_heads, head_size/x, block_size, x]
+    device const T* v_cache [[buffer(5)]],    // [num_blocks, num_kv_heads, head_size, block_size]
+    const constant int& num_kv_heads [[buffer(6)]],     // [num_heads]
+    const constant float& scale [[buffer(7)]],
+    const constant float& softcapping [[buffer(8)]],
+    device const uint32_t* block_tables [[buffer(9)]],   // [num_seqs, max_num_blocks_per_seq]
+    device const uint32_t* context_lens [[buffer(10)]],  // [num_seqs]
+    const constant int& max_num_blocks_per_seq [[buffer(11)]],
+    device const float* alibi_slopes [[buffer(12), function_constant(use_alibi)]],     // [num_heads]
+    const constant int& q_stride [[buffer(13)]],
+    const constant int& kv_block_stride [[buffer(14)]],
+    const constant int& kv_head_stride [[buffer(15)]],
+    threadgroup char* shared_mem [[threadgroup(0)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],
+    uint simd_tid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]
+) {
+  const int seq_idx = threadgroup_position_in_grid.y;
+  const int partition_idx = threadgroup_position_in_grid.z;
+  const int max_num_partitions = threadgroups_per_grid.z;
+  const int thread_idx = thread_position_in_threadgroup.x;
+  constexpr bool USE_PARTITIONING = PARTITION_SIZE > 0;
+  const uint32_t context_len = context_lens[seq_idx];
+  if (USE_PARTITIONING && partition_idx * PARTITION_SIZE >= context_len) {
+    // No work to do. Terminate the thread block.
+    return;
+  }
+
+  const int num_context_blocks = DIVIDE_ROUND_UP(context_len, BLOCK_SIZE);
+  const int num_blocks_per_partition = USE_PARTITIONING ? PARTITION_SIZE / BLOCK_SIZE : num_context_blocks;
+
+  // [start_block_idx, end_block_idx) is the range of blocks to process.
+  const int start_block_idx = USE_PARTITIONING ? partition_idx * num_blocks_per_partition : 0;
+  const int end_block_idx = MIN(start_block_idx + num_blocks_per_partition, num_context_blocks);
+  const int num_blocks = end_block_idx - start_block_idx;
+
+  // [start_token_idx, end_token_idx) is the range of tokens to process.
+  const int start_token_idx = start_block_idx * BLOCK_SIZE;
+  const int end_token_idx = MIN(start_token_idx + num_blocks * BLOCK_SIZE, context_len);
+  const int num_tokens = end_token_idx - start_token_idx;
+
+  constexpr int THREAD_GROUP_SIZE = MAX(NUM_SIMD_LANES / BLOCK_SIZE, 1);
+  constexpr int NUM_THREAD_GROUPS = NUM_THREADS / THREAD_GROUP_SIZE; // Note: This assumes THREAD_GROUP_SIZE divides NUM_THREADS
+  assert(NUM_THREADS % THREAD_GROUP_SIZE == 0);
+  constexpr int NUM_TOKENS_PER_THREAD_GROUP = DIVIDE_ROUND_UP(BLOCK_SIZE, NUM_SIMD_LANES);
+  constexpr int NUM_WARPS = NUM_THREADS / NUM_SIMD_LANES;
+  const int warp_idx = simd_tid;
+  const int lane = simd_lid;
+
+  const int head_idx = threadgroup_position_in_grid.x;
+  const int num_heads = threadgroups_per_grid.x;
+  const int num_queries_per_kv = num_heads / num_kv_heads;
+  const int kv_head_idx = head_idx / num_queries_per_kv;
+  const float alibi_slope = !use_alibi ? 0.f : alibi_slopes[head_idx];
+
+  // A vector type to store a part of a key or a query.
+  // The vector size is configured in such a way that the threads in a thread group
+  // fetch or compute 16 bytes at a time.
+  // For example, if the size of a thread group is 4 and the data type is half,
+  // then the vector size is 16 / (4 * sizeof(half)) == 2.
+  constexpr int VEC_SIZE = MAX(16 / (THREAD_GROUP_SIZE * sizeof(T)), 1);
+  using K_vec = typename Vec<T, VEC_SIZE>::Type;
+  using Q_vec = typename Vec<T, VEC_SIZE>::Type;
+
+  constexpr int NUM_ELEMS_PER_THREAD = HEAD_SIZE / THREAD_GROUP_SIZE;
+  constexpr int NUM_VECS_PER_THREAD = NUM_ELEMS_PER_THREAD / VEC_SIZE;
+
+  const int thread_group_idx = thread_idx / THREAD_GROUP_SIZE;
+  const int thread_group_offset = thread_idx % THREAD_GROUP_SIZE;
+
+  // Load the query to registers.
+  // Each thread in a thread group has a different part of the query.
+  // For example, if the thread group size is 4, then the first thread in the group
+  // has 0, 4, 8, ... th vectors of the query, and the second thread has 1, 5, 9, ...
+  // th vectors of the query, and so on.
+  const device T* q_ptr = q + seq_idx * q_stride + head_idx * HEAD_SIZE;
+  threadgroup Q_vec q_vecs[THREAD_GROUP_SIZE][NUM_VECS_PER_THREAD];
+#pragma unroll
+  for (int i = thread_group_idx; i < NUM_VECS_PER_THREAD; i += NUM_THREAD_GROUPS) {
+    const int vec_idx = thread_group_offset + i * THREAD_GROUP_SIZE;
+    q_vecs[thread_group_offset][i] = *reinterpret_cast<const device Q_vec*>(q_ptr + vec_idx * VEC_SIZE);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Use fp32 on softmax logits for better accuracy
+  threadgroup float* logits = reinterpret_cast<threadgroup float*>(shared_mem);
+  // Workspace for reduction
+  threadgroup float red_smem[2 * NUM_WARPS];
+
+  // x == THREAD_GROUP_SIZE * VEC_SIZE
+  // Each thread group fetches x elements from the key at a time.
+  constexpr int x = 16 / sizeof(T);
+  float qk_max = -FLT_MAX;
+
+  // Iterate over the key blocks.
+  // Each warp fetches a block of keys for each iteration.
+  // Each thread group in a warp fetches a key from the block, and computes
+  // dot product with the query.
+  const device uint32_t* block_table = block_tables + seq_idx * max_num_blocks_per_seq;
+  for (int block_idx = start_block_idx + warp_idx; block_idx < end_block_idx; block_idx += NUM_WARPS) {
+    // NOTE: The block number is stored in int32. However, we cast it to int64
+    // because int32 can lead to overflow when this variable is multiplied by large numbers
+    // (e.g., kv_block_stride).
+    const int64_t physical_block_number = static_cast<int64_t>(block_table[block_idx]);
+
+    // Load a key to registers.
+    // Each thread in a thread group has a different part of the key.
+    // For example, if the thread group size is 4, then the first thread in the group
+    // has 0, 4, 8, ... th vectors of the key, and the second thread has 1, 5, 9, ... th
+    // vectors of the key, and so on.
+    for (int i = 0; i < NUM_TOKENS_PER_THREAD_GROUP; i++) {
+      const int physical_block_offset = (thread_group_idx + i * NUM_SIMD_LANES) % BLOCK_SIZE;
+      const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
+      K_vec k_vecs[NUM_VECS_PER_THREAD];
+
+#pragma unroll
+      for (int j = 0; j < NUM_VECS_PER_THREAD; j++) {
+        const device T* k_ptr = k_cache + physical_block_number * kv_block_stride
+                                        + kv_head_idx * kv_head_stride
+                                        + physical_block_offset * x;
+        const int vec_idx = thread_group_offset + j * THREAD_GROUP_SIZE;
+        const int offset1 = (vec_idx * VEC_SIZE) / x;
+        const int offset2 = (vec_idx * VEC_SIZE) % x;
+        k_vecs[j] = *reinterpret_cast<const device K_vec*>(k_ptr + offset1 * BLOCK_SIZE * x + offset2);
+      }
+
+      // Compute dot product.
+      // This includes a reduction across the threads in the same thread group.
+      float qk = scale * Qk_dot<T, THREAD_GROUP_SIZE>::dot(q_vecs[thread_group_offset], k_vecs);
+      
+      // Apply softcapping
+      if (softcapping != 1.0) {
+        qk = precise::tanh(qk / softcapping) * softcapping;
+      }
+
+      // Add the ALiBi bias if slopes are given.
+      qk += (alibi_slope != 0) ? alibi_slope * (token_idx - context_len + 1) : 0;
+
+      if (thread_group_offset == 0) {
+        // Store the partial reductions to shared memory.
+        // NOTE: It is required to zero out the masked logits.
+        const bool mask = token_idx >= context_len;
+        logits[token_idx - start_token_idx] = mask ? 0.f : qk;
+        // Update the max value.
+        qk_max = mask ? qk_max : max(qk_max, qk);
+      }
+    }
+  }
+
+  // Perform reduction across the threads in the same warp to get the
+  // max qk value for each "warp" (not across the thread block yet).
+  // The 0-th thread of each thread group already has its max qk value.
+#pragma unroll
+  for (int mask = NUM_SIMD_LANES / 2; mask >= THREAD_GROUP_SIZE; mask /= 2) {
+    qk_max = max(qk_max, simd_shuffle_xor(qk_max, mask));
+  }
+  if (lane == 0) {
+    red_smem[warp_idx] = qk_max;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Get the max qk value for the sequence.
+  qk_max = lane < NUM_WARPS ? red_smem[lane] : -FLT_MAX;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    qk_max = max(qk_max, simd_shuffle_xor(qk_max, mask));
+  }
+  // Broadcast the max qk value to all threads.
+  qk_max = simd_shuffle(qk_max, 0);
+
+  // Get the sum of the exp values.
+  float exp_sum = 0.f;
+  for (int i = thread_idx; i < num_tokens; i += NUM_THREADS) {
+    float val = exp(logits[i] - qk_max);
+    logits[i] = val;
+    exp_sum += val;
+  }
+  exp_sum = block_sum<NUM_WARPS, NUM_SIMD_LANES>(&red_smem[NUM_WARPS], exp_sum, simd_tid, simd_lid);
+
+  // Compute softmax.
+  const float inv_sum = divide(1.f, exp_sum + 1e-6f);
+  for (int i = thread_idx; i < num_tokens; i += NUM_THREADS) {
+    logits[i] *= inv_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // If partitioning is enabled, store the max logit and exp_sum.
+  if (USE_PARTITIONING && thread_idx == 0 && use_partitioning) {
+    device float* max_logits_ptr = max_logits + seq_idx * num_heads * max_num_partitions
+                                       + head_idx * max_num_partitions
+                                       + partition_idx;
+    *max_logits_ptr = qk_max;
+    device float* exp_sums_ptr = exp_sums + seq_idx * num_heads * max_num_partitions
+                                   + head_idx * max_num_partitions
+                                   + partition_idx;
+    *exp_sums_ptr = exp_sum;
+  }
+
+  // Each thread will fetch 16 bytes from the value cache at a time.
+  constexpr int V_VEC_SIZE = MIN(16 / sizeof(T), BLOCK_SIZE);
+  using V_vec = typename Vec<T, V_VEC_SIZE>::Type;
+  using L_vec = typename Vec<T, V_VEC_SIZE>::Type;
+  using Float_L_vec = typename FloatVec<L_vec>::Type;
+
+  constexpr int NUM_V_VECS_PER_ROW = BLOCK_SIZE / V_VEC_SIZE;
+  constexpr int NUM_ROWS_PER_ITER = NUM_SIMD_LANES / NUM_V_VECS_PER_ROW;
+  constexpr int NUM_ROWS_PER_THREAD = DIVIDE_ROUND_UP(HEAD_SIZE, NUM_ROWS_PER_ITER);
+
+  // NOTE: We use FP32 for the accumulator for better accuracy.
+  float accs[NUM_ROWS_PER_THREAD];
+#pragma unroll
+  for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+    accs[i] = 0.f;
+  }
+
+  T zero_value = 0;
+  for (int block_idx = start_block_idx + warp_idx; block_idx < end_block_idx; block_idx += NUM_WARPS) {
+    // NOTE: The block number is stored in int32. However, we cast it to int64
+    // because int32 can lead to overflow when this variable is multiplied by large numbers
+    // (e.g., kv_block_stride).
+    const int64_t physical_block_number = static_cast<int64_t>(block_table[block_idx]);
+    const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
+    const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
+    L_vec logits_vec;
+    Float_L_vec logits_float_vec = *reinterpret_cast<threadgroup Float_L_vec*>(logits + token_idx - start_token_idx);
+    from_float(logits_vec, logits_float_vec);
+
+    const device T* v_ptr = v_cache + physical_block_number * kv_block_stride
+                                    + kv_head_idx * kv_head_stride;
+#pragma unroll
+    for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+      const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+      if (row_idx < HEAD_SIZE) {
+        const int offset = row_idx * BLOCK_SIZE + physical_block_offset;
+        // NOTE: When v_vec contains the tokens that are out of the context,
+        // we should explicitly zero out the values since they may contain NaNs.
+        // See https://github.com/vllm-project/vllm/issues/641#issuecomment-1682544472
+        V_vec v_vec = *reinterpret_cast<const device V_vec*>(v_ptr + offset);
+        if (block_idx == num_context_blocks - 1) {
+          thread T* v_vec_ptr = reinterpret_cast<thread T*>(&v_vec);
+#pragma unroll
+          for (int j = 0; j < V_VEC_SIZE; j++) {
+            v_vec_ptr[j] = token_idx + j < context_len ? v_vec_ptr[j] : zero_value;
+          }
+        }
+        accs[i] += dot(logits_vec, v_vec);
+      }
+    }
+  }
+
+  // Perform reduction within each warp.
+#pragma unroll
+  for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+    float acc = accs[i];
+#pragma unroll
+    for (int mask = NUM_V_VECS_PER_ROW / 2; mask >= 1; mask /= 2) {
+      acc += simd_shuffle_xor(acc, mask);
+    }
+    accs[i] = acc;
+  }
+
+  // NOTE: A barrier is required because the shared memory space for logits
+  // is reused for the output.
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Perform reduction across warps.
+  threadgroup float* out_smem = reinterpret_cast<threadgroup float*>(shared_mem);
+#pragma unroll
+  for (int i = NUM_WARPS; i > 1; i /= 2) {
+    int mid = i / 2;
+    // Upper warps write to shared memory.
+    if (warp_idx >= mid && warp_idx < i) {
+      threadgroup float* dst = &out_smem[(warp_idx - mid) * HEAD_SIZE];
+#pragma unroll
+      for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+        const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+        if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+          dst[row_idx] = accs[i];
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Lower warps update the output.
+    if (warp_idx < mid) {
+      const threadgroup float* src = &out_smem[warp_idx * HEAD_SIZE];
+#pragma unroll
+      for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+        const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+        if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+          accs[i] += src[row_idx];
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // Write the final output.
+  if (warp_idx == 0) {
+    device T* out_ptr = out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE
+                            + head_idx * max_num_partitions * HEAD_SIZE
+                            + partition_idx * HEAD_SIZE;
+#pragma unroll
+    for (int i = 0; i < NUM_ROWS_PER_THREAD; i++) {
+      const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
+      if (row_idx < HEAD_SIZE && lane % NUM_V_VECS_PER_ROW == 0) {
+        *(out_ptr + row_idx) = T(accs[i]);
+      }
+    }
+  }
+}
+
+template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES, int PARTITION_SIZE = 0>
+[[kernel]] void paged_attention_v2_reduce(
+    device T* out [[buffer(0)]],
+    const device float* exp_sums [[buffer(1)]],
+    const device float* max_logits [[buffer(2)]],
+    const device T* tmp_out [[buffer(3)]],
+    device uint32_t* context_lens [[buffer(4)]],
+    const constant int& max_num_partitions [[buffer(5)]],
+    threadgroup char* shared_mem [[threadgroup(0)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],
+    uint3 threads_per_threadgroup [[threads_per_threadgroup]],
+    uint simd_tid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]
+) {
+  const int num_heads = threadgroups_per_grid.x;
+  const int head_idx = threadgroup_position_in_grid.x;
+  const int seq_idx = threadgroup_position_in_grid.y;
+  const uint32_t context_len = context_lens[seq_idx];
+  const int num_partitions = DIVIDE_ROUND_UP(context_len, PARTITION_SIZE);
+  if (num_partitions == 1) {
+    // No need to reduce. Only copy tmp_out to out.
+    device T* out_ptr = out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
+    const device T* tmp_out_ptr = tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE
+                                          + head_idx * max_num_partitions * HEAD_SIZE;
+    for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE; i += threads_per_threadgroup.x) {
+      out_ptr[i] = tmp_out_ptr[i];
+    }
+    // Terminate the thread block.
+    return;
+  }
+
+  constexpr int NUM_WARPS = NUM_THREADS / NUM_SIMD_LANES;
+  const int warp_idx = simd_tid;
+  const int lane = simd_lid;
+
+  // Workspace for reduction.
+  threadgroup float red_smem[2 * NUM_WARPS];
+
+  // Load max logits to shared memory.
+  threadgroup float* shared_max_logits = reinterpret_cast<threadgroup float*>(shared_mem);
+  const device float* max_logits_ptr = max_logits + seq_idx * num_heads * max_num_partitions
+                                           + head_idx * max_num_partitions;
+  float max_logit = -FLT_MAX;
+  for (int i = thread_position_in_threadgroup.x; i < num_partitions; i += threads_per_threadgroup.x) {
+    const float l = max_logits_ptr[i];
+    shared_max_logits[i] = l;
+    max_logit = max(max_logit, l);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Get the global max logit.
+  // Reduce within the warp.
+#pragma unroll
+  for (int mask = NUM_SIMD_LANES / 2; mask >= 1; mask /= 2) {
+    max_logit = max(max_logit, simd_shuffle_xor(max_logit, mask));
+  }
+  if (lane == 0) {
+    red_smem[warp_idx] = max_logit;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  // Reduce across warps.
+  max_logit = lane < NUM_WARPS ? red_smem[lane] : -FLT_MAX;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    max_logit = max(max_logit, simd_shuffle_xor(max_logit, mask));
+  }
+  // Broadcast the max value to all threads.
+  max_logit = simd_shuffle(max_logit, 0);
+
+  // Load rescaled exp sums to shared memory.
+  threadgroup float* shared_exp_sums = reinterpret_cast<threadgroup float*>(shared_mem + sizeof(float) * num_partitions);
+  const device float* exp_sums_ptr = exp_sums + seq_idx * num_heads * max_num_partitions
+                                       + head_idx * max_num_partitions;
+  float global_exp_sum = 0.0f;
+  for (int i = thread_position_in_threadgroup.x; i < num_partitions; i += threads_per_threadgroup.x) {
+    float l = shared_max_logits[i];
+    float rescaled_exp_sum = exp_sums_ptr[i] * exp(l - max_logit);
+    global_exp_sum += rescaled_exp_sum;
+    shared_exp_sums[i] = rescaled_exp_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  global_exp_sum = block_sum<NUM_WARPS, NUM_SIMD_LANES>(&red_smem[NUM_WARPS], global_exp_sum, simd_tid, simd_lid);
+  const float inv_global_exp_sum = divide(1.0f, global_exp_sum + 1e-6f);
+
+  // Aggregate tmp_out to out.
+  const device T* tmp_out_ptr = tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE
+                                        + head_idx * max_num_partitions * HEAD_SIZE;
+  device T* out_ptr = out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
+#pragma unroll
+  for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE; i += NUM_THREADS) {
+    float acc = 0.0f;
+    for (int j = 0; j < num_partitions; ++j) {
+      acc += float(tmp_out_ptr[j * HEAD_SIZE + i]) * shared_exp_sums[j] * inv_global_exp_sum;
+    }
+    out_ptr[i] = T(acc);
+  }
+}
+
+#define instantiate_paged_attention_inner(type, head_size, block_size, num_threads, num_simd_lanes, partition_size)                                               \
+  template [[host_name("paged_attention_" #type "_hs" #head_size "_bs" #block_size "_nt" #num_threads "_nsl" #num_simd_lanes "_ps" #partition_size)]]  \
+  [[kernel]] void paged_attention<type, head_size, block_size, num_threads, num_simd_lanes, partition_size>(                                            \
+      device float* exp_sums [[buffer(0), function_constant(use_partitioning)]],                                             \
+      device float* max_logits [[buffer(1), function_constant(use_partitioning)]],                                            \
+      device type* out [[buffer(2)]],                                            \
+      device const type* q [[buffer(3)]],                                            \
+      device const type* k_cache [[buffer(4)]],                                            \
+      device const type* v_cache [[buffer(5)]],                                            \
+      const constant int& num_kv_heads [[buffer(6)]],                                          \
+      const constant float& scale [[buffer(7)]],                                            \
+      const constant float& softcapping [[buffer(8)]],                                            \
+      device const uint32_t* block_tables [[buffer(9)]],                                            \
+      device const uint32_t* context_lens [[buffer(10)]],                                            \
+      const constant int& max_num_blocks_per_seq [[buffer(11)]],                                            \
+      device const float* alibi_slopes [[buffer(12), function_constant(use_alibi)]],                                            \
+      const constant int& q_stride [[buffer(13)]],                                            \
+      const constant int& kv_block_stride [[buffer(14)]],                                            \
+      const constant int& kv_head_stride [[buffer(15)]],                                            \
+      threadgroup char* shared_mem [[threadgroup(0)]],                                            \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],                                            \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],                                            \
+      uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],                                            \
+      uint simd_tid [[simdgroup_index_in_threadgroup]],                                            \
+      uint simd_lid [[thread_index_in_simdgroup]]);                                            \
+
+#define instantiate_paged_attention_v2_reduce_inner(type, head_size, num_threads, num_simd_lanes, partition_size)                                               \
+  template [[host_name("paged_attention_v2_reduce_" #type "_hs" #head_size "_nt" #num_threads "_nsl" #num_simd_lanes "_ps" #partition_size)]]  \
+  [[kernel]] void paged_attention_v2_reduce<type, head_size, num_threads, num_simd_lanes, partition_size>(             \
+      device type* out [[buffer(0)]],             \
+      const device float* exp_sums [[buffer(1)]],             \
+      const device float* max_logits [[buffer(2)]],             \
+      const device type* tmp_out [[buffer(3)]],             \
+      device uint32_t* context_lens [[buffer(4)]],             \
+      const constant int& max_num_partitions [[buffer(5)]],             \
+      threadgroup char* shared_mem [[threadgroup(0)]],             \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],             \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],             \
+      uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],             \
+      uint3 threads_per_threadgroup [[threads_per_threadgroup]],             \
+      uint simd_tid [[simdgroup_index_in_threadgroup]],             \
+      uint simd_lid [[thread_index_in_simdgroup]]);             \
+
+
+#define instantiate_paged_attention_heads(type, block_size, num_threads, num_simd_lanes, partition_size) \
+  instantiate_paged_attention_inner(type, 64, block_size, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_inner(type, 80, block_size, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_inner(type, 96, block_size, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_inner(type, 112, block_size, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_inner(type, 128, block_size, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_inner(type, 256, block_size, num_threads, num_simd_lanes, partition_size)
+
+#define instantiate_paged_attention_v2_reduce_heads(type, num_threads, num_simd_lanes, partition_size) \
+  instantiate_paged_attention_v2_reduce_inner(type, 64, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_v2_reduce_inner(type, 80, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_v2_reduce_inner(type, 96, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_v2_reduce_inner(type, 112, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_v2_reduce_inner(type, 128, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_v2_reduce_inner(type, 256, num_threads, num_simd_lanes, partition_size)
+
+#define instantiate_paged_attention_block_size(type, num_threads, num_simd_lanes, partition_size) \
+  instantiate_paged_attention_heads(type, 8, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_heads(type, 16, num_threads, num_simd_lanes, partition_size)         \
+  instantiate_paged_attention_heads(type, 32, num_threads, num_simd_lanes, partition_size)
+
+// TODO: tune num_threads = 256
+// NOTE: partition_size = 0
+#define instantiate_paged_attention_v1(type, num_simd_lanes) \
+  instantiate_paged_attention_block_size(type, 256, num_simd_lanes, 0)
+
+// TODO: tune num_threads = 256
+// NOTE: partition_size = 512
+#define instantiate_paged_attention_v2(type, num_simd_lanes) \
+  instantiate_paged_attention_block_size(type, 256, num_simd_lanes, 512) \
+  instantiate_paged_attention_v2_reduce_heads(type, 256, num_simd_lanes, 512)
+
+instantiate_paged_attention_v1(float, 32)
+instantiate_paged_attention_v1(bfloat16_t, 32)
+instantiate_paged_attention_v1(half, 32)
+
+instantiate_paged_attention_v2(float, 32)
+instantiate_paged_attention_v2(bfloat16_t, 32)
+instantiate_paged_attention_v2(half, 32)

--- a/metal-kernels/src/reshape_and_cache.metal
+++ b/metal-kernels/src/reshape_and_cache.metal
@@ -1,0 +1,333 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#if defined(__HAVE_BFLOAT__)
+
+typedef bfloat bfloat16_t;
+
+#else
+
+/////////////////////////////////////////////////////////////////////////////
+// Helpers
+/////////////////////////////////////////////////////////////////////////////
+
+constexpr METAL_FUNC uint16_t float_to_bfloat_bits(float x) {
+  // Check for nan
+  if ((as_type<uint32_t>(x) & ~_fp_encoding_traits<float>::sign_mask) >
+      _fp_encoding_traits<float>::inf_mask) {
+    return uint16_t(as_type<uint32_t>(0x7FC0));
+  }
+  // Take bits
+  uint32_t float_bits = as_type<uint32_t>(x);
+
+  // Round to nearest even
+  float_bits += ((float_bits >> 16) & 1) + as_type<uint32_t>(0x7FFF);
+
+  // Take upper 16 bits
+  return float_bits >> 16;
+}
+
+constexpr METAL_FUNC float bfloat_bits_to_float(uint16_t x) {
+  // Upper 16 bits are the data and lower 16 bits are 0s
+  return as_type<float>((uint32_t)x << 16);
+}
+
+struct _MLX_BFloat16;
+
+template <typename T>
+static constexpr constant bool can_convert_to_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<T, float>;
+
+template <typename T>
+static constexpr constant bool can_convert_from_bfloat =
+    !is_same_v<T, _MLX_BFloat16> && is_convertible_v<float, T>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat struct
+/////////////////////////////////////////////////////////////////////////////
+
+struct _MLX_BFloat16 {
+  /////////////////////////////////////////////////////////////////////////////
+  // Constructors
+  uint16_t bits_;
+  _MLX_BFloat16() thread = default;
+  _MLX_BFloat16() threadgroup = default;
+  _MLX_BFloat16() device = default;
+  _MLX_BFloat16() constant = default;
+
+  struct bits_to_bfloat_struct {};
+  static constexpr METAL_FUNC bits_to_bfloat_struct bits_to_bfloat() {
+    return bits_to_bfloat_struct();
+  }
+  constexpr METAL_FUNC _MLX_BFloat16(uint16_t bits, bits_to_bfloat_struct)
+      : bits_(bits) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions to bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) thread
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) threadgroup
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) device
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_to_bfloat<T>>::type>
+  constexpr METAL_FUNC _MLX_BFloat16(T x) constant
+      : bits_(float_to_bfloat_bits(static_cast<float>(x))) {}
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Conversions from bfloat
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const thread {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const threadgroup {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() const device {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+
+  template <
+      typename T,
+      typename = typename enable_if<can_convert_from_bfloat<T>>::type>
+  constexpr METAL_FUNC operator T() constant {
+    return static_cast<T>(bfloat_bits_to_float(bits_));
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat operators
+/////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////
+// Unary ops
+constexpr METAL_FUNC _MLX_BFloat16 operator-(_MLX_BFloat16 x) {
+  return -static_cast<float>(x);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Binary operators
+#define bfloat_binop_base(__op__, __operator__, otype, atype, btype, ctype) \
+  constexpr METAL_FUNC otype __operator__(atype lhs, btype rhs) {           \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);          \
+  }
+
+#define bfloat_binop_helper(__op__, __operator__, otype, itype, ctype)    \
+  constexpr METAL_FUNC otype __operator__(_MLX_BFloat16 lhs, itype rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }                                                                       \
+  constexpr METAL_FUNC otype __operator__(itype lhs, _MLX_BFloat16 rhs) { \
+    return static_cast<ctype>(lhs) __op__ static_cast<ctype>(rhs);        \
+  }
+
+/////////////////////////////////////////////////////////////////////////////
+// Arithmetic Operators
+#define bfloat_binop(_op_, _operator_)                                       \
+  bfloat_binop_base(                                                         \
+      _op_, _operator_, _MLX_BFloat16, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(_op_, _operator_, float, float, float);                \
+  bfloat_binop_helper(_op_, _operator_, float, half, float);                 \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int32_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint32_t, float);     \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, int64_t, float);      \
+  bfloat_binop_helper(_op_, _operator_, _MLX_BFloat16, uint64_t, float);
+
+bfloat_binop(+, operator+);
+bfloat_binop(-, operator-);
+bfloat_binop(*, operator*);
+bfloat_binop(/, operator/);
+
+/////////////////////////////////////////////////////////////////////////////
+// Comparison ops
+#define bfloat_compop(__op__, __operator__)                             \
+  bfloat_binop_base(                                                    \
+      __op__, __operator__, bool, _MLX_BFloat16, _MLX_BFloat16, float); \
+  bfloat_binop_helper(__op__, __operator__, bool, float, float);        \
+  bfloat_binop_helper(__op__, __operator__, bool, half, float);         \
+  bfloat_binop_helper(__op__, __operator__, bool, int32_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint32_t, float);     \
+  bfloat_binop_helper(__op__, __operator__, bool, int64_t, float);      \
+  bfloat_binop_helper(__op__, __operator__, bool, uint64_t, float);
+
+bfloat_compop(>, operator>);
+bfloat_compop(<, operator<);
+bfloat_compop(>=, operator>=);
+bfloat_compop(<=, operator<=);
+bfloat_compop(==, operator==);
+bfloat_compop(!=, operator!=);
+
+#undef bfloat_compop
+#undef bfloat_binop_base
+#undef bfloat_binop_helper
+#undef bfloat_binop
+
+/////////////////////////////////////////////////////////////////////////////
+// Inplace Operators
+#define bfloat_inplace_op_helper(__op__, __operator__, itype, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(            \
+      addr_space _MLX_BFloat16& lhs, itype rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }                                                                       \
+  constexpr METAL_FUNC addr_space itype& __operator__(                    \
+      addr_space itype& lhs, _MLX_BFloat16 rhs) {                         \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);         \
+    return lhs;                                                           \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__, itype) \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, itype, threadgroup);
+
+#define bfloat_inplace_op(itype)                             \
+  bfloat_inplace_op_addr_space_helper(+, operator+=, itype); \
+  bfloat_inplace_op_addr_space_helper(-, operator-=, itype); \
+  bfloat_inplace_op_addr_space_helper(*, operator*=, itype); \
+  bfloat_inplace_op_addr_space_helper(/, operator/=, itype);
+
+bfloat_inplace_op(float);
+bfloat_inplace_op(half);
+bfloat_inplace_op(int16_t);
+bfloat_inplace_op(int32_t);
+bfloat_inplace_op(int64_t);
+bfloat_inplace_op(uint16_t);
+bfloat_inplace_op(uint32_t);
+bfloat_inplace_op(uint64_t);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+#undef bfloat_inplace_op
+
+#define bfloat_inplace_op_helper(__op__, __operator__, addr_space) \
+  constexpr METAL_FUNC addr_space _MLX_BFloat16& __operator__(     \
+      addr_space _MLX_BFloat16& lhs, _MLX_BFloat16 rhs) {          \
+    lhs = static_cast<float>(lhs) __op__ static_cast<float>(rhs);  \
+    return lhs;                                                    \
+  }
+
+#define bfloat_inplace_op_addr_space_helper(__op__, __operator__) \
+  bfloat_inplace_op_helper(__op__, __operator__, device);         \
+  bfloat_inplace_op_helper(__op__, __operator__, thread);         \
+  bfloat_inplace_op_helper(__op__, __operator__, threadgroup);
+
+bfloat_inplace_op_addr_space_helper(+, operator+=);
+bfloat_inplace_op_addr_space_helper(-, operator-=);
+bfloat_inplace_op_addr_space_helper(*, operator*=);
+bfloat_inplace_op_addr_space_helper(/, operator/=);
+
+#undef bfloat_inplace_op_helper
+#undef bfloat_inplace_op_addr_space_helper
+
+/////////////////////////////////////////////////////////////////////////////
+// Bfloat typedef
+/////////////////////////////////////////////////////////////////////////////
+
+typedef struct _MLX_BFloat16 bfloat16_t;
+
+#endif
+
+
+
+
+
+
+
+template<typename T>
+[[kernel]] void reshape_and_cache(
+    const device T* __restrict__ key [[buffer(0)]],           // [num_tokens, num_heads, head_size]
+    const device T* __restrict__ value [[buffer(1)]],         // [num_tokens, num_heads, head_size]
+    device T* __restrict__ key_cache [[buffer(2)]],           // [num_blocks, num_heads, head_size/x, block_size, x]
+    device T* __restrict__ value_cache [[buffer(3)]],         // [num_blocks, num_heads, head_size, block_size]
+    const device int64_t* __restrict__ slot_mapping [[buffer(4)]],   // [num_tokens]
+    device const int& key_stride,
+    device const int& value_stride,
+    device const int& num_heads,
+    device const int& head_size,
+    device const int& block_size,
+    device const int& x,
+    uint gid [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]]
+) {
+  const int64_t token_idx = gid;
+  const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    // Padding token that should be ignored.
+    return;
+  }
+
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+
+  const int n = num_heads * head_size;
+  for (int i = tid; i < n; i += threads_per_threadgroup) {
+    const int64_t src_key_idx = token_idx * key_stride + i;
+    const int64_t src_value_idx = token_idx * value_stride + i;
+
+    const int head_idx = i / head_size;
+    const int head_offset = i % head_size;
+    const int x_idx = head_offset / x;
+    const int x_offset = head_offset % x;
+
+    const int64_t tgt_key_idx = block_idx * num_heads * (head_size / x) * block_size * x
+                                + head_idx * (head_size / x) * block_size * x
+                                + x_idx * block_size * x
+                                + block_offset * x
+                                + x_offset;
+    const int64_t tgt_value_idx = block_idx * num_heads * head_size * block_size
+                                  + head_idx * head_size * block_size
+                                  + head_offset * block_size
+                                  + block_offset;
+    key_cache[tgt_key_idx] = key[src_key_idx];
+    value_cache[tgt_value_idx] = value[src_value_idx];
+  }
+}
+
+#define instantiate_reshape_and_cache(type)                           \
+  template [[host_name("reshape_and_cache_" #type)]]                  \
+  [[kernel]] void reshape_and_cache<type>(                  \
+    const device type* __restrict__ key [[buffer(0)]],                  \
+    const device type* __restrict__ value [[buffer(1)]],                  \
+    device type* __restrict__ key_cache [[buffer(2)]],                  \
+    device type* __restrict__ value_cache [[buffer(3)]],                  \
+    const device int64_t* __restrict__ slot_mapping [[buffer(4)]],                  \
+    device const int& key_stride,                  \
+    device const int& value_stride,                  \
+    device const int& num_heads,                  \
+    device const int& head_size,                  \
+    device const int& block_size,                  \
+    device const int& x,                  \
+    uint gid [[threadgroup_position_in_grid]],                  \
+    uint tid [[thread_position_in_threadgroup]],                  \
+    uint threads_per_threadgroup [[threads_per_threadgroup]]);
+
+instantiate_reshape_and_cache(float)
+instantiate_reshape_and_cache(bfloat16_t)
+instantiate_reshape_and_cache(half)

--- a/metal-kernels/src/utils.rs
+++ b/metal-kernels/src/utils.rs
@@ -1,0 +1,154 @@
+use metal::{Buffer, ComputeCommandEncoderRef};
+use std::ffi::c_void;
+
+pub fn set_param<P: EncoderParam>(encoder: &ComputeCommandEncoderRef, position: u64, data: P) {
+    <P as EncoderParam>::set_param(encoder, position, data)
+}
+
+/// Helper functions to create the various objects on the compute command encoder
+/// on a single line.
+/// Prevents getting wrong some arguments number and mixing length and size in bytes.
+pub trait EncoderParam {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self);
+}
+macro_rules! primitive {
+    ($type:ty) => {
+        impl EncoderParam for $type {
+            fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+                encoder.set_bytes(
+                    position,
+                    core::mem::size_of::<$type>() as u64,
+                    &data as *const $type as *const c_void,
+                );
+            }
+        }
+    };
+}
+primitive!(bool);
+primitive!(usize);
+primitive!(i32);
+primitive!(i64);
+primitive!(u32);
+primitive!(u64);
+primitive!(f32);
+
+pub struct BufferOffset<'a> {
+    pub buffer: &'a Buffer,
+    pub offset_in_bytes: usize,
+}
+
+impl<T> EncoderParam for &[T] {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_bytes(
+            position,
+            core::mem::size_of_val(data) as u64,
+            data.as_ptr() as *const c_void,
+        );
+    }
+}
+
+impl EncoderParam for &Buffer {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_buffer(position, Some(data), 0);
+    }
+}
+
+impl EncoderParam for (&Buffer, usize) {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_buffer(position, Some(data.0), data.1 as u64);
+    }
+}
+
+impl EncoderParam for &BufferOffset<'_> {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_buffer(position, Some(data.buffer), data.offset_in_bytes as u64);
+    }
+}
+
+impl EncoderParam for &mut Buffer {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_buffer(position, Some(data), 0);
+    }
+}
+
+impl EncoderParam for (&mut Buffer, usize) {
+    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+        encoder.set_buffer(position, Some(data.0), data.1 as u64);
+    }
+}
+
+#[macro_export]
+macro_rules! set_params {
+    ($encoder:ident, ($($param:expr),+)) => (
+        let mut _index = 0;
+        $(
+            $crate::utils::set_param($encoder, _index, $param);
+            _index += 1;
+        )*
+    );
+}
+
+pub trait EncoderProvider {
+    type Encoder<'a>: AsRef<metal::ComputeCommandEncoderRef>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_>;
+}
+
+pub struct WrappedEncoder<'a> {
+    inner: &'a ComputeCommandEncoderRef,
+    end_encoding_on_drop: bool,
+}
+
+impl Drop for WrappedEncoder<'_> {
+    fn drop(&mut self) {
+        if self.end_encoding_on_drop {
+            self.inner.end_encoding()
+        }
+    }
+}
+
+impl AsRef<metal::ComputeCommandEncoderRef> for WrappedEncoder<'_> {
+    fn as_ref(&self) -> &metal::ComputeCommandEncoderRef {
+        self.inner
+    }
+}
+
+impl EncoderProvider for &metal::CommandBuffer {
+    type Encoder<'a>
+        = WrappedEncoder<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        WrappedEncoder {
+            inner: self.new_compute_command_encoder(),
+            end_encoding_on_drop: true,
+        }
+    }
+}
+
+impl EncoderProvider for &metal::CommandBufferRef {
+    type Encoder<'a>
+        = WrappedEncoder<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        WrappedEncoder {
+            inner: self.new_compute_command_encoder(),
+            end_encoding_on_drop: true,
+        }
+    }
+}
+
+impl EncoderProvider for &ComputeCommandEncoderRef {
+    type Encoder<'a>
+        = WrappedEncoder<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        WrappedEncoder {
+            inner: self,
+            end_encoding_on_drop: false,
+        }
+    }
+}

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -1,21 +1,27 @@
-use std::{collections::HashMap, iter::zip, ptr::NonNull};
-
+#[cfg(feature = "cuda")]
 use crate::{
     backend::{get_or_load_func, Conjoined},
     openai::responses::APIError,
     try_api,
 };
-use candle_core::cuda_backend::CudaStorageSlice;
+#[cfg(feature = "metal")]
+use candle_core::{
+    backend::BackendStorage, CpuStorage, Device, IndexOp, Layout, MetalDevice, MetalStorage,
+    Result, Storage, Tensor, WithDType,
+};
+#[cfg(feature = "cuda")]
 use candle_core::{
     cuda_backend::cudarc::driver::{CudaSlice, DevicePtr, LaunchAsync, LaunchConfig},
+    cuda_backend::CudaStorageSlice,
     Device, IndexOp, Storage, Tensor,
 };
-
-use super::COPY_BLOCKS_KERNEL_NAME;
-use kernels::COPY_BLOCKS_KERNEL;
+#[cfg(feature = "cuda")]
+const COPY_BLOCKS_KERNEL_NAME: &str = "copy_blocks_kernel";
+use std::{collections::HashMap, iter::zip, ptr::NonNull};
 
 /// # Safety
 /// Unsafe due to passing pointers
+#[cfg(feature = "cuda")]
 pub unsafe fn copy_blocks(
     key_caches: Vec<&mut Tensor>,
     value_caches: Vec<&mut Tensor>,
@@ -138,7 +144,7 @@ pub unsafe fn copy_blocks(
     let stream = try_api!(dev.fork_default_stream());
 
     let kernel = try_api!(get_or_load_func(
-        COPY_BLOCKS_KERNEL,
+        kernels::COPY_BLOCKS_KERNEL,
         COPY_BLOCKS_KERNEL_NAME,
         key_caches.first().unwrap().dtype(),
         None,
@@ -161,6 +167,7 @@ pub unsafe fn copy_blocks(
     Ok(())
 }
 
+#[cfg(feature = "cuda")]
 pub fn swap_blocks(
     src: Tensor,
     dst: &mut Tensor,
@@ -232,6 +239,227 @@ pub fn swap_blocks(
         }
         (src, dst) => {
             return Err(APIError::new(format!("Tensors must be on either the GPU or CPU to swap,, got {src:?} (src) and {dst:?} (dst).")))
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "metal")]
+pub fn copy_blocks(
+    key_caches: Vec<&mut Tensor>,
+    value_caches: Vec<&mut Tensor>,
+    block_mapping: HashMap<usize, Vec<usize>>,
+) -> Result<()> {
+    let cache_dev = key_caches.first().unwrap().device();
+    let Device::Metal(dev) = cache_dev else {
+        panic!("Expected the key caches to be on a Metal device.")
+    };
+    if !cache_dev.same_device(value_caches.first().unwrap().device()) {
+        candle_core::bail!(
+            "`key` and `value` caches have different devices, got {:?} and {:?} respectively.",
+            cache_dev,
+            value_caches.first().unwrap().device()
+        );
+    }
+    if key_caches.first().unwrap().dtype() != value_caches.first().unwrap().dtype() {
+        candle_core::bail!(
+            "Key and value caches have different types, got {:?} and {:?}.",
+            key_caches.first().unwrap().dtype(),
+            value_caches.first().unwrap().dtype()
+        );
+    }
+
+    let mut block_mapping_vec: Vec<i64> = Vec::new();
+    for (src_block_number, dst_blocks) in block_mapping {
+        for dst_block_number in dst_blocks {
+            block_mapping_vec.push(src_block_number.try_into().unwrap());
+            block_mapping_vec.push(dst_block_number.try_into().unwrap());
+        }
+    }
+    let block_mapping = dev.new_buffer_with_data(&block_mapping_vec)?;
+
+    let num_pairs: u64 = (block_mapping_vec.len() / 2).try_into().unwrap();
+
+    let numel_per_block: u64 = key_caches
+        .first()
+        .unwrap()
+        .i(0)?
+        .shape()
+        .dims()
+        .iter()
+        .product::<usize>()
+        .try_into()
+        .unwrap();
+
+    for (key_cache, value_cache) in zip(&key_caches, &value_caches) {
+        key_cache.to_device(cache_dev)?;
+        value_cache.to_device(cache_dev)?;
+
+        let key_offset = key_cache.storage_and_layout().1.start_offset();
+        let Storage::Metal(key_storage) = &*key_cache.storage_and_layout().0 else {
+            unreachable!()
+        };
+
+        let value_offset = value_cache.storage_and_layout().1.start_offset();
+        let Storage::Metal(value_storage) = &*value_cache.storage_and_layout().0 else {
+            unreachable!()
+        };
+
+        let command_buffer = dev.command_buffer()?;
+        command_buffer.set_label("copy-blocks");
+
+        metal_kernels::call_copy_blocks(
+            dev.device(),
+            &command_buffer,
+            metal_kernels::Kernels::default(),
+            key_cache.dtype(),
+            key_storage.buffer(),
+            key_offset * key_storage.dtype().size_in_bytes(),
+            value_storage.buffer(),
+            value_offset * value_storage.dtype().size_in_bytes(),
+            &block_mapping,
+            0,
+            num_pairs,
+            numel_per_block,
+        )
+        .map_err(candle_core::Error::wrap)?;
+    }
+
+    Ok(())
+}
+
+// `dst` REALLY should be &mut. That's the only reason this is unsafe.
+/// # Safety
+/// `dst` is the only shared reference and upholds the `&mut` aliasing guarantee.
+#[cfg(feature = "metal")]
+pub fn swap_blocks(src: Tensor, dst: &Tensor, block_mapping: HashMap<usize, usize>) -> Result<()> {
+    let block_size_in_bytes = src.dtype().size_in_bytes() * src.dims()[0];
+    if src.device().location() != dst.device().location() {
+        candle_core::bail!(
+            "Tensors must be on the same device to copy, got locations {:?} (src) and {:?} (dst).",
+            src.device().location(),
+            dst.device().location()
+        );
+    }
+    match (src.device(), dst.device()) {
+        (Device::Metal(src_dev), Device::Metal(_)) => {
+            let (src_storage, src_layout) = src.storage_and_layout();
+            let (dst_storage, dst_layout) = dst.storage_and_layout();
+            assert!(matches!(&*src_storage, Storage::Metal(_)));
+            assert!(matches!(&*dst_storage, Storage::Metal(_)));
+            let Storage::Metal(src_storage) = &*src_storage else {
+                unreachable!()
+            };
+            let Storage::Metal(dst_storage) = &*dst_storage else {
+                unreachable!()
+            };
+
+            for (src_block_number, dst_block_number) in block_mapping {
+                // We copy by bytes
+                let src_offset = src_block_number * block_size_in_bytes
+                    + src_layout.start_offset() * src_storage.dtype().size_in_bytes();
+                let dst_offset = dst_block_number * block_size_in_bytes
+                    + dst_layout.start_offset() * dst_storage.dtype().size_in_bytes();
+
+                let command_buffer = src_dev.command_buffer()?;
+                command_buffer.set_label("swap-blocks-gpu-gpu");
+                let blit = command_buffer.new_blit_command_encoder();
+                blit.set_label("swap-blocks-gpu-gpu");
+                let length = (src_layout.shape().elem_count() * src_storage.dtype().size_in_bytes())
+                    as metal::NSUInteger;
+                blit.copy_from_buffer(
+                    src_storage.buffer(),
+                    src_offset as u64,
+                    dst_storage.buffer(),
+                    dst_offset as u64,
+                    length,
+                );
+                blit.end_encoding();
+            }
+        }
+        (Device::Cpu, Device::Metal(dev)) => {
+            let (src_storage, src_layout) = src.storage_and_layout();
+            let (dst_storage, dst_layout) = dst.storage_and_layout();
+            assert!(matches!(&*src_storage, Storage::Cpu(_)));
+            assert!(matches!(&*dst_storage, Storage::Metal(_)));
+            let Storage::Cpu(src_storage) = &*src_storage else {
+                unreachable!()
+            };
+            let Storage::Metal(dst_storage) = &*dst_storage else {
+                unreachable!()
+            };
+
+            fn swap_thunk<SRCT: WithDType>(
+                src_slice: &[SRCT],
+                src_layout: &Layout,
+                dst_storage: &MetalStorage,
+                dst_layout: &Layout,
+                dev: &MetalDevice,
+                block_size_in_bytes: usize,
+                block_mapping: HashMap<usize, usize>,
+            ) -> Result<()> {
+                for (src_block_number, dst_block_number) in block_mapping {
+                    let src_offset = src_block_number * block_size_in_bytes
+                        + src_layout.start_offset() * SRCT::DTYPE.size_in_bytes();
+                    let dst_offset = dst_block_number * block_size_in_bytes
+                        + dst_layout.start_offset() * dst_storage.dtype().size_in_bytes();
+                    // We copy by bytes
+                    let src_buffer = dev.new_buffer_with_data(
+                        &src_slice[src_offset..src_offset + block_size_in_bytes],
+                    )?;
+
+                    let command_buffer = dev.command_buffer()?;
+                    command_buffer.set_label("swap-blocks-cpu-gpu");
+                    let blit = command_buffer.new_blit_command_encoder();
+                    blit.set_label("swap-blocks-cpu-gpu");
+                    let length = (src_layout.shape().elem_count() * SRCT::DTYPE.size_in_bytes())
+                        as metal::NSUInteger;
+                    blit.copy_from_buffer(
+                        &src_buffer,
+                        src_offset as u64,
+                        dst_storage.buffer(),
+                        dst_offset as u64,
+                        length,
+                    );
+                    blit.end_encoding();
+                }
+                Ok(())
+            }
+
+            match src_storage {
+                CpuStorage::BF16(s) => swap_thunk(
+                    s,
+                    src_layout,
+                    dst_storage,
+                    dst_layout,
+                    dev,
+                    block_size_in_bytes,
+                    block_mapping,
+                )?,
+                CpuStorage::F16(s) => swap_thunk(
+                    s,
+                    src_layout,
+                    dst_storage,
+                    dst_layout,
+                    dev,
+                    block_size_in_bytes,
+                    block_mapping,
+                )?,
+                CpuStorage::F32(s) => swap_thunk(
+                    s,
+                    src_layout,
+                    dst_storage,
+                    dst_layout,
+                    dev,
+                    block_size_in_bytes,
+                    block_mapping,
+                )?,
+                _ => candle_core::bail!("expected bf16, f16, or f32 for cpu<>gpu swap-blocks"),
+            }
+        }
+        (src, dst) => {
+            candle_core::bail!("Tensors must be on either the GPU or CPU to swap, got {src:?} (src) and {dst:?} (dst).");
         }
     }
 

--- a/src/backend/gptq.rs
+++ b/src/backend/gptq.rs
@@ -1,5 +1,7 @@
 use candle::backend::BackendStorage;
-use candle::{CpuStorage, CudaStorage, DType, Layout, Result, Shape, Storage, Tensor};
+#[cfg(feature = "cuda")]
+use candle::CudaStorage;
+use candle::{CpuStorage, DType, Layout, Result, Shape, Storage, Tensor};
 use candle_core as candle;
 use half::{bf16, f16};
 #[cfg(feature = "cuda")]

--- a/src/backend/paged_attention.rs
+++ b/src/backend/paged_attention.rs
@@ -1,11 +1,11 @@
-// use candle_core::{cuda_backend::cudarc::driver::CudaFunction, DType, Tensor};
 use candle::backend::BackendStorage;
-use candle::{CpuStorage, CudaStorage, DType, Layout, Result, Shape, Storage, Tensor};
+#[cfg(feature = "cuda")]
+use candle::CudaStorage;
+#[cfg(feature = "metal")]
+use candle::MetalStorage;
+use candle::{CpuStorage, DType, Layout, Result, Shape, Storage, Tensor};
 use candle_core as candle;
 use half::{bf16, f16};
-use kernels::ffi;
-#[cfg(feature = "cuda")]
-use kernels::ffi::{paged_attention_v1, paged_attention_v2};
 use std::ffi::c_int;
 
 struct PagedAttention {
@@ -15,6 +15,7 @@ struct PagedAttention {
     value_cache: Tensor,
     block_tables: Tensor,
     context_lens: Tensor,
+    alibi_slopes: Option<Tensor>,
     max_context_len: usize,
 }
 
@@ -170,7 +171,7 @@ impl PagedAttention {
 
         if use_v1 {
             unsafe {
-                paged_attention_v1(
+                kernels::ffi::paged_attention_v1(
                     out_ptr,
                     q_ptr,
                     kc_ptr,
@@ -204,7 +205,7 @@ impl PagedAttention {
             let max_logits_ptr = *max_logits.device_ptr() as *const f32;
 
             unsafe {
-                paged_attention_v2(
+                kernels::ffi::paged_attention_v2(
                     out_ptr,
                     exp_sums_ptr,
                     max_logits_ptr,
@@ -234,6 +235,233 @@ impl PagedAttention {
         let out = CudaStorage::wrap_cuda_slice(out, dev.clone());
         Ok((out, out_shape))
     }
+
+    #[cfg(feature = "metal")]
+    fn metal_fwd_t(&self, q: &MetalStorage, q_l: &Layout) -> Result<(MetalStorage, Shape)> {
+        let dtype = q.dtype();
+        let internal_type = match dtype {
+            DType::F16 => metal_kernels::PagedAttentionDType::F16,
+            DType::BF16 => metal_kernels::PagedAttentionDType::BF16,
+            DType::F32 => metal_kernels::PagedAttentionDType::F32,
+            dtype => candle_core::bail!("dtype {dtype:?} is not supported"),
+        };
+
+        let dev = q.device();
+        let out_shape = q_l.shape().clone();
+
+        let (kc, kc_l) = self.key_cache.storage_and_layout();
+        let kc = match &*kc {
+            Storage::Metal(kc) => kc,
+            _ => candle_core::bail!("key_cache must be a metal tensor"),
+        };
+
+        let (vc, vc_l) = self.value_cache.storage_and_layout();
+        let vc = match &*vc {
+            Storage::Metal(vc) => vc,
+            _ => candle_core::bail!("value_cache must be a metal tensor"),
+        };
+
+        let (bt, bt_l) = self.block_tables.storage_and_layout();
+        let bt = match &*bt {
+            Storage::Metal(bt) => bt,
+            _ => candle_core::bail!("block_tables must be a metal tensor"),
+        };
+
+        let (cl, cl_l) = self.context_lens.storage_and_layout();
+        let cl = match &*cl {
+            Storage::Metal(cl) => cl,
+            _ => candle_core::bail!("context_lens must be a metal tensor"),
+        };
+
+        let q_rank = q_l.stride().len();
+        let kc_rank = kc_l.stride().len();
+        let vc_rank = vc_l.stride().len();
+
+        if q_rank != 3 {
+            candle_core::bail!(
+                "paged-attention expects `q` tensor to be of rank 3 \
+                (q: {q_l:?})"
+            )
+        }
+
+        if kc_rank != 5 {
+            candle_core::bail!(
+                "paged-attention expects `key_cache` tensor to be of rank 5 \
+                (key_cache: {kc_l:?})"
+            )
+        }
+
+        if vc_rank != 4 {
+            candle_core::bail!(
+                "paged-attention expects `value_cache` tensor to be of rank 4 \
+                (value_cache: {vc_l:?})"
+            )
+        }
+
+        let alibi_storage_and_offset = if let Some(alibi_slopes) = self.alibi_slopes.as_ref() {
+            let (alibi_s, alibi_s_l) = alibi_slopes.storage_and_layout();
+            let alibi_s = match &*alibi_s {
+                Storage::Metal(alibi_s) => alibi_s,
+                _ => candle_core::bail!("context_lens must be a metal tensor"),
+            };
+            Some((
+                alibi_s.clone(),
+                alibi_s_l.start_offset() * alibi_s.dtype().size_in_bytes(),
+            ))
+        } else {
+            None
+        };
+
+        let (num_seqs, num_heads, head_size) = q_l.shape().dims3()?;
+        if !(head_size == 64
+            || head_size == 80
+            || head_size == 96
+            || head_size == 112
+            || head_size == 128
+            || head_size == 256)
+        {
+            candle_core::bail!("`head_size` must be one of 64, 80, 96, 112, 128 or 256");
+        }
+
+        let (num_seqs_bt, max_num_blocks_per_seq) = bt_l.shape().dims2()?;
+
+        if num_seqs_bt != num_seqs {
+            candle_core::bail!(
+                "shape mismatch block_tables {:?}, expected {:?}",
+                bt_l.shape(),
+                (num_seqs, max_num_blocks_per_seq)
+            )
+        }
+
+        let (num_blocks, num_kv_heads, head_size_kc, block_size, x) = kc_l.shape().dims5()?;
+        if head_size_kc != head_size / x {
+            candle_core::bail!(
+                "shape mismatch value_cache {:?}, expected {:?}",
+                vc_l.shape(),
+                (num_blocks, num_heads, head_size / x, block_size, x)
+            )
+        }
+
+        if (num_blocks, num_kv_heads, head_size, block_size) != vc_l.shape().dims4()? {
+            candle_core::bail!(
+                "shape mismatch key_cache {:?} and value_cache {:?}",
+                kc_l.shape(),
+                vc_l.shape()
+            )
+        }
+
+        if (num_seqs) != cl_l.shape().dims1()? {
+            candle_core::bail!(
+                "shape mismatch context_lens {:?}, expected {:?}",
+                cl_l.shape(),
+                (num_seqs)
+            )
+        }
+
+        let q_stride = q_l.stride()[0];
+        let kv_block_stride = kc_l.stride()[0];
+        let kv_head_stride = kc_l.stride()[1];
+
+        let partition_size = 512;
+        let max_num_partitions = self.max_context_len.div_ceil(partition_size);
+        let use_v1 = (max_num_partitions == 1 || num_seqs * num_heads > 512)
+            && partition_size % block_size == 0;
+
+        let elem_count = out_shape.elem_count();
+
+        let command_buffer = dev.command_buffer()?;
+        command_buffer.set_label("paged-attention");
+
+        let out = dev.new_buffer(elem_count, dtype, "paged-attention-out")?;
+
+        if use_v1 {
+            metal_kernels::paged_attention_v1(
+                dev.device(),
+                &command_buffer,
+                metal_kernels::Kernels::default(),
+                internal_type,
+                q.buffer(),
+                q_l.start_offset() * q.dtype().size_in_bytes(),
+                kc.buffer(),
+                kc_l.start_offset() * kc.dtype().size_in_bytes(),
+                vc.buffer(),
+                vc_l.start_offset() * vc.dtype().size_in_bytes(),
+                bt.buffer(),
+                bt_l.start_offset() * bt.dtype().size_in_bytes(),
+                cl.buffer(),
+                cl_l.start_offset() * cl.dtype().size_in_bytes(),
+                alibi_storage_and_offset,
+                &out,
+                num_kv_heads as i32,
+                self.softmax_scale,
+                self.softcapping,
+                block_size as i32,
+                self.max_context_len as i32,
+                num_seqs as i32,
+                num_heads as i32,
+                head_size as i32,
+                max_num_blocks_per_seq as i32,
+                q_stride as i32,
+                kv_block_stride as i32,
+                kv_head_stride as i32,
+            )
+            .map_err(candle_core::Error::wrap)?;
+        } else {
+            let tmp_out_shape = Shape::from((num_seqs, num_heads, max_num_partitions, head_size));
+            let exp_sums_shape = Shape::from((num_seqs, num_heads, max_num_partitions));
+            let tmp_out =
+                dev.new_buffer(tmp_out_shape.elem_count(), dtype, "paged-attention-tmpout")?;
+            let exp_sums = dev.new_buffer(
+                exp_sums_shape.elem_count(),
+                DType::F32,
+                "paged-attention-expsums",
+            )?;
+            let max_logits = dev.new_buffer(
+                exp_sums_shape.elem_count(),
+                DType::F32,
+                "paged-attention-maxlogits",
+            )?;
+
+            metal_kernels::paged_attention_v2(
+                dev.device(),
+                &command_buffer,
+                metal_kernels::Kernels::default(),
+                internal_type,
+                &exp_sums,
+                &max_logits,
+                q.buffer(),
+                q_l.start_offset() * q.dtype().size_in_bytes(),
+                kc.buffer(),
+                kc_l.start_offset() * kc.dtype().size_in_bytes(),
+                vc.buffer(),
+                vc_l.start_offset() * vc.dtype().size_in_bytes(),
+                bt.buffer(),
+                bt_l.start_offset() * bt.dtype().size_in_bytes(),
+                cl.buffer(),
+                cl_l.start_offset() * cl.dtype().size_in_bytes(),
+                alibi_storage_and_offset,
+                &tmp_out,
+                &out,
+                num_kv_heads as i32,
+                self.softmax_scale,
+                self.softcapping,
+                block_size as i32,
+                self.max_context_len as i32,
+                num_seqs as i32,
+                num_heads as i32,
+                head_size as i32,
+                max_num_blocks_per_seq as i32,
+                q_stride as i32,
+                kv_block_stride as i32,
+                kv_head_stride as i32,
+            )
+            .map_err(candle_core::Error::wrap)?;
+        }
+
+        let newstorage =
+            candle_core::MetalStorage::new(out, q.device().clone(), elem_count, q.dtype());
+        Ok((newstorage, out_shape))
+    }
 }
 
 impl candle::CustomOp1 for PagedAttention {
@@ -251,6 +479,13 @@ impl candle::CustomOp1 for PagedAttention {
             DType::F32 => self.cuda_fwd_t::<f32>(q, q_l),
             DType::F16 => self.cuda_fwd_t::<f16>(q, q_l),
             DType::BF16 => self.cuda_fwd_t::<bf16>(q, q_l),
+            dt => candle::bail!("paged-attention is only supported for f32/f16/bf16 ({dt:?})"),
+        }
+    }
+    #[cfg(feature = "metal")]
+    fn metal_fwd(&self, q: &MetalStorage, q_l: &Layout) -> Result<(MetalStorage, Shape)> {
+        match q.dtype() {
+            DType::F32 | DType::F16 | DType::BF16 => self.metal_fwd_t(q, q_l),
             dt => candle::bail!("paged-attention is only supported for f32/f16/bf16 ({dt:?})"),
         }
     }
@@ -280,6 +515,7 @@ pub fn paged_attention(
     value_cache: &Tensor,
     block_tables: &Tensor,
     context_lens: &Tensor,
+    alibi_slopes: Option<&Tensor>,
     max_context_len: usize,
     softmax_scale: f32,
     softcapping: f32,
@@ -290,6 +526,7 @@ pub fn paged_attention(
         value_cache: value_cache.clone(),
         block_tables: block_tables.clone(),
         context_lens: context_lens.clone(),
+        alibi_slopes: alibi_slopes.to_owned().cloned(),
         max_context_len,
         softcapping,
     };
@@ -428,7 +665,7 @@ impl ReshapeCache {
         let s_ptr = *s.device_ptr() as *const core::ffi::c_long;
 
         unsafe {
-            ffi::reshape_and_cache(
+            kernels::ffi::call_reshape_and_cache(
                 k_ptr,
                 v_ptr,
                 kc_ptr,
@@ -444,6 +681,139 @@ impl ReshapeCache {
                 internal_type,
             )
         }
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    pub fn metal_fwd_t(
+        &self,
+        k: &MetalStorage,
+        k_l: &Layout,
+        value: &Tensor,
+        key_cache: &Tensor,
+        value_cache: &Tensor,
+        slot_mapping: &Tensor,
+    ) -> Result<()> {
+        let dtype = k.dtype();
+        let internal_type = match dtype {
+            DType::F16 => metal_kernels::PagedAttentionDType::F16,
+            DType::BF16 => metal_kernels::PagedAttentionDType::BF16,
+            DType::F32 => metal_kernels::PagedAttentionDType::F32,
+            dtype => candle_core::bail!("dtype {dtype:?} is not supported"),
+        };
+
+        let (v, v_l) = value.storage_and_layout();
+        let v = match &*v {
+            Storage::Metal(v) => v,
+            _ => candle_core::bail!("value must be a metal tensor"),
+        };
+
+        let (kc, kc_l) = key_cache.storage_and_layout();
+        let kc = match &*kc {
+            Storage::Metal(kc) => kc,
+            _ => candle_core::bail!("key_cache must be a metal tensor"),
+        };
+
+        let (vc, vc_l) = value_cache.storage_and_layout();
+        let vc = match &*vc {
+            Storage::Metal(vc) => vc,
+            _ => candle_core::bail!("value_cache must be a metal tensor"),
+        };
+
+        let (s, s_l) = slot_mapping.storage_and_layout();
+        let s = match &*s {
+            Storage::Metal(s) => s,
+            _ => candle_core::bail!("slot_mapping must be a metal tensor"),
+        };
+
+        let k_rank = k_l.stride().len();
+        let v_rank = v_l.stride().len();
+        let kc_rank = kc_l.stride().len();
+        let vc_rank = vc_l.stride().len();
+
+        if k_rank != 3 || v_rank != 3 {
+            candle_core::bail!(
+                "paged-attention expects input tensors of rank 3 (k: {k_l:?}, v: {v_l:?})"
+            )
+        }
+
+        if kc_rank != 5 {
+            candle_core::bail!(
+                "paged-attention expects `key_cache` tensor to be of rank 5 \
+                    (key_cache: {kc_l:?})"
+            )
+        }
+
+        if vc_rank != 4 {
+            candle_core::bail!(
+                "paged-attention expects `value_cache` tensor to be of rank 4 \
+                    (value_cache: {vc_l:?})"
+            )
+        }
+
+        let (num_tokens, num_heads, head_size) = k_l.shape().dims3()?;
+        if (num_tokens, num_heads, head_size) != v_l.shape().dims3()? {
+            candle_core::bail!("shape mismatch k {:?} and v {:?}", k_l.shape(), v_l.shape())
+        }
+
+        let (num_blocks, num_heads_kc, head_size_kc, block_size, x) = kc_l.shape().dims5()?;
+        if num_heads_kc != num_heads || head_size_kc != head_size / x {
+            candle_core::bail!(
+                "shape mismatch value_cache {:?}, expected {:?}",
+                vc_l.shape(),
+                (num_blocks, num_heads, head_size / x, block_size, x)
+            )
+        }
+
+        if (num_blocks, num_heads, head_size, block_size) != vc_l.shape().dims4()? {
+            candle_core::bail!(
+                "shape mismatch key_cache {:?} and value_cache {:?}",
+                kc_l.shape(),
+                vc_l.shape()
+            )
+        }
+
+        if (num_tokens) != s_l.shape().dims1()? {
+            candle_core::bail!(
+                "shape mismatch slot_mapping {:?}, expected {:?}",
+                s_l.shape(),
+                (num_tokens)
+            )
+        }
+
+        let key_stride = k_l.stride()[0] as i32;
+        let value_stride = v_l.stride()[0] as i32;
+
+        let dev = k.device();
+
+        let command_buffer = dev.command_buffer()?;
+        command_buffer.set_label("reshape-and-cache");
+
+        metal_kernels::call_reshape_and_cache(
+            dev.device(),
+            &command_buffer,
+            metal_kernels::Kernels::default(),
+            internal_type,
+            k.buffer(),
+            k_l.start_offset() * k.dtype().size_in_bytes(),
+            v.buffer(),
+            v_l.start_offset() * value.dtype().size_in_bytes(),
+            kc.buffer(),
+            kc_l.start_offset() * key_cache.dtype().size_in_bytes(),
+            vc.buffer(),
+            vc_l.start_offset() * value_cache.dtype().size_in_bytes(),
+            s.buffer(),
+            s_l.start_offset() * slot_mapping.dtype().size_in_bytes(),
+            num_tokens as i32,
+            num_heads as i32,
+            head_size as i32,
+            block_size as i32,
+            x as i32,
+            key_stride,
+            value_stride,
+        )
+        .map_err(candle_core::Error::wrap)?;
+
         Ok(())
     }
 }
@@ -477,6 +847,21 @@ impl candle::InplaceOp1 for ReshapeCache {
                 &self.slot_mapping,
             ),
             DType::BF16 => self.cuda_fwd_t::<bf16>(
+                k,
+                k_l,
+                &self.value,
+                &self.key_cache,
+                &self.value_cache,
+                &self.slot_mapping,
+            ),
+            dt => candle::bail!("reshape-cache is only supported for f32/f16/bf16 ({dt:?})"),
+        }
+    }
+
+    #[cfg(feature = "metal")]
+    fn metal_fwd(&self, k: &mut MetalStorage, k_l: &Layout) -> Result<()> {
+        match k.dtype() {
+            DType::F32 | DType::F16 | DType::BF16 => self.metal_fwd_t(
                 k,
                 k_l,
                 &self.value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ impl SpecificConfig {
 pub fn get_model_loader(
     selected_model: ModelSelected,
     model_id: Option<String>,
-) -> (Box<dyn ModelLoader>, String) {
+) -> (Box<dyn ModelLoader>, String, Option<String>) {
     match selected_model {
         ModelSelected::Llama {
             repeat_last_n,
@@ -278,7 +278,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "llama".to_string(),
             )),
@@ -287,6 +287,7 @@ pub fn get_model_loader(
             } else {
                 "meta-llama/Llama-2-7b-chat-hf".to_string()
             },
+            quant,
         ),
         ModelSelected::Llama3 {
             repeat_last_n,
@@ -303,7 +304,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "llama3".to_string(),
             )),
@@ -312,6 +313,7 @@ pub fn get_model_loader(
             } else {
                 "meta-llama/Meta-Llama-3.1-8B-Instruct".to_string()
             },
+            quant,
         ),
         ModelSelected::Phi2 {
             repeat_last_n,
@@ -328,7 +330,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "phi2".to_string(),
             )),
@@ -337,6 +339,7 @@ pub fn get_model_loader(
             } else {
                 "microsoft/microsoft/phi-2".to_string()
             },
+            quant,
         ),
         ModelSelected::Phi3 {
             repeat_last_n,
@@ -355,7 +358,7 @@ pub fn get_model_loader(
                     top_p,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "phi3".to_string(),
             )),
@@ -364,6 +367,7 @@ pub fn get_model_loader(
             } else {
                 "microsoft/Phi-3-mini-4k-instruct".to_string()
             },
+            quant,
         ),
         ModelSelected::Qwen2 {
             repeat_last_n,
@@ -382,7 +386,7 @@ pub fn get_model_loader(
                     top_p,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "qwen2".to_string(),
             )),
@@ -391,6 +395,7 @@ pub fn get_model_loader(
             } else {
                 "Qwen/Qwen1.5-1.8B-Chat".to_string()
             },
+            quant,
         ),
         ModelSelected::Gemma {
             repeat_last_n,
@@ -407,7 +412,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "gemma".to_string(),
             )),
@@ -416,6 +421,7 @@ pub fn get_model_loader(
             } else {
                 "google/gemma-2b-it".to_string()
             },
+            quant,
         ),
         ModelSelected::Mistral {
             repeat_last_n,
@@ -432,7 +438,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "mistral".to_string(),
             )),
@@ -441,6 +447,7 @@ pub fn get_model_loader(
             } else {
                 "mistralai/Mistral-7B-Instruct-v0.3".to_string()
             },
+            quant,
         ),
 
         ModelSelected::Yi {
@@ -458,7 +465,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "yi".to_string(),
             )),
@@ -467,6 +474,7 @@ pub fn get_model_loader(
             } else {
                 "01-ai/Yi-6B-Chat".to_string()
             },
+            quant,
         ),
 
         ModelSelected::StableLM {
@@ -484,7 +492,7 @@ pub fn get_model_loader(
                     None,
                     penalty,
                     max_gen_tokens,
-                    quant,
+                    quant.clone(),
                 ),
                 "stablelm".to_string(),
             )),
@@ -493,6 +501,7 @@ pub fn get_model_loader(
             } else {
                 "stabilityai/stablelm-zephyr-3b".to_string()
             },
+            quant,
         ),
     }
 }

--- a/src/openai/logits_processor.rs
+++ b/src/openai/logits_processor.rs
@@ -115,7 +115,7 @@ impl LogitsProcessor {
         self.sample_f(logits, |_| {})
     }
 
-    pub fn sample_f_batch(&self, logits: &Tensor, f: impl FnOnce(&mut [f32])) -> Result<Vec<u32>> {
+    pub fn sample_f_batch(&self, logits: &Tensor) -> Result<Vec<u32>> {
         let logits = logits.to_dtype(DType::F32)?;
         let tokens = match &self.sampling {
             Sampling::ArgMax => self.sample_argmax_batch(&logits),
@@ -168,7 +168,7 @@ impl LogitsProcessor {
     pub fn sample_batch(&self, logits: &Tensor) -> Result<Vec<u32>> {
         let next_tokens = match &self.sampling {
             Sampling::ArgMax => self.sample_argmax_batch(logits)?,
-            _ => self.sample_f_batch(logits, |_| {})?,
+            _ => self.sample_f_batch(logits)?,
         };
         Ok(next_tokens)
     }

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -4,6 +4,8 @@ pub mod llama;
 pub mod mistral;
 pub mod phi2;
 pub mod phi3;
+pub mod quantized_llama;
+pub mod quantized_phi3;
 pub mod qwen2;
 pub mod stable_lm;
 pub mod yi;

--- a/src/openai/models/quantized_llama.rs
+++ b/src/openai/models/quantized_llama.rs
@@ -1,0 +1,583 @@
+use super::Config;
+use crate::paged_attention::input_metadata::InputMetadata;
+use crate::paged_attention::PagedAttention;
+use crate::SpecificConfig;
+use candle_core::quantized::QTensor;
+use candle_core::quantized::{ggml_file, gguf_file};
+use candle_core::{DType, Device, IndexOp, Result, Tensor};
+use candle_nn::{Embedding, Module};
+use candle_transformers::quantized_nn::RmsNorm;
+use either::Either;
+use std::iter::zip;
+pub const MAX_SEQ_LEN: usize = 4096;
+
+// QMatMul wrapper adding some tracing.
+#[derive(Debug, Clone)]
+struct QMatMul {
+    inner: candle_core::quantized::QMatMul,
+}
+
+impl QMatMul {
+    fn from_qtensor(qtensor: QTensor) -> Result<Self> {
+        let inner = candle_core::quantized::QMatMul::from_qtensor(qtensor)?;
+        Ok(Self { inner })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        self.inner.forward(xs)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    feed_forward_w1: QMatMul,
+    feed_forward_w2: QMatMul,
+    feed_forward_w3: QMatMul,
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let w1 = self.feed_forward_w1.forward(xs)?;
+        let w3 = self.feed_forward_w3.forward(xs)?;
+        self.feed_forward_w2
+            .forward(&(candle_nn::ops::silu(&w1)? * w3)?)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MlpOrMoe {
+    Mlp(Mlp),
+    MoE {
+        n_expert_used: usize,
+        feed_forward_gate_inp: QMatMul,
+        experts: Vec<Mlp>,
+    },
+}
+
+impl Module for MlpOrMoe {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::MoE {
+                feed_forward_gate_inp,
+                experts,
+                n_expert_used,
+            } => {
+                let (b_size, seq_len, hidden_dim) = xs.dims3()?;
+                let xs = xs.reshape(((), hidden_dim))?;
+                let router_logits = feed_forward_gate_inp.forward(&xs)?;
+                let routing_weights = candle_nn::ops::softmax_last_dim(&router_logits)?;
+
+                // In order to extract topk, we extract the data from the tensor and manipulate it
+                // directly. Maybe we will want to use some custom ops instead at some point.
+                let routing_weights = routing_weights.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+
+                // routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+                // top_x contains the row indexes to evaluate for each expert.
+                let mut top_x = vec![vec![]; experts.len()];
+                let mut selected_rws = vec![vec![]; experts.len()];
+                for (row_idx, rw) in routing_weights.iter().enumerate() {
+                    let mut dst = (0..rw.len() as u32).collect::<Vec<u32>>();
+                    dst.sort_by(|&i, &j| rw[j as usize].total_cmp(&rw[i as usize]));
+                    let mut sum_routing_weights = 0f32;
+                    for &expert_idx in dst.iter().take(*n_expert_used) {
+                        let expert_idx = expert_idx as usize;
+                        let routing_weight = rw[expert_idx];
+                        sum_routing_weights += routing_weight;
+                        top_x[expert_idx].push(row_idx as u32);
+                    }
+                    for &expert_idx in dst.iter().take(*n_expert_used) {
+                        let expert_idx = expert_idx as usize;
+                        let routing_weight = rw[expert_idx];
+                        selected_rws[expert_idx].push(routing_weight / sum_routing_weights)
+                    }
+                }
+
+                // routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+                // expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+                let mut ys = xs.zeros_like()?;
+                for (expert_idx, expert_layer) in experts.iter().enumerate() {
+                    let top_x = &top_x[expert_idx];
+                    if top_x.is_empty() {
+                        continue;
+                    }
+                    let top_x = Tensor::new(top_x.as_slice(), xs.device())?;
+                    let selected_rws =
+                        Tensor::new(selected_rws[expert_idx].as_slice(), xs.device())?
+                            .reshape(((), 1))?;
+                    // Index the correct hidden states and compute the expert hidden state for
+                    // the current expert. We need to make sure to multiply the output hidden
+                    // states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+                    let current_state = xs.index_select(&top_x, 0)?.reshape(((), hidden_dim))?;
+                    // current_hidden_states = expert_layer(current_state, routing_weights[top_x_list, idx_list, None])
+                    let current_hidden_states = expert_layer.forward(&current_state)?;
+                    let current_hidden_states =
+                        current_hidden_states.broadcast_mul(&selected_rws)?;
+                    ys = ys.index_add(&top_x, &current_hidden_states, 0)?;
+                }
+
+                let ys = ys.reshape((b_size, seq_len, hidden_dim))?;
+                Ok(ys)
+            }
+            Self::Mlp(mlp) => mlp.forward(xs),
+        }
+    }
+}
+
+struct LayerWeights {
+    attention_wq: QMatMul,
+    attention_wk: QMatMul,
+    attention_wv: QMatMul,
+    attention_wo: QMatMul,
+    attention_norm: RmsNorm,
+    mlp_or_moe: MlpOrMoe,
+    ffn_norm: RmsNorm,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    cos: Tensor,
+    sin: Tensor,
+    attn: PagedAttention,
+    dtype: DType,
+}
+
+impl LayerWeights {
+    fn apply_rotary_emb(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        input_positions: &[Vec<usize>],
+    ) -> Result<(Tensor, Tensor)> {
+        let (b_size, _h, seq_len, _n_embd) = q.dims4()?;
+        let mut q_embeds = Vec::new();
+        let mut k_embeds = Vec::new();
+        for (b, seqlen_offset) in zip(0..b_size, input_positions) {
+            let cos = self.cos.narrow(0, seqlen_offset[0], seq_len)?;
+            let sin = self.sin.narrow(0, seqlen_offset[0], seq_len)?;
+            let x_q = q.narrow(0, b, 1)?;
+            let x_k = k.narrow(0, b, 1)?;
+            let q_embed = candle_nn::rotary_emb::rope(&x_q, &cos, &sin)?;
+            let k_embed = candle_nn::rotary_emb::rope(&x_k, &cos, &sin)?;
+            q_embeds.push(q_embed);
+            k_embeds.push(k_embed);
+        }
+        Ok((
+            Tensor::cat(&q_embeds, 0).unwrap(),
+            Tensor::cat(&k_embeds, 0).unwrap(),
+        ))
+    }
+
+    fn forward_attn(
+        &mut self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        input_positions: &[Vec<usize>],
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, n_embd) = x.dims3()?;
+        let q = self.attention_wq.forward(x)?.to_dtype(self.dtype)?;
+        let k = self.attention_wk.forward(x)?.to_dtype(self.dtype)?;
+        let v = self.attention_wv.forward(x)?.to_dtype(self.dtype)?;
+
+        let (q, k, v) = if seq_len == 1 {
+            //no need transpose for seq_len == 1, change reshape dim
+            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            (q, k, v)
+        } else {
+            let q = q
+                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = k
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            (q.contiguous()?, k.contiguous()?, v.contiguous()?)
+        };
+
+        let (q, k) = self.apply_rotary_emb(&q, &k, input_positions)?;
+
+        let y = self.attn.forward(
+            &q,
+            &k,
+            &v,
+            mask,
+            cache.map(|(k_, _)| k_.clone()),
+            cache.map(|(_, v_)| v_.clone()),
+            input_metadata,
+            None,
+        )?;
+
+        let y = if mask.is_some() {
+            y.transpose(1, 2)?.reshape(&[b_sz, seq_len, n_embd])?
+        } else {
+            y.reshape(&[b_sz, seq_len, n_embd])?
+        };
+
+        let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
+        Ok(y)
+    }
+}
+
+pub struct GGUFLLaMa {
+    tok_embeddings: Embedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    output: QMatMul,
+    cfg: Config,
+    dtype: DType,
+}
+
+fn precomput_freqs_cis(
+    head_dim: usize,
+    freq_base: f32,
+    device: &Device,
+    dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    let theta: Vec<_> = (0..head_dim)
+        .step_by(2)
+        .map(|i| 1f32 / freq_base.powf(i as f32 / head_dim as f32))
+        .collect();
+    let theta = Tensor::new(theta.as_slice(), device)?;
+    let idx_theta = Tensor::arange(0, MAX_SEQ_LEN as u32, device)?
+        .to_dtype(DType::F32)?
+        .reshape((MAX_SEQ_LEN, 1))?
+        .matmul(&theta.reshape((1, theta.elem_count()))?)?;
+    let cos = idx_theta.cos()?.to_dtype(dtype)?;
+    let sin = idx_theta.sin()?.to_dtype(dtype)?;
+    Ok((cos, sin))
+}
+
+impl GGUFLLaMa {
+    pub fn into_config(
+        embedding_length: usize,
+        i_size: usize,
+        block_count: usize,
+        head_count: usize,
+        head_count_kv: usize,
+        rms_eps: f64,
+        max_seq_len: usize,
+        kv_cache_dtype: DType,
+        s_cfg: SpecificConfig,
+    ) -> Config {
+        Config {
+            hidden_size: embedding_length,
+            head_dim: Some(embedding_length / head_count),
+            intermediate_size: i_size,
+            vocab_size: 0,
+            num_hidden_layers: block_count,
+            num_attention_heads: head_count,
+            num_key_value_heads: head_count_kv,
+            rms_norm_eps: rms_eps,
+            rope_theta: 0.,
+            use_flash_attn: false,
+            bos_token_id: super::TokenID(Either::Left(None)),
+            eos_token_id: super::TokenID(Either::Left(None)),
+            max_seq_len: max_seq_len,
+            sliding_window: None,
+            hidden_act: None,
+            tie_word_embeddings: false,
+            rope_scaling: None,
+            original_max_position_embeddings: Some(max_seq_len),
+            attention_bias: false,
+            partial_rotary_factor: None,
+            qk_layer_rms_norm: None,
+            kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
+            specific_config: s_cfg,
+            attn_logit_softcapping: None,
+            final_logit_softcapping: None,
+            quantization_config: None,
+        }
+    }
+
+    pub fn from_ggml(
+        mut ct: ggml_file::Content,
+        gqa: usize,
+        dtype: DType,
+        s_cfg: SpecificConfig,
+    ) -> Result<Self> {
+        let head_dim = (ct.hparams.n_embd / ct.hparams.n_head) as usize;
+        let (cos, sin) = precomput_freqs_cis(head_dim, 10000., &ct.device, dtype)?;
+        let tok_embeddings = ct.remove("tok_embeddings.weight")?;
+        let tok_embeddings = tok_embeddings.dequantize(&ct.device)?;
+        let norm = RmsNorm::from_qtensor(ct.remove("norm.weight")?, 1e-5)?;
+        let output = ct.remove("output.weight")?;
+        let mut layers = Vec::with_capacity(ct.hparams.n_layer as usize);
+        for layer_idx in 0..ct.hparams.n_layer {
+            let prefix = format!("layers.{layer_idx}");
+            let attention_wq = ct.remove(&format!("{prefix}.attention.wq.weight"))?;
+            let attention_wk = ct.remove(&format!("{prefix}.attention.wk.weight"))?;
+            let attention_wv = ct.remove(&format!("{prefix}.attention.wv.weight"))?;
+            let attention_wo = ct.remove(&format!("{prefix}.attention.wo.weight"))?;
+            let mlp_or_moe = {
+                let feed_forward_w1 = ct.remove(&format!("{prefix}.feed_forward.w1.weight"))?;
+                let feed_forward_w2 = ct.remove(&format!("{prefix}.feed_forward.w2.weight"))?;
+                let feed_forward_w3 = ct.remove(&format!("{prefix}.feed_forward.w3.weight"))?;
+                MlpOrMoe::Mlp(Mlp {
+                    feed_forward_w1: QMatMul::from_qtensor(feed_forward_w1)?,
+                    feed_forward_w2: QMatMul::from_qtensor(feed_forward_w2)?,
+                    feed_forward_w3: QMatMul::from_qtensor(feed_forward_w3)?,
+                })
+            };
+            let attention_norm = ct.remove(&format!("{prefix}.attention_norm.weight"))?;
+            let ffn_norm = ct.remove(&format!("{prefix}.ffn_norm.weight"))?;
+            layers.push(LayerWeights {
+                attention_wq: QMatMul::from_qtensor(attention_wq)?,
+                attention_wk: QMatMul::from_qtensor(attention_wk)?,
+                attention_wv: QMatMul::from_qtensor(attention_wv)?,
+                attention_wo: QMatMul::from_qtensor(attention_wo)?,
+                attention_norm: RmsNorm::from_qtensor(attention_norm, 1e-5)?,
+                mlp_or_moe,
+                ffn_norm: RmsNorm::from_qtensor(ffn_norm, 1e-5)?,
+                n_head: ct.hparams.n_head as usize,
+                n_kv_head: ct.hparams.n_head as usize / gqa,
+                head_dim: (ct.hparams.n_embd / ct.hparams.n_head) as usize,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                attn: PagedAttention::new(
+                    ct.hparams.n_head as usize,
+                    (ct.hparams.n_embd / ct.hparams.n_head) as usize,
+                    1. / ((head_dim as f32).sqrt()),
+                    Some(ct.hparams.n_head as usize / gqa),
+                    None,
+                    ct.device.clone(),
+                    None,
+                )?,
+                dtype,
+            })
+        }
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, ct.hparams.n_embd as usize),
+            layers,
+            norm,
+            output: QMatMul::from_qtensor(output)?,
+            cfg: GGUFLLaMa::into_config(
+                ct.hparams.n_embd as usize,
+                0,
+                ct.hparams.n_layer as usize,
+                ct.hparams.n_head as usize,
+                ct.hparams.n_head as usize / gqa,
+                1e-5,
+                0,
+                dtype,
+                s_cfg,
+            ),
+            dtype,
+        })
+    }
+
+    pub fn from_gguf<R: std::io::Seek + std::io::Read>(
+        ct: gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+        dtype: DType,
+        s_cfg: SpecificConfig,
+    ) -> Result<Self> {
+        let md_get = |s: &str| match ct.metadata.get(s) {
+            None => candle_core::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+
+        // Parameter extraction from metadata.
+        let n_expert = md_get("llama.expert_count")
+            .and_then(|v| v.to_u32())
+            .unwrap_or(0) as usize;
+        let n_expert_used = md_get("llama.expert_used_count")
+            .and_then(|v| v.to_u32())
+            .unwrap_or(0) as usize;
+        let head_count = md_get("llama.attention.head_count")?.to_u32()? as usize;
+        let head_count_kv = md_get("llama.attention.head_count_kv")?.to_u32()? as usize;
+        let block_count = md_get("llama.block_count")?.to_u32()? as usize;
+        let embedding_length = md_get("llama.embedding_length")?.to_u32()? as usize;
+        let rope_dim = md_get("llama.rope.dimension_count")?.to_u32()? as usize;
+        // Strangely this value is generally 1e-6 in GGUF file but used to be 1e-5 by default.
+        let rms_norm_eps = md_get("llama.attention.layer_norm_rms_epsilon")?.to_f32()? as f64;
+
+        let rope_freq_base = md_get("llama.rope.freq_base")
+            .and_then(|m| m.to_f32())
+            .unwrap_or(10000f32);
+        let (cos, sin) = precomput_freqs_cis(rope_dim, rope_freq_base, device, dtype)?;
+
+        let tok_embeddings_q = ct.tensor(reader, "token_embd.weight", device)?;
+        let tok_embeddings = tok_embeddings_q.dequantize(device)?;
+        let norm = RmsNorm::from_qtensor(
+            ct.tensor(reader, "output_norm.weight", device)?,
+            rms_norm_eps,
+        )?;
+        let output = match ct.tensor(reader, "output.weight", device) {
+            Ok(tensor) => tensor,
+            Err(_) => tok_embeddings_q,
+        };
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in 0..block_count {
+            let prefix = format!("blk.{layer_idx}");
+            let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
+            let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
+            let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
+            let attention_wo =
+                ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
+            let mlp_or_moe = if n_expert <= 1 {
+                let feed_forward_w1 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_gate.weight"), device)?;
+                let feed_forward_w2 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_down.weight"), device)?;
+                let feed_forward_w3 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_up.weight"), device)?;
+                MlpOrMoe::Mlp(Mlp {
+                    feed_forward_w1: QMatMul::from_qtensor(feed_forward_w1)?,
+                    feed_forward_w2: QMatMul::from_qtensor(feed_forward_w2)?,
+                    feed_forward_w3: QMatMul::from_qtensor(feed_forward_w3)?,
+                })
+            } else {
+                let feed_forward_gate_inp =
+                    ct.tensor(reader, &format!("{prefix}.ffn_gate_inp.weight"), device)?;
+                let mut experts = Vec::with_capacity(n_expert);
+                for i in 0..n_expert {
+                    let feed_forward_w1 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_gate.{i}.weight"), device)?;
+                    let feed_forward_w2 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_down.{i}.weight"), device)?;
+                    let feed_forward_w3 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_up.{i}.weight"), device)?;
+                    experts.push(Mlp {
+                        feed_forward_w1: QMatMul::from_qtensor(feed_forward_w1)?,
+                        feed_forward_w2: QMatMul::from_qtensor(feed_forward_w2)?,
+                        feed_forward_w3: QMatMul::from_qtensor(feed_forward_w3)?,
+                    })
+                }
+                MlpOrMoe::MoE {
+                    n_expert_used,
+                    feed_forward_gate_inp: QMatMul::from_qtensor(feed_forward_gate_inp)?,
+                    experts,
+                }
+            };
+            let attention_norm =
+                ct.tensor(reader, &format!("{prefix}.attn_norm.weight"), device)?;
+            let ffn_norm = ct.tensor(reader, &format!("{prefix}.ffn_norm.weight"), device)?;
+            layers.push(LayerWeights {
+                attention_wq: QMatMul::from_qtensor(attention_wq)?,
+                attention_wk: QMatMul::from_qtensor(attention_wk)?,
+                attention_wv: QMatMul::from_qtensor(attention_wv)?,
+                attention_wo: QMatMul::from_qtensor(attention_wo)?,
+                attention_norm: RmsNorm::from_qtensor(attention_norm, rms_norm_eps)?,
+                mlp_or_moe,
+                ffn_norm: RmsNorm::from_qtensor(ffn_norm, rms_norm_eps)?,
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim: embedding_length / head_count,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                attn: PagedAttention::new(
+                    head_count,
+                    embedding_length / head_count,
+                    1. / ((embedding_length / head_count) as f32).sqrt(),
+                    Some(head_count_kv),
+                    None,
+                    device.clone(),
+                    None,
+                )?,
+                dtype,
+            })
+        }
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, embedding_length),
+            layers,
+            norm,
+            output: QMatMul::from_qtensor(output)?,
+            cfg: GGUFLLaMa::into_config(
+                embedding_length,
+                0,
+                block_count,
+                head_count,
+                head_count_kv,
+                rms_norm_eps,
+                MAX_SEQ_LEN,
+                dtype,
+                s_cfg,
+            ),
+            dtype,
+        })
+    }
+
+    fn prepare_decoder_attention_mask(
+        &self,
+        b_size: usize,
+        tgt_len: usize,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let mask: Vec<_> = (0..tgt_len)
+            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
+            .collect();
+        let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), device)?;
+        mask.expand((b_size, 1, tgt_len, tgt_len))?
+            .to_dtype(self.dtype)
+    }
+
+    pub fn forward(
+        &mut self,
+        x: &Tensor,
+        input_positions: &[Vec<usize>],
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len) = x.dims2()?;
+        let mask = if seq_len == 1 {
+            None
+        } else {
+            Some(self.prepare_decoder_attention_mask(b_sz, seq_len, x.device())?)
+        };
+        let mut layer_in = self.tok_embeddings.forward(x)?;
+
+        if let Some(kv_caches) = kv_caches {
+            for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter_mut()) {
+                let x = layer_in;
+                let residual = &x;
+                let x = layer.attention_norm.forward(&x)?;
+                let attn = layer.forward_attn(
+                    &x,
+                    mask.as_ref(),
+                    input_positions,
+                    Some((k_cache, v_cache)),
+                    input_metadata,
+                )?;
+                let x = (attn + residual)?;
+
+                // MLP
+                let residual = &x;
+                let x = layer.ffn_norm.forward(&x)?;
+                let x = layer.mlp_or_moe.forward(&x)?;
+                let x = (x + residual)?;
+                layer_in = x
+            }
+        } else {
+            for layer in self.layers.iter_mut() {
+                let x = layer_in;
+                let residual = &x;
+                let x = layer.attention_norm.forward(&x)?;
+                let attn =
+                    layer.forward_attn(&x, mask.as_ref(), input_positions, None, input_metadata)?;
+                let x = (attn + residual)?;
+
+                // MLP
+                let residual = &x;
+                let x = layer.ffn_norm.forward(&x)?;
+                let x = layer.mlp_or_moe.forward(&x)?;
+                let x = (x + residual)?;
+                layer_in = x
+            }
+        }
+        let x = self.norm.forward(&layer_in)?;
+        let x = x.i((.., seq_len - 1, ..))?;
+        self.output.forward(&x)
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
+    }
+}

--- a/src/openai/models/quantized_phi3.rs
+++ b/src/openai/models/quantized_phi3.rs
@@ -1,0 +1,401 @@
+use super::Config;
+use crate::paged_attention::input_metadata::InputMetadata;
+use crate::paged_attention::PagedAttention;
+use crate::SpecificConfig;
+use candle_core::quantized::gguf_file;
+use candle_core::quantized::QTensor;
+use candle_core::{DType, Device, IndexOp, Module, Result, Tensor, D};
+use candle_nn::{Embedding, RmsNorm};
+use either::Either;
+use std::iter::zip;
+#[derive(Debug, Clone)]
+struct QLinear {
+    inner: candle_core::quantized::QMatMul,
+}
+
+impl QLinear {
+    fn new<R: std::io::Read + std::io::Seek>(
+        ct: &gguf_file::Content,
+        r: &mut R,
+        name: &str,
+        device: &Device,
+    ) -> Result<Self> {
+        let w = ct.tensor(r, &format!("{name}.weight"), device)?;
+        let inner = candle_core::quantized::QMatMul::from_qtensor(w)?;
+        Ok(Self { inner })
+    }
+}
+
+impl Module for QLinear {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        self.inner.forward(xs)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    ffn_up: QLinear,
+    ffn_down: QLinear,
+    i_size: usize,
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let up_states = xs.apply(&self.ffn_up)?;
+        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
+        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
+        let up_states = (up_states * gate.silu()?)?;
+        up_states.apply(&self.ffn_down)
+    }
+}
+
+fn rms_norm(w: QTensor, eps: f64) -> Result<RmsNorm> {
+    let w = w.dequantize(&w.device())?;
+    let rms = RmsNorm::new(w, eps);
+    Ok(rms)
+}
+
+struct LayerWeights {
+    attn_qkv: QLinear,
+    attn_output: QLinear,
+    attn_norm: RmsNorm,
+    ffn_norm: RmsNorm,
+    mlp: Mlp,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    cos: Tensor,
+    sin: Tensor,
+    attn: PagedAttention,
+    dtype: DType,
+}
+
+impl LayerWeights {
+    fn apply_rotary_emb(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        input_positions: &[Vec<usize>],
+    ) -> Result<(Tensor, Tensor)> {
+        let (b_size, _h, seq_len, _n_embd) = q.dims4()?;
+        let mut q_embeds = Vec::new();
+        let mut k_embeds = Vec::new();
+        for (b, seqlen_offset) in zip(0..b_size, input_positions) {
+            let cos = self.cos.narrow(0, seqlen_offset[0], seq_len)?;
+            let sin = self.sin.narrow(0, seqlen_offset[0], seq_len)?;
+            let x_q = q.narrow(0, b, 1)?;
+            let x_k = k.narrow(0, b, 1)?;
+            let q_embed = candle_nn::rotary_emb::rope(&x_q, &cos, &sin)?;
+            let k_embed = candle_nn::rotary_emb::rope(&x_k, &cos, &sin)?;
+            q_embeds.push(q_embed);
+            k_embeds.push(k_embed);
+        }
+        Ok((
+            Tensor::cat(&q_embeds, 0).unwrap(),
+            Tensor::cat(&k_embeds, 0).unwrap(),
+        ))
+    }
+
+    fn forward_attn(
+        &mut self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        input_positions: &[Vec<usize>],
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, n_embd) = x.dims3()?;
+        let qkv = self.attn_qkv.forward(x)?;
+
+        let query_pos = self.n_head * self.head_dim;
+        let q = qkv.narrow(D::Minus1, 0, query_pos)?.to_dtype(self.dtype)?;
+        let k = qkv
+            .narrow(D::Minus1, query_pos, self.n_kv_head * self.head_dim)?
+            .to_dtype(self.dtype)?;
+        let v = qkv
+            .narrow(
+                D::Minus1,
+                query_pos + self.n_kv_head * self.head_dim,
+                self.n_kv_head * self.head_dim,
+            )?
+            .to_dtype(self.dtype)?;
+
+        let (q, k, v) = if seq_len == 1 {
+            //no need transpose for seq_len == 1, change reshape dim
+            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            (q, k, v)
+        } else {
+            let q = q
+                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = k
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            (q.contiguous()?, k.contiguous()?, v.contiguous()?)
+        };
+
+        let (q, k) = self.apply_rotary_emb(&q, &k, input_positions)?;
+
+        let y = self.attn.forward(
+            &q,
+            &k,
+            &v,
+            mask,
+            cache.map(|(k_, _)| k_.clone()),
+            cache.map(|(_, v_)| v_.clone()),
+            input_metadata,
+            None,
+        )?;
+
+        let y = if mask.is_some() {
+            y.transpose(1, 2)?.reshape(&[b_sz, seq_len, n_embd])?
+        } else {
+            y.reshape(&[b_sz, seq_len, n_embd])?
+        };
+
+        let y = self.attn_output.forward(&y.to_dtype(x.dtype())?)?;
+        Ok(y)
+    }
+}
+
+pub struct GGUFPhi3 {
+    tok_embeddings: Embedding,
+    layers: Vec<LayerWeights>,
+    output_norm: RmsNorm,
+    output: QLinear,
+    cfg: Config,
+    dtype: DType,
+}
+
+fn precomput_freqs_cis(
+    head_dim: usize,
+    max_seq_len: usize,
+    freq_base: f32,
+    device: &Device,
+    dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    let theta: Vec<_> = (0..head_dim)
+        .step_by(2)
+        .map(|i| 1f32 / freq_base.powf(i as f32 / head_dim as f32))
+        .collect();
+    let theta = Tensor::new(theta.as_slice(), device)?;
+    let idx_theta = Tensor::arange(0, max_seq_len as u32, device)?
+        .to_dtype(DType::F32)?
+        .reshape((max_seq_len, 1))?
+        .matmul(&theta.reshape((1, theta.elem_count()))?)?;
+    let cos = idx_theta.cos()?.to_dtype(dtype)?;
+    let sin = idx_theta.sin()?.to_dtype(dtype)?;
+    Ok((cos, sin))
+}
+
+impl GGUFPhi3 {
+    pub fn into_config(
+        embedding_length: usize,
+        i_size: usize,
+        block_count: usize,
+        head_count: usize,
+        head_count_kv: usize,
+        rms_eps: f64,
+        max_seq_len: usize,
+        kv_cache_dtype: DType,
+        s_cfg: SpecificConfig,
+    ) -> Config {
+        Config {
+            hidden_size: embedding_length,
+            head_dim: Some(embedding_length / head_count),
+            intermediate_size: i_size,
+            vocab_size: 0,
+            num_hidden_layers: block_count,
+            num_attention_heads: head_count,
+            num_key_value_heads: head_count_kv,
+            rms_norm_eps: rms_eps,
+            rope_theta: 0.,
+            use_flash_attn: false,
+            bos_token_id: super::TokenID(Either::Left(None)),
+            eos_token_id: super::TokenID(Either::Left(None)),
+            max_seq_len: max_seq_len,
+            sliding_window: None,
+            hidden_act: None,
+            tie_word_embeddings: false,
+            rope_scaling: None,
+            original_max_position_embeddings: Some(max_seq_len),
+            attention_bias: false,
+            partial_rotary_factor: None,
+            qk_layer_rms_norm: None,
+            kv_cache_dtype,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
+            specific_config: s_cfg,
+            attn_logit_softcapping: None,
+            final_logit_softcapping: None,
+            quantization_config: None,
+        }
+    }
+
+    pub fn from_gguf<R: std::io::Seek + std::io::Read>(
+        ct: gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+        dtype: DType,
+        s_cfg: SpecificConfig,
+    ) -> Result<Self> {
+        let md_get = |s: &str| match ct.metadata.get(s) {
+            None => candle_core::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+
+        // Parameter extraction from metadata.
+        let head_count = md_get("phi3.attention.head_count")?.to_u32()? as usize;
+        let head_count_kv = md_get("phi3.attention.head_count_kv")?.to_u32()? as usize;
+        let block_count = md_get("phi3.block_count")?.to_u32()? as usize;
+        let embedding_length = md_get("phi3.embedding_length")?.to_u32()? as usize;
+        let max_seq_len = md_get("phi3.context_length")?.to_u32()? as usize;
+        let head_dim = embedding_length / head_count;
+        let i_size = md_get("phi3.feed_forward_length")?.to_u32()? as usize;
+        let rope_dim = md_get("phi3.rope.dimension_count")?.to_u32()? as usize;
+        let rms_eps = md_get("phi3.attention.layer_norm_rms_epsilon")?.to_f32()? as f64;
+        let (cos, sin) = precomput_freqs_cis(rope_dim, max_seq_len, 10_000., device, dtype)?;
+
+        let tok_embeddings = ct.tensor(reader, "token_embd.weight", device)?;
+        let tok_embeddings = tok_embeddings.dequantize(device)?;
+        let output_norm = rms_norm(ct.tensor(reader, "output_norm.weight", device)?, rms_eps)?;
+        let output = QLinear::new(&ct, reader, "output", device)?;
+
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in 0..block_count {
+            let prefix = format!("blk.{layer_idx}");
+            let ffn_up = QLinear::new(&ct, reader, &format!("{prefix}.ffn_up"), device)?;
+            let ffn_down = QLinear::new(&ct, reader, &format!("{prefix}.ffn_down"), device)?;
+            let mlp = Mlp {
+                ffn_up,
+                ffn_down,
+                i_size,
+            };
+            let attn_norm = rms_norm(
+                ct.tensor(reader, &format!("{prefix}.attn_norm.weight"), device)?,
+                rms_eps,
+            )?;
+            let ffn_norm = rms_norm(
+                ct.tensor(reader, &format!("{prefix}.ffn_norm.weight"), device)?,
+                rms_eps,
+            )?;
+            layers.push(LayerWeights {
+                attn_qkv: QLinear::new(&ct, reader, &format!("{prefix}.attn_qkv"), device)?,
+                attn_output: QLinear::new(&ct, reader, &format!("{prefix}.attn_output"), device)?,
+                attn_norm,
+                ffn_norm,
+                mlp,
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                attn: PagedAttention::new(
+                    head_count,
+                    head_dim,
+                    1. / ((head_dim as f32).sqrt()),
+                    Some(head_count_kv),
+                    None,
+                    device.clone(),
+                    None,
+                )?,
+                dtype,
+            })
+        }
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, embedding_length),
+            layers,
+            output_norm,
+            output,
+            cfg: GGUFPhi3::into_config(
+                embedding_length,
+                i_size,
+                block_count,
+                head_count,
+                head_count_kv,
+                rms_eps,
+                max_seq_len,
+                dtype,
+                s_cfg,
+            ),
+            dtype,
+        })
+    }
+
+    fn prepare_decoder_attention_mask(
+        &self,
+        b_size: usize,
+        tgt_len: usize,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let mask: Vec<_> = (0..tgt_len)
+            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0. }))
+            .collect();
+        let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), device)?;
+        mask.expand((b_size, 1, tgt_len, tgt_len))?
+            .to_dtype(self.dtype)
+    }
+
+    pub fn forward(
+        &mut self,
+        xs: &Tensor,
+        input_positions: &[Vec<usize>],
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &mut InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len) = xs.dims2()?;
+        let mask = if seq_len == 1 {
+            None
+        } else {
+            Some(self.prepare_decoder_attention_mask(b_sz, seq_len, xs.device())?)
+        };
+        let mut xs = self.tok_embeddings.forward(xs)?;
+
+        if let Some(kv_caches) = kv_caches {
+            for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter_mut()) {
+                let residual = &xs;
+                let ys = xs.apply(&layer.attn_norm)?;
+                let ys = layer.forward_attn(
+                    &ys,
+                    mask.as_ref(),
+                    input_positions,
+                    Some((k_cache, v_cache)),
+                    input_metadata,
+                )?;
+                let ys = (ys + residual)?;
+                let residual = &ys;
+                let ys = ys.apply(&layer.ffn_norm)?;
+                let ys = layer.mlp.forward(&ys)?;
+                xs = (ys + residual)?
+            }
+        } else {
+            for layer in self.layers.iter_mut() {
+                let residual = &xs;
+                let ys = xs.apply(&layer.attn_norm)?;
+                let ys = layer.forward_attn(
+                    &ys,
+                    mask.as_ref(),
+                    input_positions,
+                    None,
+                    input_metadata,
+                )?;
+                let ys = (ys + residual)?;
+                let residual = &ys;
+                let ys = ys.apply(&layer.ffn_norm)?;
+                let ys = layer.mlp.forward(&ys)?;
+                xs = (ys + residual)?
+            }
+        }
+        let xs = xs.i((.., seq_len - 1, ..))?.apply(&self.output_norm)?;
+        self.output.forward(&xs)
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
+    }
+}

--- a/src/openai/pipelines/mod.rs
+++ b/src/openai/pipelines/mod.rs
@@ -114,6 +114,7 @@ pub trait ModelLoader {
         &self,
         paths: Box<dyn ModelPaths>,
         dtype: DType,
+        quant: Option<String>,
         device: Device,
     ) -> Result<(Box<dyn ModulePipeline>, PipelineConfig), APIError>;
 }

--- a/src/paged_attention/mod.rs
+++ b/src/paged_attention/mod.rs
@@ -176,6 +176,7 @@ impl PagedAttention {
             value_cache.as_ref().unwrap(),
             input_metadata.block_tables.as_ref().unwrap(),
             input_metadata.context_lens.as_ref().unwrap(),
+            None,
             input_metadata.max_context_len.unwrap(),
             self.scale,
             softcapping.unwrap_or(1.0f64) as f32,


### PR DESCRIPTION
This PR adds support for Mac/Metal devices.

### Tested Case:

```shell
cargo run --release --features metal -- --port 2000 --dtype bf16 --weight-path /Users/Downloads --weight-file Phi-3.5-mini-instruct-Q4_K_M.gguf phi3 --quant gguf --temperature 0. --penalty 1.0
```

Ensure the `gguf` model `Phi-3.5-mini-instruct-Q4_K_M.gguf` is downloaded to `/Users/Downloads`. To run the program, supply the `quant` parameter as `gguf` and build `candle-vllm` with the `metal` feature enabled. An active internet connection is required to access `huggingface.co`, allowing the program to download `tokenizer.json` for proper token decoding.