### PR TITLE
Improve performance of deepseek models (Rust compiler 1.83.0+ required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [this folder](examples/) for some examples.
 
 ### Step 1: Start Candle-vLLM service by selecting the running method
 
-Install dependencies
+Install dependencies (Rust compiler `1.83.0+` required)
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 sudo apt install libssl-dev -y


### PR DESCRIPTION
The `bincount` operation takes a significant amount of time, especially with large token context sizes, leading to a slower moe_infer process. This PR replaces bincount with a Rust `HashSet` for counting expert appearances in topk_ids (produced by the Top-K operation or MoE gating), resulting in an overall inference performance improvement of `over 20%` for DeepSeek models.

Tested case (DeepSeek-V2-Chat)

**Before:**

``` shell
Prompt "<｜begin▁of▁sentence｜>User: Talk about China.\n\nAssistant:"
Request cmpl-c934f6d3-02ac-48a5-bad3-e9d562ab92f1 with length 11 added to sequence group.
2025-04-10 05:55:13 WARN candle_vllm::openai::pipelines::llm_engine Sending 1 tasks to 1 subprocesses
Request cmpl-c934f6d3-02ac-48a5-bad3-e9d562ab92f1 decoding 404 tokens finished in 17 seconds
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine generate_once: no unfinished_sequences, break
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine Sending finish message to subprocesses
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine generate_once: finished generation

 [1 requests] Prefilling: 11 prompt tokens processed in 0 seconds

 [1 requests] Decoding: 404 tokens processed in 17 seconds (22 tokens/s)
```

**After:**

``` shell
Prompt "<｜begin▁of▁sentence｜>User: Talk about China.\n\nAssistant:"
Request cmpl-f8224dbd-ba1c-4b1f-b92a-12806ac8ea2e with length 11 added to sequence group.
2025-04-10 05:52:31 WARN candle_vllm::openai::pipelines::llm_engine Sending 1 tasks to 1 subprocesses
Request cmpl-f8224dbd-ba1c-4b1f-b92a-12806ac8ea2e decoding 404 tokens finished in 11 seconds
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine generate_once: no unfinished_sequences, break
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine Sending finish message to subprocesses
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine generate_once: finished generation

 [1 requests] Prefilling: 11 prompt tokens processed in 0 seconds

 [1 requests] Decoding: 404 tokens processed in 11 seconds (34 tokens/s)
```