### PR TITLE
Faster token sampling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@ pub enum ModelSelected {
         temperature: Option<f32>,
 
         #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
+
+        #[arg(long)]
         penalty: Option<f32>,
 
         #[arg(long)]
@@ -42,6 +48,12 @@ pub enum ModelSelected {
         temperature: Option<f32>,
 
         #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
+
+        #[arg(long)]
         penalty: Option<f32>,
 
         #[arg(long)]
@@ -59,6 +71,12 @@ pub enum ModelSelected {
 
         #[arg(long)]
         temperature: Option<f32>,
+
+        #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
 
         #[arg(long)]
         penalty: Option<f32>,
@@ -130,6 +148,12 @@ pub enum ModelSelected {
         temperature: Option<f32>,
 
         #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
+
+        #[arg(long)]
         penalty: Option<f32>,
 
         #[arg(long)]
@@ -149,6 +173,12 @@ pub enum ModelSelected {
         temperature: Option<f32>,
 
         #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
+
+        #[arg(long)]
         penalty: Option<f32>,
 
         #[arg(long)]
@@ -166,6 +196,12 @@ pub enum ModelSelected {
 
         #[arg(long)]
         temperature: Option<f32>,
+
+        #[arg(long)]
+        top_p: Option<f64>,
+
+        #[arg(long)]
+        top_k: Option<usize>,
 
         #[arg(long)]
         penalty: Option<f32>,
@@ -296,6 +332,8 @@ pub fn get_model_loader(
         ModelSelected::Llama {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -304,8 +342,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
@@ -322,6 +360,8 @@ pub fn get_model_loader(
         ModelSelected::Llama3 {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -330,8 +370,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
@@ -348,6 +388,8 @@ pub fn get_model_loader(
         ModelSelected::Phi2 {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -356,8 +398,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
@@ -430,6 +472,8 @@ pub fn get_model_loader(
         ModelSelected::Gemma {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -438,8 +482,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
@@ -456,6 +500,8 @@ pub fn get_model_loader(
         ModelSelected::Mistral {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -464,8 +510,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
@@ -483,6 +529,8 @@ pub fn get_model_loader(
         ModelSelected::Yi {
             repeat_last_n,
             temperature,
+            top_k,
+            top_p,
             penalty,
             max_gen_tokens,
             quant,
@@ -491,8 +539,8 @@ pub fn get_model_loader(
                 SpecificConfig::new(
                     repeat_last_n,
                     temperature,
-                    None,
-                    None,
+                    top_k,
+                    top_p,
                     penalty,
                     max_gen_tokens,
                     quant.clone(),

--- a/src/openai/logits_processor.rs
+++ b/src/openai/logits_processor.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "cuda")]
+use crate::backend::custom_ops::sort::ArgSortOp; //Use our custom sort kernel, fix kernel crash on A100
 use crate::candle::D;
-use crate::candle::{DType, Error, Result, Tensor};
+use crate::candle::{DType, Error, IndexOp, Result, Tensor};
 use rand::{distributions::Distribution, SeedableRng};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -58,61 +60,77 @@ impl LogitsProcessor {
     /// top-p sampling (or "nucleus sampling") samples from the smallest set of tokens that exceed
     /// probability top_p. This way we never sample tokens that have very low probabilities and are
     /// less likely to go "off the rails".
-    fn sample_topp(&self, prs: &mut Vec<f32>, top_p: f32) -> Result<u32> {
-        let mut argsort_indices = (0..prs.len()).collect::<Vec<_>>();
-
-        // Sort by descending probability.
-        argsort_indices.sort_by(|&i, &j| prs[j].total_cmp(&prs[i]));
-
+    fn sample_topp(&self, logits: &Tensor, top_p: f32) -> Result<u32> {
+        let mut prs: Vec<f32> = logits.to_vec1()?;
+        #[cfg(feature = "cuda")]
+        let argsort_indices: Vec<u32> = logits.arg_sort(false)?.to_vec1()?;
+        #[cfg(not(feature = "cuda"))]
+        let argsort_indices: Vec<u32> = logits.arg_sort_last_dim(false)?.to_vec1()?;
         // Clamp smaller probabilities to zero.
         let mut cumsum = 0.;
         for index in &argsort_indices {
             if cumsum >= top_p {
-                prs[*index] = 0.0;
+                prs[*index as usize] = 0.0;
             } else {
-                cumsum += prs[*index];
+                cumsum += prs[*index as usize];
             }
         }
         // Sample with clamped probabilities.
-        self.sample_multinomial(prs)
+        self.sample_multinomial(&prs)
     }
 
     // top-k sampling samples from the k tokens with the largest probabilities.
-    fn sample_topk(&self, prs: &mut Vec<f32>, top_k: usize) -> Result<u32> {
-        if top_k >= prs.len() {
-            self.sample_multinomial(prs)
+    fn sample_topk(&self, logits: &Tensor, top_k: usize) -> Result<u32> {
+        #[cfg(feature = "cuda")]
+        let (sorted, asort) = logits.sort(false)?;
+        #[cfg(not(feature = "cuda"))]
+        let (sorted, asort) = logits.sort_last_dim(false)?;
+
+        if top_k >= *logits.layout().dims().last().unwrap() {
+            let prs: Vec<f32> = sorted.to_vec1()?;
+            self.sample_multinomial(&prs)
         } else {
-            let mut argsort_indices = (0..prs.len()).collect::<Vec<_>>();
-            let (indices, _, _) =
-                argsort_indices.select_nth_unstable_by(top_k, |&i, &j| prs[j].total_cmp(&prs[i]));
-            let prs = indices.iter().map(|&i| prs[i]).collect::<Vec<_>>();
+            let prs: Vec<f32> = sorted.to_vec1()?[0..top_k].to_vec();
             let index = self.sample_multinomial(&prs)?;
+            let indices: Vec<u32> = asort.to_vec1()?[0..top_k].to_vec();
             Ok(indices[index as usize] as u32)
         }
     }
 
     // top-k sampling samples from the k tokens with the largest probabilities.
     // then top-p sampling.
-    fn sample_topk_topp(&self, prs: &mut Vec<f32>, top_k: usize, top_p: f32) -> Result<u32> {
-        if top_k >= prs.len() {
-            self.sample_topp(prs, top_p)
+    fn sample_topk_topp(&self, logits: &Tensor, top_k: usize, top_p: f32) -> Result<u32> {
+        #[cfg(feature = "cuda")]
+        let (sorted, asort) = logits.sort(false)?;
+        #[cfg(not(feature = "cuda"))]
+        let (sorted, asort) = logits.sort_last_dim(false)?;
+        if top_k >= *logits.layout().dims().last().unwrap() {
+            let prs: Vec<f32> = sorted.to_vec1()?;
+            self.sample_multinomial(&prs)
         } else {
-            let mut argsort_indices = (0..prs.len()).collect::<Vec<_>>();
-            let (indices, _, _) =
-                argsort_indices.select_nth_unstable_by(top_k, |&i, &j| prs[j].total_cmp(&prs[i]));
-            let mut prs = indices.iter().map(|&i| prs[i]).collect::<Vec<_>>();
+            let indices: Vec<u32> = asort.to_vec1()?[0..top_k].to_vec();
+            let mut prs: Vec<f32> = sorted.to_vec1()?[0..top_k].to_vec();
             let sum_p = prs.iter().sum::<f32>();
             let index = if top_p <= 0.0 || top_p >= sum_p {
                 self.sample_multinomial(&prs)?
             } else {
-                self.sample_topp(&mut prs, top_p)?
+                let mut cumsum = 0.;
+                for i in 0..prs.len() {
+                    if cumsum >= top_p {
+                        prs[i] = 0.0;
+                    } else {
+                        cumsum += prs[i];
+                    }
+                }
+                // Sample with clamped probabilities.
+                self.sample_multinomial(&prs)?
             };
             Ok(indices[index as usize] as u32)
         }
     }
 
     pub fn sample(&self, logits: &Tensor) -> Result<u32> {
-        self.sample_f(logits, |_| {})
+        self.sample_f(logits)
     }
 
     pub fn sample_f_batch(&self, logits: &Tensor) -> Result<Vec<u32>> {
@@ -125,32 +143,33 @@ impl LogitsProcessor {
             | Sampling::TopKThenTopP { temperature, .. } => {
                 let temper = if *temperature > 0. { *temperature } else { 1.0 };
                 let logits = (&logits / temper)?;
-                let prs = candle_nn::ops::softmax_last_dim(&logits)?;
-                let prs_vec = prs.to_vec2()?;
+                let prs_tensor = candle_nn::ops::softmax_last_dim(&logits)?;
+                let batch = *prs_tensor.layout().dims().first().unwrap();
                 let mut vec_ret = Vec::<u32>::new();
-                for idx in 0..prs_vec.len() {
+                for idx in 0..batch {
                     let next_token = match &self.sampling {
                         Sampling::All { .. } => {
-                            let prs = prs_vec[idx].clone();
+                            let prs = prs_tensor.i((idx, ..))?.to_vec1()?;
                             self.sample_multinomial(&prs)?
                         }
                         Sampling::TopP { p, .. } => {
-                            let mut prs = prs_vec[idx].clone();
                             if *p <= 0.0 || *p >= 1.0 {
                                 // simply sample from the predicted probability distribution
+                                let prs = prs_tensor.i((idx, ..))?.to_vec1()?;
                                 self.sample_multinomial(&prs)?
                             } else {
                                 // top-p (nucleus) sampling, clamping the least likely tokens to zero
-                                self.sample_topp(&mut prs, *p as f32)?
+                                let prs = prs_tensor.i((idx, ..))?;
+                                self.sample_topp(&prs, *p as f32)?
                             }
                         }
                         Sampling::TopK { k, .. } => {
-                            let mut prs = prs_vec[idx].clone();
-                            self.sample_topk(&mut prs, *k)?
+                            let prs = prs_tensor.i((idx, ..))?;
+                            self.sample_topk(&prs, *k)?
                         }
                         Sampling::TopKThenTopP { k, p, .. } => {
-                            let mut prs = prs_vec[idx].clone();
-                            self.sample_topk_topp(&mut prs, *k, *p as f32)?
+                            let prs = prs_tensor.i((idx, ..))?;
+                            self.sample_topk_topp(&prs, *k, *p as f32)?
                         }
                         _ => {
                             unreachable!();
@@ -173,39 +192,37 @@ impl LogitsProcessor {
         Ok(next_tokens)
     }
 
-    pub fn sample_f(&self, logits: &Tensor, f: impl FnOnce(&mut [f32])) -> Result<u32> {
+    pub fn sample_f(&self, logits: &Tensor) -> Result<u32> {
         let logits = logits.to_dtype(DType::F32)?;
-        let prs = |temperature: f64| -> Result<Vec<f32>> {
+        let prs = |temperature: f64| -> Result<Tensor> {
             let logits = (&logits / temperature)?;
             let prs = candle_nn::ops::softmax_last_dim(&logits)?;
-            let mut prs = prs.to_vec1()?;
-            f(&mut prs);
             Ok(prs)
         };
 
         let next_token = match &self.sampling {
             Sampling::ArgMax => self.sample_argmax(logits)?,
             Sampling::All { temperature } => {
-                let prs = prs(*temperature)?;
+                let prs = prs(*temperature)?.to_vec1()?;
                 self.sample_multinomial(&prs)?
             }
             Sampling::TopP { p, temperature } => {
-                let mut prs = prs(*temperature)?;
+                let prs = prs(*temperature)?;
                 if *p <= 0.0 || *p >= 1.0 {
                     // simply sample from the predicted probability distribution
-                    self.sample_multinomial(&prs)?
+                    self.sample_multinomial(&prs.to_vec1()?)?
                 } else {
                     // top-p (nucleus) sampling, clamping the least likely tokens to zero
-                    self.sample_topp(&mut prs, *p as f32)?
+                    self.sample_topp(&prs, *p as f32)?
                 }
             }
             Sampling::TopK { k, temperature } => {
-                let mut prs = prs(*temperature)?;
-                self.sample_topk(&mut prs, *k)?
+                let prs = prs(*temperature)?;
+                self.sample_topk(&prs, *k)?
             }
             Sampling::TopKThenTopP { k, p, temperature } => {
-                let mut prs = prs(*temperature)?;
-                self.sample_topk_topp(&mut prs, *k, *p as f32)?
+                let prs = prs(*temperature)?;
+                self.sample_topk_topp(&prs, *k, *p as f32)?
             }
         };
         Ok(next_token)


### PR DESCRIPTION
This PR offers a more elegant solution for token sampling on GPU compared to our previous PR for candle [Fix Sort Kernel](https://github.com/huggingface/candle/pull/2730), thanks to the use of Rust FFI (which candle currently does not use for GPU, making it complicated to achieving bitonic sort kernel).

The custom sort kernel [`kernels/sort.cu`](https://github.com/EricLBuehler/candle-vllm/blob/master/kernels/src/sort.cu) we created in candle-vllm is intended to resolve kernel crashes during tensor sorting on **A100** and older generation GPUs, as outlined in our initial PR for candle:

> "This PR addresses an issue with the asort kernel, which can lead to CUDA invalid arguments error when the last dimension to be sorted exceeded the number of threads allowed per CUDA block. With the revised asort kernel, we can now partially perform logit sampling on the GPU (specifically, the sorting process). This optimization improves text generation performance by up to 25% **(in candle)**, depending on the model and the number of tokens generated."

### A100 Test Case

```
cargo run --release --features cuda -- --dtype f16 --port 2000 --weight-path /home/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4-Marlin llama3 --quant marlin --penalty 1.0 --temperature 0.7 --top-p 0.8
```

**Performance Improvement:**

- **Before:** LLaMA-3.1-8B (42 tokens/s)  
- **After:** LLaMA-3.1-8B (60 tokens/s)

**Expected Performance Boost:**

When sampling parameters `temperature` and `top-p`/`top-k` are given, the optimization delivers a **20% to 45%** increase in generation speed, depending on the model and workload.