### PR TITLE
Fix StopTokens deserialization

### DIFF
--- a/src/openai/requests.rs
+++ b/src/openai/requests.rs
@@ -10,6 +10,7 @@ pub enum Messages {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum StopTokens {
     Multi(Vec<String>),
     Single(String),


### PR DESCRIPTION
When the request JSON contains non-null "stop" field, the request will fail due to deserialization error. This PR fixed this issue.