### PR TITLE
Fix process sync issue when chat streaming aborted

### DIFF
--- a/src/backend/heartbeat.rs
+++ b/src/backend/heartbeat.rs
@@ -1,6 +1,6 @@
 use crate::openai::communicator::DaemonManager;
 use std::{process, thread, time};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 pub async fn heartbeat_worker(num_subprocess: Option<usize>) {
     let _ = thread::spawn(move || {
         let mut connect_retry_count = 0;
@@ -28,7 +28,7 @@ pub async fn heartbeat_worker(num_subprocess: Option<usize>) {
         } else {
             DaemonManager::new_command("heartbeat", num_subprocess)
         };
-        warn!("enter heartbeat processing loop ({:?})", command_manager);
+        info!("enter heartbeat processing loop ({:?})", command_manager);
         loop {
             let alive_result = command_manager.as_mut().unwrap().heartbeat();
             if alive_result.is_err() {
@@ -42,7 +42,7 @@ pub async fn heartbeat_worker(num_subprocess: Option<usize>) {
                 }
                 heartbeat_error_count += 1;
             } else {
-                info!("paired processes still alive!");
+                debug!("paired processes still alive!");
             }
             let _ = thread::sleep(time::Duration::from_millis(1000 as u64));
         }

--- a/src/openai/communicator.rs
+++ b/src/openai/communicator.rs
@@ -57,6 +57,7 @@ pub enum MessageType {
     Data(Vec<TaskData>),
     Sample(Vec<TaskSampleData>),
     Continue,
+    Abort(Vec<usize>),
     Finish,
     HeartBeat,
     Close,
@@ -203,7 +204,7 @@ impl DaemonManager {
             let mut streams = Vec::with_capacity(num_subprocess);
             for _ in 0..num_subprocess {
                 let stream = listener.accept()?;
-                warn!("accept one daemon process!");
+                info!("accept one daemon process!");
                 streams.push(stream);
             }
 


### PR DESCRIPTION
There is a bug in multi-process, multi-GPU inference: the paired (daemon) processes are unable to exit the generation procedure if the chat streaming of the main process is aborted right after the prefill stage. This results in mismatched input shapes between the main and daemon processes during parallel inference, causing NCCL to hang. This PR fixes the issue.