### PR TITLE
Support AWQ quant & DeepSeek-R1 685B on less GPU memory (CPU offloading)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ libpagedattention.a
 *.gz
 kernels/src/lib.rs
 *.log
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,8 +343,8 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "candle-core"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -372,12 +372,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "candle-examples"
+name = "candle-core"
 version = "0.8.4"
 source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
 dependencies = [
+ "byteorder",
+ "gemm 0.17.1",
+ "half",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.0",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 1.0.61",
+ "ug",
+ "yoke",
+ "zip",
+]
+
+[[package]]
+name = "candle-examples"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
+dependencies = [
  "anyhow",
- "candle-core",
+ "candle-core 0.8.3",
  "candle-nn",
  "candle-transformers",
  "csv",
@@ -393,27 +414,27 @@ dependencies = [
 
 [[package]]
 name = "candle-flash-attn"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
- "candle-core",
+ "candle-core 0.8.3",
  "half",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "bindgen_cuda 0.1.5",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -423,11 +444,11 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "accelerate-src",
- "candle-core",
+ "candle-core 0.8.3",
  "candle-metal-kernels",
  "half",
  "intel-mkl-src",
@@ -441,12 +462,12 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.8.4"
-source = "git+https://github.com/huggingface/candle.git#64296090907922aeaf5e647017197a8c8de6dce4"
+version = "0.8.3"
+source = "git+https://github.com/guoqingbao/candle.git?branch=candle-main#fec66116b7638dd607a675e61806de913c65b471"
 dependencies = [
  "accelerate-src",
  "byteorder",
- "candle-core",
+ "candle-core 0.8.3",
  "candle-flash-attn",
  "candle-nn",
  "fancy-regex",
@@ -468,7 +489,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bincode",
- "candle-core",
+ "candle-core 0.8.3",
  "candle-examples",
  "candle-flash-attn",
  "candle-nn",
@@ -2083,7 +2104,7 @@ name = "metal-kernels"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "candle-core",
+ "candle-core 0.8.4",
  "metal 0.27.0",
  "once_cell",
  "thiserror 1.0.61",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.8.4" }
-candle-examples = { git = "https://github.com/huggingface/candle.git", version = "0.8.4" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.8.4" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.1"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/huggingface/candle.git", version = "0.8.4" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
 hf-hub = "0.3.2"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -33,7 +33,7 @@ accelerate-src = { version = "0.3.2", optional = true }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], optional = true }
 cudarc = {version = "0.13.5", features = ["f16", "cuda-version-from-build-system"], optional = true }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.8.4", optional = true }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main", optional = true }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", 
 
 1) It may takes few minutes to load F32/F16/BF16 models into quantized;
 
-2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`) and 4-bit AWQ (after convertion using the given script);
+2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`) and 4-bit AWQ (after conversion using the given script);
 
 3) Marlin format only supported in CUDA platform.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,17 @@ See [this folder](examples/) for some examples.
 ### Step 1: Start Candle-vLLM service by selecting the running method
 
 Install dependencies (Rust compiler `1.83.0+` required)
-```
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 sudo apt install libssl-dev -y
 sudo apt install pkg-config -y
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
+```
+
+**Make sure the CUDA Toolkit is correctly configured:**
+```shell
+export PATH=$PATH:/usr/local/cuda/bin/
 ```
 
 Run **Uncompressed** models
@@ -102,6 +107,12 @@ Run **Marlin-format models**,
 ```shell
 # If you have Marlin-format model, run it with (--quant marlin)
 cargo run --release --features cuda -- --dtype bf16 --port 2000 --weight-path /home/DeepSeek-R1-Distill-Qwen-14B-GPTQ-Marlin/ qwen2 --quant marlin --penalty 1.0 --temperature 0.
+```
+
+Run **Marlin-compatible AWQ models**,
+```shell
+python3 examples/convert_awq_marlin.py --src /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/ --dst /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/ --bits 4 --method awq --group 128 --nk False
+cargo run --release --features cuda,nccl -- --multi-process --dtype f16 --port 2000 --device-ids "0" --weight-path /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/ llama3 --quant awq --temperature 0. --penalty 1.0
 ```
 
 You may also run specific model using **Huggingface model-id**, e.g.,
@@ -152,6 +163,14 @@ If you encountered problems under Multi-GPU settings (especially on Multi-thread
 export NCCL_P2P_DISABLE=1 # disable p2p cause this feature can cause illegal memory access in certain environments
 ```
 **Note:** number of GPUs used must be aligned to 2^n (e.g., 2, 4, or 8).
+
+
+Run **DeepSeek-R1 (685B) on Lower GPU Memory Setups**, e.g., `8 x A100(48GB)`
+
+```
+RUST_LOG=warn cargo run --release --features cuda,nccl -- --log --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --model-id cognitivecomputations/DeepSeek-R1-awq deep-seek --quant awq --temperature 0. --penalty 1.0 --num-experts-offload-per-rank 10
+```
+**Note:** This setup offloads 10 experts per rank (a total of 80 out of 256 experts) to the CPU (around 120GB additional host memory required). During inference, these offloaded experts are swapped back into GPU memory as needed. If you have even less GPU memory, consider increasing the `--num-experts-offload-per-rank` parameter (up to a maximum of 32 experts per rank in this case).
 
 ### Step 2:
 #### Option 1: Chat with Chat.py (for simple tests)
@@ -312,19 +331,25 @@ async def benchmark():
 asyncio.run(benchmark())
 ```
 
-## GPTQ/Marlin 4-bit quantization
-Candle-vllm now supports GPTQ (Marlin kernel), you may supply the `quant` (marlin) parameter if you have `Marlin` format quantized weights, such as:
+## GPTQ/AWQ/Marlin 4-bit quantization
+Candle-vllm now supports GPTQ/AWQ (Marlin kernel), you may supply the `quant` (marlin) parameter if you have `Marlin` format quantized weights, such as:
 
-```
+```shell
 cargo run --release --features cuda -- --port 2000 --dtype f16 --weight-path /home/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4-Marlin/ llama3 --quant marlin --temperature 0. --penalty 1.
 ```
+or, convert existing AWQ 4bit model to marlin compatible format
+```shell
+python3 examples/convert_awq_marlin.py --src /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/ --dst /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/ --bits 4 --method awq --group 128 --nk False
+cargo run --release --features cuda,nccl -- --multi-process --dtype f16 --port 2000 --device-ids "0" --weight-path /home/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/ llama3 --quant awq --temperature 0. --penalty 1.0
+```
+
 You may also use `GPTQModel` to transform a model to marlin-compatible format using the given script `examples/convert_marlin.py`. 
 
-**Note:** for using Marlin fast kernel, only 4-bit GPTQ quantization supported at the moment, and the input data type should be `bf16` (--dtype bf16) or `f16` (--dtype f16). 
+**Note:** for using Marlin fast kernel, only 4-bit GPTQ quantization supported at the moment. 
 
 ## In-situ quantization (or in-situ marlin conversion)
 
-Candle-vllm now supports in-situ quantization, allowing the transformation of default weights (F32/F16/BF16) or `4-bit GPTQ` weights into any GGML format (or `marlin format`) during model loading. This feature helps conserve GPU memory (or speedup inference performance through marlin kernel), making it more efficient for consumer-grade GPUs (e.g., RTX 4090). To use this feature, simply supply the quant parameter when running candle-vllm.
+Candle-vllm now supports in-situ quantization, allowing the transformation of default weights (F32/F16/BF16) or `4-bit GPTQ/AWQ` weights into any GGML format (or `marlin format`) during model loading. This feature helps conserve GPU memory (or speedup inference performance through marlin kernel), making it more efficient for consumer-grade GPUs (e.g., RTX 4090). To use this feature, simply supply the quant parameter when running candle-vllm.
 
 For unquantized models:
 
@@ -338,13 +363,13 @@ For quantized 4-bit GPTQ model:
 cargo run --release --features cuda -- --port 2000 --weight-path /home/mistral_7b-int4/ mistral --quant marlin
 ```
 
-Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml"]
+Options for `quant` parameters: ["q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "q2k", "q3k","q4k","q5k","q6k", "marlin", "gguf", "ggml", "gptq", "awq"]
 
 **Please note**:
 
 1) It may takes few minutes to load F32/F16/BF16 models into quantized;
 
-2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`);
+2) Marlin format in-situ conversion only support 4-bit GPTQ (with `sym=True`, `groupsize=128` or -1, `desc_act=False`) and 4-bit AWQ (after convertion using the given script);
 
 3) Marlin format only supported in CUDA platform.
 

--- a/examples/convert_awq_marlin.py
+++ b/examples/convert_awq_marlin.py
@@ -1,0 +1,233 @@
+import torch
+import numpy
+from safetensors.torch import load_file, save_file
+import argparse
+import os
+import shutil
+
+def get_scale_perms():
+    scale_perm: List[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_single: List[int] = []
+    for i in range(4):
+        scale_perm_single.extend(
+            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+    return scale_perm, scale_perm_single
+
+def pack_cols(
+    q_w: torch.Tensor,
+    num_bits: int,
+    size_k: int,
+    size_n: int,
+):
+    assert q_w.shape == (size_k, size_n)
+
+    pack_factor = 32 // num_bits
+    assert size_n % pack_factor == 0
+
+    orig_device = q_w.device
+
+    q_w = q_w.cpu().numpy().astype(numpy.uint32)
+
+    q_res = numpy.zeros((size_k, size_n // pack_factor), dtype=numpy.uint32)
+
+    for i in range(pack_factor):
+        q_res |= q_w[:, i::pack_factor] << num_bits * i
+
+    q_res = torch.from_numpy(q_res.astype(numpy.int32)).to(orig_device)
+    q_res = q_res.contiguous()
+
+    return q_res
+
+def unpack_cols(
+    packed_q_w: torch.Tensor,
+    num_bits: int,
+    size_k: int,
+    size_n: int,
+):
+    pack_factor = 32 // num_bits
+    assert size_n % pack_factor == 0
+    assert packed_q_w.shape == (
+        size_k, size_n // pack_factor
+    ), "packed_q_w.shape = {} size_k = {}, size_n = {} pack_Factor = {}".format(
+        packed_q_w.shape, size_k, size_n, pack_factor)
+
+    orig_device = packed_q_w.device
+
+    packed_q_w_cpu = packed_q_w.cpu().numpy().astype(numpy.uint32)
+    q_res = numpy.zeros((size_k, size_n), dtype=numpy.uint32)
+
+    mask = (1 << num_bits) - 1
+    for i in range(pack_factor):
+        vals = packed_q_w_cpu & mask
+        packed_q_w_cpu >>= num_bits
+        q_res[:, i::pack_factor] = vals
+
+    q_res = torch.from_numpy(q_res.astype(numpy.int32)).to(orig_device)
+    q_res = q_res.contiguous()
+
+    return q_res
+
+def marlin_zero_points(zp: torch.Tensor, size_k: int, size_n: int,
+                       num_bits: int) -> torch.Tensor:
+    # Permute zero-points in a similar way to scales, but do not use the
+    # "single" permutation, since zero-points are applied on every MMA
+    scale_perm, _ = get_scale_perms()
+    zp = zp.reshape((-1, len(scale_perm)))[:, scale_perm]
+
+    # Interleave column dim (for the dequantize code) and pack it to int32
+    if num_bits == 4:
+        interleave = numpy.array([0, 2, 4, 6, 1, 3, 5, 7])
+    elif num_bits == 8:
+        interleave = numpy.array([0, 2, 1, 3])
+    else:
+        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+
+    zp = zp.reshape((-1, len(interleave)))[:, interleave].ravel()
+    zp = zp.reshape((-1, size_n)).contiguous()
+    zp = pack_cols(zp, num_bits, size_k, size_n)
+
+    return zp
+
+
+def awq_to_marlin_zero_points(q_zp_packed: torch.Tensor, size_k: int,
+                              size_n: int, num_bits: int) -> torch.Tensor:
+    # AWQ zero-points are quantized and packed on the column dim.
+    # In addition, the values are permuted based on dequantizer.
+    # Here we undo both of these, and then apply marlin permutation
+    # and pack it back.
+    q_zp = unpack_cols(q_zp_packed, num_bits, size_k, size_n)
+
+    # Undo interleaving (use argsort(..) to get inverse perm)
+    if num_bits == 4:
+        undo_interleave = numpy.argsort(numpy.array([0, 2, 4, 6, 1, 3, 5, 7]))
+    elif num_bits == 8:
+        undo_interleave = numpy.argsort(numpy.array([0, 2, 1, 3]))
+    else:
+        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+
+    q_zp = q_zp.reshape((-1, len(undo_interleave)))[:, undo_interleave].ravel()
+    q_zp = q_zp.reshape((-1, size_n)).contiguous()
+
+    marlin_zp = marlin_zero_points(q_zp, size_k, size_n, num_bits)
+    return marlin_zp
+
+
+
+def transform_file(src_folder, dst_folder, bits, method, group_size, nk):
+    """
+    Transform and save safetensors file.
+
+    Args:
+        src_folder (str): Path to the source safetensors file.
+        dst_folder (str): Path to the target safetensors file.
+    """
+    if not os.path.exists(src_folder):
+        raise FileNotFoundError(f"Source file not found: {src_folder}")
+    print(f"Loading source file: {src_folder}")
+    tgt_dict = {}
+
+    files = os.listdir(src_folder)
+    files = [k for k in files if k.endswith(".safetensors") and k.find("model") >= 0 ]
+    if len(files) > 1:
+        files = list(sorted(files, key=lambda x: int(x[6:11])))
+
+    for file in files:
+        f = os.path.join(src_folder, file)
+        dst_f = os.path.join(dst_folder, file)
+        src_dict = load_file(f)
+        tgt_dict = {}
+        for key, tensor in src_dict.items():
+            if key.endswith(".qzeros"):
+                print(f"Transforming tensor: {key}")
+                pack_factor = 32 // bits
+                qzeros = awq_to_marlin_zero_points(tensor, tensor.shape[0], tensor.shape[1] * pack_factor, bits)
+                tgt_dict[key] = qzeros
+            else:
+                tgt_dict[key] = tensor
+        save_file(tgt_dict, dst_f)
+    print("Transformation complete.")
+
+import json
+def load_json(json_path, fn):
+    json_fn = os.path.join(json_path, fn)
+    with open(json_fn, "r", encoding="utf-8") as f_json:
+        json_dict = json.load(f_json)
+    return json_dict
+
+def main():
+    """
+    Main function to handle command-line arguments for transforming safetensors files.
+    """
+    parser = argparse.ArgumentParser(description="Transform AWQ zeros to Marlin format.")
+    parser.add_argument(
+        "--src", 
+        type=str, 
+        required=False, 
+        help="Path to the source safetensors single file."
+    )
+    parser.add_argument(
+        "--dst", 
+        type=str, 
+        required=True, 
+        help="Path to save the transformed safetensors file."
+    )
+
+    parser.add_argument(
+        "--bits", 
+        type=int, 
+        required=True, 
+        default=8,
+        help="Weight bits (default 8 bit for w8a16)."
+    )
+
+    parser.add_argument(
+        "--method", 
+        type=str, 
+        required=True, 
+        default="gptq",
+        help="Weight format (gptq or awq)."
+    )
+
+    parser.add_argument(
+        "--group", 
+        type=int, 
+        required=False, 
+        default=128,
+        help="Group size."
+    )
+
+    parser.add_argument(
+        "--nk", 
+        type=bool, 
+        required=False, 
+        default=True,
+        help="Output nk format (default nk format)."
+    )
+
+    args = parser.parse_args()
+    assert args.src != "" and os.path.exists(args.src), "Must provide src folder (or src folder not found)!"
+    assert args.dst != "" and not os.path.exists(args.dst), "Must provide dst folder (or dst folder must be empty)!"
+
+    assert args.bits == 8 or args.bits == 4, "only 4-bit and 8-bit models are supported!"
+    assert args.group == 128 or args.group == 64, "only group size of 128 is supported!"
+    assert args.method == "awq" or args.method == "gptq", "only awq and gptq quantization methods are supported!"
+    assert ((args.bits == 8 or args.bits == 4) and args.method == "gptq") or (args.bits == 4 and args.method == "awq"), "8-bit gptq, 4-bit gptq and 4-bit awq only!"
+
+    try:
+        src_directory = args.src
+        if not os.path.exists(args.dst):
+            os.makedirs(args.dst)
+        if os.path.exists(src_directory + "/model.safetensors.index.json"):
+            shutil.copy2(src_directory + "/model.safetensors.index.json", args.dst)
+        transform_file(args.src, args.dst, args.bits, args.method, args.group, args.nk)
+        shutil.copy2(src_directory + "/config.json", args.dst)
+        shutil.copy2(src_directory + "/tokenizer.json", args.dst)
+        shutil.copy2(src_directory + "/tokenizer_config.json", args.dst)
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/kernels/src/ffi.rs
+++ b/kernels/src/ffi.rs
@@ -97,7 +97,7 @@ extern "C" {
         m: c_int,
         k: c_int,
         n: c_int,
-        workspace: *const c_void, 
+        workspace: *const c_void,
         groupsize: c_int,
         stream: i64,
     );
@@ -127,7 +127,7 @@ extern "C" {
         m: c_int,
         k: c_int,
         n: c_int,
-        workspace: *const c_void, 
+        workspace: *const c_void,
         groupsize: c_int,
         stream: i64,
     );

--- a/kernels/src/ffi.rs
+++ b/kernels/src/ffi.rs
@@ -76,11 +76,13 @@ extern "C" {
         inputs: *const c_void,
         weight: *const c_int,
         scales: *const c_void,
+        zeros: *const c_void,
+        g_idx: *const c_void,
         out: *mut c_void,
         m: c_int,
         k: c_int,
         n: c_int,
-        workspace: *const c_void, //tensor with at least `n / 128 * max_par` entries that are all zero
+        workspace: *const c_void,
         groupsize: c_int,
         stream: i64,
     );
@@ -89,20 +91,60 @@ extern "C" {
         inputs: *const c_void,
         weight: *const c_int,
         scales: *const c_void,
+        zeros: *const c_void,
+        g_idx: *const c_void,
         out: *mut c_void,
         m: c_int,
         k: c_int,
         n: c_int,
-        workspace: *const c_void, //tensor with at least `n / 128 * max_par` entries that are all zero
+        workspace: *const c_void, 
         groupsize: c_int,
         stream: i64,
     );
 
+    pub fn marlin_awq_4bit_f16(
+        inputs: *const c_void,
+        weight: *const c_int,
+        scales: *const c_void,
+        zeros: *const c_void,
+        g_idx: *const c_void,
+        out: *mut c_void,
+        m: c_int,
+        k: c_int,
+        n: c_int,
+        workspace: *const c_void,
+        groupsize: c_int,
+        stream: i64,
+    );
+
+    pub fn marlin_awq_4bit_bf16(
+        inputs: *const c_void,
+        weight: *const c_int,
+        scales: *const c_void,
+        zeros: *const c_void,
+        g_idx: *const c_void,
+        out: *mut c_void,
+        m: c_int,
+        k: c_int,
+        n: c_int,
+        workspace: *const c_void, 
+        groupsize: c_int,
+        stream: i64,
+    );
     pub fn gptq_repack(
         weight: *const c_void,
         result: *const c_void,
         m: c_int,
         n: c_int,
+        stream: i64,
+    );
+
+    pub fn awq_repack(
+        weight: *const c_void,
+        result: *const c_void,
+        k: c_int,
+        n: c_int,
+        bits: c_int,
         stream: i64,
     );
 

--- a/kernels/src/marlin/marlin.cuh
+++ b/kernels/src/marlin/marlin.cuh
@@ -17,20 +17,23 @@ namespace marlin {
 // 8 warps are a good choice since every SM has 4 schedulers and having more
 // than 1 warp per schedule allows some more latency hiding. At the same time,
 // we want relatively few warps to have many registers per warp and small tiles.
-
+static constexpr int default_threads = 256;
 static constexpr int repack_threads = 256;
 static constexpr int repack_stages = 8;
 static constexpr int min_thread_n = 64;
 static constexpr int min_thread_k = 64;
-
+static constexpr int max_thread_n = 256;
 static constexpr int tile_size = 16;
 static constexpr int max_par = 16;
 static constexpr int tile_k_size = tile_size;
 static constexpr int tile_n_size = tile_k_size * 4;
+static constexpr int pipe_stages = 4;
 
 __device__ inline constexpr int ceildiv(int a, int b) {
   return (a + b - 1) / b;
 }
+
+constexpr int div_ceil(int a, int b) { return (a + b - 1) / b; }
 
 // Predicated asynchronous global->shared copy; used for inputs A where we apply
 // predication to handle batchsizes that are not multiples of 16.
@@ -114,5 +117,15 @@ struct Vec {
 };
 
 using I4 = Vec<int, 4>;
+
+
+enum ScalarTypeID {
+  //gptq
+   kU4B8,
+ kU8B128,
+//awq
+  kU4,
+  kU8,
+};
 
 }  // namespace marlin

--- a/kernels/src/marlin_cuda_kernel.cu
+++ b/kernels/src/marlin_cuda_kernel.cu
@@ -75,16 +75,18 @@ __device__ inline int lop3(int a, int b, int c) {
 }
 
 
-template <typename scalar_t>
+template <typename scalar_t, ScalarTypeID w_type_id>
 __device__ inline typename ScalarType<scalar_t>::FragB dequant(int q);
 
 // Efficiently dequantize an int32 value into a full B-fragment of 4 fp16
 // values. We mostly follow the strategy in the link below, with some small
 // changes:
 // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+
+//gptq dequant
 template <>
 __device__ inline typename ScalarType<half>::FragB
-      dequant<half>(int q) {
+      dequant<half, ScalarTypeID::kU4B8>(int q) {
   const int LO = 0x000f000f;
   const int HI = 0x00f000f0;
   const int EX = 0x64006400;
@@ -107,7 +109,7 @@ __device__ inline typename ScalarType<half>::FragB
 
 template <>
 __device__ inline typename ScalarType<nv_bfloat16>::FragB
-    dequant<nv_bfloat16>(int q) {
+    dequant<nv_bfloat16, ScalarTypeID::kU4B8>(int q) {
   static constexpr uint32_t MASK = 0x000f000f;
   static constexpr uint32_t EX = 0x43004300;
 
@@ -130,6 +132,53 @@ __device__ inline typename ScalarType<nv_bfloat16>::FragB
   return frag_b;
 }
 
+//awq dequant
+template <>
+__device__ inline typename ScalarType<half>::FragB
+dequant<half, ScalarTypeID::kU4>(int q) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3 < (0xf0 & 0xcc) | 0xaa > (q, LO, EX);
+  int hi = lop3 < (0xf0 & 0xcc) | 0xaa > (q, HI, EX);
+
+  const int SUB = 0x64006400;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd400d400;
+  typename ScalarType<half>::FragB frag_b;
+  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo),
+                      *reinterpret_cast<const half2*>(&SUB));
+  frag_b[1] = __hfma2(*reinterpret_cast<half2*>(&hi),
+                      *reinterpret_cast<const half2*>(&MUL),
+                      *reinterpret_cast<const half2*>(&ADD));
+  return frag_b;
+}
+
+template <>
+__device__ inline typename ScalarType<nv_bfloat16>::FragB
+dequant<nv_bfloat16, ScalarTypeID::kU4>(int q) {
+  static constexpr uint32_t MASK = 0x000f000f;
+  static constexpr uint32_t EX = 0x43004300;
+
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+
+  int lo = lop3 < (0xf0 & 0xcc) | 0xaa > (q, MASK, EX);
+  q >>= 4;
+  int hi = lop3 < (0xf0 & 0xcc) | 0xaa > (q, MASK, EX);
+
+  typename ScalarType<nv_bfloat16>::FragB frag_b;
+  static constexpr uint32_t MUL = 0x3F803F80;
+  static constexpr uint32_t ADD = 0xC300C300;
+
+  frag_b[0] = __hfma2(*reinterpret_cast<nv_bfloat162*>(&lo),
+                      *reinterpret_cast<const nv_bfloat162*>(&MUL),
+                      *reinterpret_cast<const nv_bfloat162*>(&ADD));
+  frag_b[1] = __hfma2(*reinterpret_cast<nv_bfloat162*>(&hi),
+                      *reinterpret_cast<const nv_bfloat162*>(&MUL),
+                      *reinterpret_cast<const nv_bfloat162*>(&ADD));
+  return frag_b;
+}
 // Multiply dequantized values by the corresponding quantization scale; used
 // only for grouped quantization.
 template <typename scalar_t>
@@ -143,6 +192,39 @@ __device__ inline void scale(typename ScalarType<scalar_t>::FragB& frag_b,
   frag_b[1] = __hmul2(frag_b[1], s);
 }
 
+
+template <typename scalar_t>
+__device__ inline void sub_zp(typename ScalarType<scalar_t>::FragB& frag_b,
+                              typename ScalarType<scalar_t>::scalar_t2& frag_zp,
+                              int i) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 zp =
+      ScalarType<scalar_t>::num2num2(reinterpret_cast<scalar_t*>(&frag_zp)[i]);
+  frag_b[0] = __hsub2(frag_b[0], zp);
+  frag_b[1] = __hsub2(frag_b[1], zp);
+}
+
+// Same as above, but for act_order (each K is multiplied individually)
+template <typename scalar_t>
+__device__ inline void scale4(typename ScalarType<scalar_t>::FragB& frag_b,
+                              typename ScalarType<scalar_t>::FragS& frag_s_1,
+                              typename ScalarType<scalar_t>::FragS& frag_s_2,
+                              typename ScalarType<scalar_t>::FragS& frag_s_3,
+                              typename ScalarType<scalar_t>::FragS& frag_s_4,
+                              int i) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 s_val_1_2;
+  s_val_1_2.x = reinterpret_cast<scalar_t*>(&frag_s_1)[i];
+  s_val_1_2.y = reinterpret_cast<scalar_t*>(&frag_s_2)[i];
+
+  scalar_t2 s_val_3_4;
+  s_val_3_4.x = reinterpret_cast<scalar_t*>(&frag_s_3)[i];
+  s_val_3_4.y = reinterpret_cast<scalar_t*>(&frag_s_4)[i];
+
+  frag_b[0] = __hmul2(frag_b[0], s_val_1_2);
+  frag_b[1] = __hmul2(frag_b[1], s_val_3_4);
+}
+
 template <typename scalar_t,
           const int threads,          // number of threads in a threadblock
           const int thread_m_blocks,  // number of 16x16 blocks in the m
@@ -152,18 +234,26 @@ template <typename scalar_t,
           const int thread_k_blocks,  // same for k dimension (reduction)
           const int stages,  // number of stages for the async global->shared
                              // fetch pipeline
-          const int group_blocks = -1  // number of consecutive 16x16 blocks
+          const int group_blocks = -1,  // number of consecutive 16x16 blocks
+          const ScalarTypeID w_type_id,
+          const bool has_act_order,     // whether act_order is enabled
+          const bool has_zp,            // whether zero-points are enabled
+          const int num_bits
                                        // with a separate quantization scale
           >
 __global__ void Marlin(
     const int4* __restrict__ A,  // fp16 input matrix of shape mxk
     const int4* __restrict__ B,  // 4bit quantized weight matrix of shape kxn
     int4* __restrict__ C,        // fp16 output buffer of shape mxn
-    const int4* __restrict__ s,  // fp16 quantization scales of shape
+    const int4* __restrict__ scales_ptr,  // fp16 quantization scales of shape
+    const int4* __restrict__ zp_ptr,      // 4bit packed zero-points of shape
+                                          // (k/groupsize)x(n/pack_factor)
+    const int* __restrict__ g_idx,        // int32 group indices of shape k
                                  // (k/groupsize)xn
     int prob_m,                  // batch dimension m
     int prob_n,                  // output dimension n
     int prob_k,                  // reduction dimension k
+    int num_groups,
     int* locks  // extra global storage for barrier synchronization
 ) {
   // Each threadblock processes one "stripe" of the B matrix with (roughly) the
@@ -183,6 +273,12 @@ __global__ void Marlin(
   using FragB = typename ScalarType<scalar_t>::FragB;
   using FragC = typename ScalarType<scalar_t>::FragC;
   using FragS = typename ScalarType<scalar_t>::FragS;
+  using FragZP = typename ScalarType<scalar_t>::FragZP;
+
+  const bool is_zp_float = false;
+  // static constexpr auto w_type = vllm::ScalarType::from_id(w_type_id);
+
+  constexpr int pack_factor = 32 / num_bits;
 
   // For larger GEMMs we run multiple batchsize 64 versions in parallel for a
   // better partitioning with less reductions
@@ -194,13 +290,17 @@ __global__ void Marlin(
 
   int k_tiles = prob_k / 16 / thread_k_blocks;
   int n_tiles = prob_n / 16 / thread_n_blocks;
-  int iters = ceildiv(k_tiles * n_tiles * parallel, gridDim.x);
-  // Ensure that the number of tiles in each stripe is a multiple of the
-  // groupsize; this avoids an annoying special case where a stripe starts in
-  // the middle of group.
-  if (group_blocks != -1)
-    iters = (group_blocks / thread_k_blocks) *
-            ceildiv(iters, (group_blocks / thread_k_blocks));
+  int iters = div_ceil(k_tiles * n_tiles * parallel, gridDim.x);
+
+  if constexpr (!has_act_order && group_blocks != -1) {
+    if (group_blocks >= thread_k_blocks) {
+      // Ensure that the number of tiles in each stripe is a multiple of the
+      // groupsize; this avoids an annoying special case where a stripe starts
+      // in the middle of group.
+      iters = (group_blocks / thread_k_blocks) *
+              div_ceil(iters, (group_blocks / thread_k_blocks));
+    }
+  }
 
   int slice_row = (iters * blockIdx.x) % k_tiles;
   int slice_col_par = (iters * blockIdx.x) / k_tiles;
@@ -211,6 +311,8 @@ __global__ void Marlin(
   int slice_idx;  // index of threadblock in current slice; numbered bottom to
                   // top
 
+  int par_id = 0;
+
   // We can easily implement parallel problem execution by just remapping
   // indices and advancing global pointers
   if (slice_col_par >= n_tiles) {
@@ -218,6 +320,7 @@ __global__ void Marlin(
     C += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_n / 8;
     locks += (slice_col_par / n_tiles) * n_tiles;
     slice_col = slice_col_par % n_tiles;
+    par_id = slice_col_par / n_tiles;
   }
 
   // Compute all information about the current slice which is required for
@@ -248,48 +351,73 @@ __global__ void Marlin(
       C += 16 * thread_m_blocks * prob_n / 8;
       locks += n_tiles;
       slice_col = 0;
+      par_id++;
     }
   };
   init_slice();
 
-  int a_gl_stride = prob_k / 8;  // stride of the A matrix in global memory
-  // We typically use `constexpr` to indicate that this value is a compile-time
-  // constant
-  constexpr int a_sh_stride =
-      16 * thread_k_blocks / 8;  // stride of an A matrix tile in shared memory
-  constexpr int a_gl_rd_delta_o =
-      16 * thread_k_blocks /
-      8;  // delta between subsequent A tiles in global memory
-  int a_gl_rd_delta_i =
-      a_gl_stride *
-      (threads / a_gl_rd_delta_o);  // between subsequent accesses within a tile
-  constexpr int a_sh_wr_delta =
-      a_sh_stride *
-      (threads / a_gl_rd_delta_o);  // between shared memory writes
-  constexpr int a_sh_rd_delta_o =
-      2 * ((threads / 32) /
-           (thread_n_blocks / 4));  // between shared memory tile reads
-  constexpr int a_sh_rd_delta_i =
-      a_sh_stride * 16;  // within a shared memory tile
-  constexpr int a_sh_stage =
-      a_sh_stride * (16 * thread_m_blocks);  // overall size of a tile
-  constexpr int a_sh_wr_iters =
-      ceildiv(a_sh_stage,
-              a_sh_wr_delta);  // number of shared write iterations for a tile
+  // A sizes/strides
 
-  int b_gl_stride = 16 * prob_n / 32;
-  constexpr int b_sh_stride = 32 * thread_n_blocks / 4;
+  // stride of the A matrix in global memory
+  int a_gl_stride = prob_k / 8;
+  // stride of an A matrix tile in shared memory
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8;
+  // delta between subsequent A tiles in global memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8;
+  // between subsequent accesses within a tile
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o);
+  // between shared memory writes
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o);
+  // between shared memory tile reads
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4));
+  // within a shared memory tile
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16;
+  // overall size of a tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks);
+  // number of shared write iterations for a tile
+  constexpr int a_sh_wr_iters = div_ceil(a_sh_stage, a_sh_wr_delta);
+
+  // B sizes/strides
+  int b_gl_stride = 16 * prob_n / (pack_factor * 4);
+  constexpr int b_sh_stride = ((thread_n_blocks * 16) * 16 / pack_factor) / 4;
+  constexpr int b_thread_vecs = num_bits == 4 ? 1 : 2;
+  constexpr int b_sh_stride_threads = b_sh_stride / b_thread_vecs;
+
   int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
-  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride);
-  constexpr int b_sh_wr_delta = threads;
-  constexpr int b_sh_rd_delta = threads;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride_threads);
+  constexpr int b_sh_wr_delta = threads * b_thread_vecs;
+  constexpr int b_sh_rd_delta = threads * b_thread_vecs;
   constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
   constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
 
+  // Scale sizes/strides without act_order
   int s_gl_stride = prob_n / 8;
   constexpr int s_sh_stride = 16 * thread_n_blocks / 8;
-  constexpr int s_sh_stage = s_sh_stride;
+  constexpr int s_tb_groups =
+      !has_act_order && group_blocks != -1 && group_blocks < thread_k_blocks
+          ? thread_k_blocks / group_blocks
+          : 1;
+  constexpr int s_sh_stage = s_tb_groups * s_sh_stride;
   int s_gl_rd_delta = s_gl_stride;
+
+  // Scale size/strides with act_order
+  constexpr int tb_k = 16 * thread_k_blocks;
+  constexpr int g_idx_stage = has_act_order ? (tb_k * sizeof(int)) / 16 : 0;
+  // constexpr int act_s_row_stride      = 1;
+  // int           act_s_col_stride      = act_s_row_stride * num_groups;
+  int act_s_col_stride = 1;
+  int act_s_col_warp_stride = act_s_col_stride * 8;
+  int tb_n_warps = thread_n_blocks / 4;
+  int act_s_col_tb_stride = act_s_col_warp_stride * tb_n_warps;
+
+  // Zero-points sizes/strides
+  int zp_gl_stride = is_zp_float ? prob_n / 8 : (prob_n / pack_factor) / 4;
+  constexpr int zp_sh_stride = is_zp_float
+                                   ? 16 * thread_n_blocks / 8
+                                   : ((16 * thread_n_blocks) / pack_factor) / 4;
+  constexpr int zp_tb_groups = s_tb_groups;
+  constexpr int zp_sh_stage = has_zp ? zp_tb_groups * zp_sh_stride : 0;
+  int zp_gl_rd_delta = zp_gl_stride;
 
   // Global A read index of current thread.
   int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) +
@@ -303,26 +431,75 @@ __global__ void Marlin(
       a_sh_stride * ((threadIdx.x % 32) % 16) + (threadIdx.x % 32) / 16;
   a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
 
-  int b_gl_rd =
-      b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride_threads) +
+                (threadIdx.x % b_sh_stride_threads) * b_thread_vecs;
   b_gl_rd += b_sh_stride * slice_col;
   b_gl_rd += b_gl_rd_delta_o * slice_row;
-  int b_sh_wr = threadIdx.x;
-  int b_sh_rd = threadIdx.x;
+  auto b_sh_wr = threadIdx.x * b_thread_vecs;
+  auto b_sh_rd = threadIdx.x * b_thread_vecs;
 
-  int s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+  // For act_order
+  constexpr int k_iter_size = tb_k / b_sh_wr_iters;
+  int slice_k_start = tb_k * slice_row;
+  int slice_k_finish = slice_k_start + tb_k * slice_iters;
+  int slice_k_start_shared_fetch = slice_k_start;
+  int slice_n_offset = act_s_col_tb_stride * slice_col;
+
+  // No act_order
+  int s_gl_rd;
+  if constexpr (!has_act_order) {
+    if constexpr (group_blocks == -1) {
+      s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+    } else {
+      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
                 s_sh_stride * slice_col + threadIdx.x;
-  int s_sh_wr = threadIdx.x;
-  int s_sh_rd;
+    }
+  }
+  auto s_sh_wr = threadIdx.x;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
+
+  // Zero-points
+  int zp_gl_rd;
+  if constexpr (has_zp) {
+    if constexpr (group_blocks == -1) {
+      zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+    } else {
+      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) +
+                 zp_sh_stride * slice_col + threadIdx.x;
+    }
+  }
+  auto zp_sh_wr = threadIdx.x;
+  bool zp_sh_wr_pred = threadIdx.x < zp_sh_stride;
+
   // We use a different scale layout for grouped and column-wise quantization as
   // we scale a `half2` tile in column-major layout in the former and in
   // row-major in the latter case.
-  if (group_blocks != -1)
+  int s_sh_rd;
+  if constexpr (group_blocks != -1)
     s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
               (threadIdx.x % 32) / 4;
   else
     s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
               (threadIdx.x % 32) % 4;
+
+  // Zero-points have the same read layout as the scales
+  // (without column-wise case)
+  constexpr int num_col_threads = 8;
+  constexpr int num_row_threads = 4;
+  constexpr int num_ints_per_thread = 8 / pack_factor;
+  int zp_sh_rd;
+  if constexpr (has_zp) {
+    if constexpr (is_zp_float) {
+      if constexpr (group_blocks != -1) {
+        zp_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
+                   (threadIdx.x % 32) / 4;
+      }
+    } else {
+      zp_sh_rd = num_ints_per_thread * num_col_threads *
+                     ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
+                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
+    }
+  }
 
   // Precompute which thread should not read memory in which iterations; this is
   // needed if there are more threads than required for a certain tilesize or
@@ -331,7 +508,6 @@ __global__ void Marlin(
   #pragma unroll
   for (int i = 0; i < a_sh_wr_iters; i++)
     a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
-  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
 
   // To ensure that writing and reading A tiles to/from shared memory, the
   // latter in fragment format, is fully bank conflict free, we need to use a
@@ -372,12 +548,20 @@ __global__ void Marlin(
   // Shared memory storage for global fetch pipelines.
   int4* sh_a = sh;
   int4* sh_b = sh_a + (stages * a_sh_stage);
-  int4* sh_s = sh_b + (stages * b_sh_stage);
+  int4* sh_g_idx = sh_b + (stages * b_sh_stage);
+  int4* sh_zp = sh_g_idx + (stages * g_idx_stage);
+  int4* sh_s = sh_zp + (stages * zp_sh_stage);
+  int4* sh_red = sh_s + (stages * s_sh_stage);
+
   // Register storage for double buffer of shared memory reads.
   FragA frag_a[2][thread_m_blocks];
-  I4 frag_b_quant[2];
+  I4 frag_b_quant[2][b_thread_vecs];
   FragC frag_c[thread_m_blocks][4][2];
-  FragS frag_s[2][4];
+  FragS frag_s[2][4];                    // No act-order
+  FragS act_frag_s[2][4][4];             // For act-order
+  int frag_qzp[2][num_ints_per_thread];  // Zero-points
+  FragZP frag_zp;                        // Zero-points in fp16
+  FragZP frag_zpf[2];                    // Zero-points in fp16 in HQQ
 
   // Zero accumulators.
   auto zero_accums = [&]() {
@@ -386,6 +570,43 @@ __global__ void Marlin(
       reinterpret_cast<float*>(frag_c)[i] = 0;
   };
 
+  int sh_first_group_id = -1;
+  int sh_num_groups = -1;
+  constexpr int sh_max_num_groups = 32;
+
+  auto fetch_scales_to_shared = [&](bool is_async, int first_group_id,
+                                    int last_group_id) {
+    sh_first_group_id = first_group_id;
+    sh_num_groups = last_group_id - first_group_id + 1;
+
+    if (sh_num_groups < sh_max_num_groups) {
+      sh_num_groups = sh_max_num_groups;
+    }
+
+    if (sh_first_group_id + sh_num_groups > num_groups) {
+      sh_num_groups = num_groups - sh_first_group_id;
+    }
+
+    int row_offset = first_group_id * s_gl_stride;
+
+    if (is_async) {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          cp_async4_pred(&sh_s[(i * s_sh_stride) + threadIdx.x],
+                         &scales_ptr[row_offset + (i * s_gl_stride) +
+                                     slice_n_offset + threadIdx.x]);
+        }
+      }
+    } else {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          sh_s[(i * s_sh_stride) + threadIdx.x] =
+              scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset +
+                         threadIdx.x];
+        }
+      }
+    }
+  };
   // Asynchronously fetch the next A, B and s tile from global to the next
   // shared memory pipeline location.
   auto fetch_to_shared = [&](int pipe, int a_off, bool pred = true) {
@@ -401,24 +622,84 @@ __global__ void Marlin(
       int4* sh_b_stage = sh_b + b_sh_stage * pipe;
   #pragma unroll
       for (int i = 0; i < b_sh_wr_iters; i++) {
-        cp_async4(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr], B_ptr[i]);
+  #pragma unroll
+        for (int j = 0; j < b_thread_vecs; j++) {
+          cp_async4(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr + j], B_ptr[i] + j);
+        }
+
         B_ptr[i] += b_gl_rd_delta_o;
       }
-      // Only fetch scales if this tile starts a new group
-      if constexpr (group_blocks != -1) {
-        // This assumes group_blocks >= thread_k_blocks
-        // and would need to be modified to support smaller groups.
-        static_assert(group_blocks >= thread_k_blocks);
-        if (pipe % (group_blocks / thread_k_blocks) == 0) {
+
+      if constexpr (has_act_order) {
+        // Fetch g_idx thread-block portion
+        int full_pipe = a_off;
+        int cur_k = slice_k_start_shared_fetch + tb_k * full_pipe;
+        if (cur_k < prob_k && cur_k < slice_k_finish) {
+          int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+
+          int4 const* cur_g_idx_stage_ptr =
+              reinterpret_cast<int4 const*>(&g_idx[cur_k]);
+
+          if (threadIdx.x < g_idx_stage) {
+            cp_async4_pred(&sh_g_idx_stage[threadIdx.x],
+                           &cur_g_idx_stage_ptr[threadIdx.x]);
+          }
+        }
+      } else {
+        if constexpr (group_blocks != -1) {
           int4* sh_s_stage = sh_s + s_sh_stage * pipe;
-          if (s_sh_wr_pred) cp_async4(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
-          s_gl_rd += s_gl_rd_delta;
+
+          if constexpr (group_blocks >= thread_k_blocks) {
+            if (s_sh_wr_pred) {
+              cp_async4(&sh_s_stage[s_sh_wr], &scales_ptr[s_gl_rd]);
+            }
+            // Only fetch scales if this tile starts a new group
+            if ((pipe + 1) % (group_blocks / thread_k_blocks) == 0) {
+              s_gl_rd += s_gl_rd_delta;
+            }
+          } else {
+            for (int i = 0; i < s_tb_groups; i++) {
+              if (s_sh_wr_pred) {
+                cp_async4(&sh_s_stage[i * s_sh_stride + s_sh_wr],
+                          &scales_ptr[s_gl_rd]);
+              }
+              s_gl_rd += s_gl_rd_delta;
+            }
+          }
+        }
+
+        if constexpr (has_zp && group_blocks != -1) {
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+          if constexpr (group_blocks >= thread_k_blocks) {
+            // Only fetch zero-points if this tile starts a new group
+            if (pipe % (group_blocks / thread_k_blocks) == 0) {
+              if (zp_sh_wr_pred) {
+                cp_async4(&sh_zp_stage[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+              }
+              zp_gl_rd += zp_gl_rd_delta;
+            }
+          } else {
+            for (int i = 0; i < zp_tb_groups; i++) {
+              if (zp_sh_wr_pred) {
+                cp_async4(&sh_zp_stage[i * zp_sh_stride + zp_sh_wr],
+                          &zp_ptr[zp_gl_rd]);
+              }
+              zp_gl_rd += zp_gl_rd_delta;
+            }
+          }
         }
       }
     }
     // Insert a fence even when we are winding down the pipeline to ensure that
     // waiting is also correct at this point.
     cp_async_fence();
+  };
+
+  auto fetch_zp_to_shared = [&]() {
+    if (zp_sh_wr_pred) {
+      cp_async4(&sh_zp[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+    }
   };
 
   // Wait until the next thread tile has been loaded to shared memory.
@@ -434,42 +715,265 @@ __global__ void Marlin(
   // Load the next sub-tile from the current location in the shared memory pipe
   // into the current register buffer.
   auto fetch_to_registers = [&](int k, int pipe) {
-    // It may seem inefficient that we reload the groups for every sub-tile;
-    // however, this does not seem to be a significant bottleneck, while some
-    // theoretically better attempts have lead to bad instruction ordering by
-    // the compiler and correspondingly a noticeable drop in performance.
-    if constexpr (group_blocks != -1) {
-      // This assumes group_blocks >= thread_k_blocks
-      // and would need to be modified to support smaller groups.
-      static_assert(group_blocks >= thread_k_blocks);
-      int4* sh_s_stage =
-          sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) *
-                               (pipe / (group_blocks / thread_k_blocks)));
-      reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
-    }
     int4* sh_a_stage = sh_a + a_sh_stage * pipe;
   #pragma unroll
     for (int i = 0; i < thread_m_blocks; i++)
-      ldsm4<scalar_t>(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+      ldsm4<scalar_t>(frag_a[k % 2][i],
+                      &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
     int4* sh_b_stage = sh_b + b_sh_stage * pipe;
-    frag_b_quant[k % 2] = *reinterpret_cast<I4*>(
-        &sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd]);
+
+  #pragma unroll
+    for (int i = 0; i < b_thread_vecs; i++) {
+      frag_b_quant[k % 2][i] = *reinterpret_cast<I4*>(
+          &sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd + i]);
+    }
+  };
+
+  bool is_same_group[stages];
+  int same_group_id[stages];
+
+  auto init_same_group = [&](int pipe) {
+    if constexpr (!has_act_order) {
+      is_same_group[pipe] = false;
+      same_group_id[pipe] = 0;
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    int group_id_1 = sh_g_idx_int_ptr[0];
+    int group_id_2 = sh_g_idx_int_ptr[tb_k - 1];
+
+    is_same_group[pipe] = group_id_1 == group_id_2;
+    same_group_id[pipe] = group_id_1;
+  };
+
+  auto fetch_scales_to_registers = [&](int k, int full_pipe) {
+    int pipe = full_pipe % stages;
+
+    if constexpr (!has_act_order) {
+      // No act-order case
+      if constexpr (group_blocks != -1) {
+        if constexpr (group_blocks >= thread_k_blocks) {
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+          reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+        } else {
+          auto warp_id = threadIdx.x / 32;
+          int n_warps = thread_n_blocks / 4;
+
+          int warp_row = warp_id / n_warps;
+
+          int cur_k = warp_row * 16;
+          cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+          int k_blocks = cur_k / 16;
+          int cur_group_id = k_blocks / group_blocks;
+
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+
+          reinterpret_cast<int4*>(&frag_s[k % 2])[0] =
+              sh_s_stage[s_sh_rd + cur_group_id * s_sh_stride];
+        }
+      }
+
+      return;
+    }
+
+    // Act-order case
+
+    // Determine K of the "current" thread-block
+    int cur_k = slice_k_start + tb_k * full_pipe;
+    if (cur_k >= prob_k || cur_k >= slice_k_finish) {
+      return;
+    }
+
+    // Reset (to current thread-block) since we read g_idx portion from the
+    // shared memory
+    cur_k = 0;
+
+    // Progress to current iteration
+    cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+    // Determine "position" inside the thread-block (based on warp and
+    // thread-id)
+    auto warp_id = threadIdx.x / 32;
+    int n_warps =
+        thread_n_blocks / 4;  // Each warp processes 4 16-size tiles over N
+
+    int warp_row = warp_id / n_warps;
+    int warp_col = warp_id % n_warps;
+
+    cur_k += warp_row * 16;
+
+    auto th_id = threadIdx.x % 32;
+    cur_k += (th_id % 4) * 2;  // Due to tensor-core layout for fp16 B matrix
+
+    int s_col_shift =
+        /*slice_n_offset +*/ (act_s_col_warp_stride * warp_col) +
+        (th_id / 4) * act_s_col_stride;
+
+    if (is_same_group[pipe]) {
+      if (k % 2 == 0) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            sh_s[(same_group_id[pipe] - sh_first_group_id) * s_sh_stride +
+                 s_col_shift];
+      } else {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            *(reinterpret_cast<int4*>(&(act_frag_s[(k - 1) % 2][0][0])));
+      }
+
+      for (int i = 1; i < 4; i++) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
+            *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0])));
+      }
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    constexpr int k_frag_offsets[4] = {0, 1, 8,
+                                       9};  // Tensor core offsets per thread
+
+  #pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int actual_k = cur_k + k_frag_offsets[i];
+
+      int group_id = sh_g_idx_int_ptr[actual_k];
+      int rel_group_id = group_id - sh_first_group_id;
+
+      *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
+          sh_s[rel_group_id * s_sh_stride + s_col_shift];
+    }
+  };
+
+  auto fetch_zp_to_registers = [&](int k, int full_pipe) {
+    // This code does not handle group_blocks == 0,
+    // which signifies act_order.
+    // has_zp implies AWQ, which doesn't have act_order,
+    static_assert(!has_zp || group_blocks != 0);
+
+    if constexpr (has_zp) {
+      int pipe = full_pipe % stages;
+
+      if constexpr (group_blocks == -1) {
+        for (int i = 0; i < num_ints_per_thread; i++) {
+          frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp))[zp_sh_rd + i];
+        }
+
+      } else if constexpr (group_blocks >= thread_k_blocks) {
+        int4* sh_zp_stage =
+            sh_zp + zp_sh_stage * ((group_blocks / thread_k_blocks) *
+                                   (pipe / (group_blocks / thread_k_blocks)));
+        for (int i = 0; i < num_ints_per_thread; i++) {
+          frag_qzp[k % 2][i] =
+              (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+        }
+      } else {
+        auto warp_id = threadIdx.x / 32;
+        int n_warps = thread_n_blocks / 4;
+
+        int warp_row = warp_id / n_warps;
+
+        int cur_k = warp_row * 16;
+        cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+        int k_blocks = cur_k / 16;
+        int cur_group_id = 0;
+
+        // Suppress bogus and persistent divide-by-zero warning
+  #pragma nv_diagnostic push
+  #pragma nv_diag_suppress divide_by_zero
+        cur_group_id = k_blocks / group_blocks;
+  #pragma nv_diagnostic pop
+
+        int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+        sh_zp_stage += cur_group_id * zp_sh_stride;
+
+        for (int i = 0; i < num_ints_per_thread; i++) {
+          frag_qzp[k % 2][i] =
+              (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+        }
+      }
+    }
   };
 
   // Execute the actual tensor core matmul of a sub-tile.
   auto matmul = [&](int k) {
+    if constexpr (has_zp) {
+      FragB frag_zp_0;
+      FragB frag_zp_1;
+      int zp_quant_0, zp_quant_1;
+
+      if constexpr (num_bits == 4) {
+        zp_quant_0 = frag_qzp[k % 2][0];
+        zp_quant_1 = zp_quant_0 >> 8;
+      } else {
+        static_assert(num_bits == 8);
+        zp_quant_0 = frag_qzp[k % 2][0];
+        zp_quant_1 = frag_qzp[k % 2][1];
+      }
+
+      frag_zp_0 = dequant<scalar_t, w_type_id>(zp_quant_0);
+      frag_zp_1 = dequant<scalar_t, w_type_id>(zp_quant_1);
+
+      frag_zp[0] = frag_zp_0[0];
+      frag_zp[1] = frag_zp_0[1];
+      frag_zp[2] = frag_zp_1[0];
+      frag_zp[3] = frag_zp_1[1];
+    }
+
   // We have the m dimension as the inner loop in order to encourage overlapping
   // dequantization and matmul operations.
   #pragma unroll
     for (int j = 0; j < 4; j++) {
-      int b_quant = frag_b_quant[k % 2][j];
-      int b_quant_shift = b_quant >> 8;
-      FragB frag_b0 = dequant<scalar_t>(b_quant);
-      // If there are no groups, we can just scale the final output once and can
-      // avoid doing so for each weight.
-      if (group_blocks != -1) scale<scalar_t>(frag_b0, frag_s[k % 2][j], 0);
-      FragB frag_b1 = dequant<scalar_t>(b_quant_shift);
-      if (group_blocks != -1) scale<scalar_t>(frag_b1, frag_s[k % 2][j], 1);
+      FragB frag_b0;
+      FragB frag_b1;
+      int b_quant_0, b_quant_1;
+
+      if constexpr (num_bits == 4) {
+        b_quant_0 = frag_b_quant[k % 2][0][j];
+        b_quant_1 = b_quant_0 >> 8;
+      }
+
+      frag_b0 = dequant<scalar_t, w_type_id>(b_quant_0);
+      frag_b1 = dequant<scalar_t, w_type_id>(b_quant_1);
+
+      // Apply zero-point to frag_b0
+      if constexpr (has_zp) {
+        sub_zp<scalar_t>(frag_b0, frag_zp[j], 0);
+      }
+
+      // Apply scale to frag_b0
+      if constexpr (has_act_order) {
+        scale4<scalar_t>(frag_b0, act_frag_s[k % 2][0][j],
+                         act_frag_s[k % 2][1][j], act_frag_s[k % 2][2][j],
+                         act_frag_s[k % 2][3][j], 0);
+      } else {
+        if constexpr (group_blocks != -1) {
+          scale<scalar_t>(frag_b0, frag_s[k % 2][j], 0);
+        }
+      }
+
+      // Apply zero-point to frag_b1
+      if constexpr (has_zp) {
+        sub_zp<scalar_t>(frag_b1, frag_zp[j], 1);
+      }
+
+      // Apply scale to frag_b1
+      if constexpr (has_act_order) {
+        scale4<scalar_t>(frag_b1, act_frag_s[k % 2][0][j],
+                         act_frag_s[k % 2][1][j], act_frag_s[k % 2][2][j],
+                         act_frag_s[k % 2][3][j], 1);
+
+      } else {
+        if constexpr (group_blocks != -1) {
+          scale<scalar_t>(frag_b1, frag_s[k % 2][j], 1);
+        }
+      }
+
   #pragma unroll
       for (int i = 0; i < thread_m_blocks; i++) {
         mma<scalar_t>(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
@@ -483,13 +987,13 @@ __global__ void Marlin(
   // multiple warps that accumulate their partial sums of the same output
   // location; which we have to reduce over in the end. We do in shared memory.
   auto thread_block_reduce = [&]() {
-    constexpr int red_off = threads / b_sh_stride / 2;
+    constexpr int red_off = threads / b_sh_stride_threads / 2;
     if (red_off >= 1) {
-      int red_idx = threadIdx.x / b_sh_stride;
-      constexpr int red_sh_stride = b_sh_stride * 4 * 2;
-      constexpr int red_sh_delta = b_sh_stride;
-      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride) +
-                      (threadIdx.x % b_sh_stride);
+      auto red_idx = threadIdx.x / b_sh_stride_threads;
+      constexpr int red_sh_stride = b_sh_stride_threads * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride_threads;
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride_threads) +
+                      (threadIdx.x % b_sh_stride_threads);
 
       // Parallel logarithmic shared memory reduction. We make sure to avoid any
       // unnecessary read or write iterations, e.g., for two warps we write only
@@ -505,15 +1009,15 @@ __global__ void Marlin(
               int red_sh_wr =
                   red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
               if (i < red_off) {
-                float* c_rd =
-                    reinterpret_cast<float*>(&sh[red_sh_delta * j + red_sh_rd]);
-                float* c_wr = reinterpret_cast<float*>(&sh[red_sh_wr]);
+                float* c_rd = reinterpret_cast<float*>(
+                    &sh_red[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh_red[red_sh_wr]);
   #pragma unroll
                 for (int k = 0; k < 4; k++)
                   reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] +=
                       c_rd[k] + c_wr[k];
               }
-              sh[red_sh_wr] =
+              sh_red[red_sh_wr] =
                   reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
             }
           }
@@ -523,7 +1027,7 @@ __global__ void Marlin(
   #pragma unroll
           for (int i = 0; i < 4 * 2; i++) {
             float* c_rd =
-                reinterpret_cast<float*>(&sh[red_sh_delta * i + red_sh_rd]);
+                reinterpret_cast<float*>(&sh_red[red_sh_delta * i + red_sh_rd]);
   #pragma unroll
             for (int j = 0; j < 4; j++)
               reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] +=
@@ -552,7 +1056,7 @@ __global__ void Marlin(
                     4 * (threadIdx.x / 32) + threadIdx.x % 4;
       c_gl_wr += (2 * thread_n_blocks) * slice_col;
       constexpr int c_sh_wr_delta = active_threads;
-      int c_sh_wr = threadIdx.x;
+      auto c_sh_wr = threadIdx.x;
 
       int row = (threadIdx.x % 32) / 4;
 
@@ -563,7 +1067,7 @@ __global__ void Marlin(
   #pragma unroll
         for (int i = 0; i < thread_m_blocks * 4; i++) {
           cp_async4_pred(
-              &sh[c_sh_wr + c_sh_wr_delta * i],
+              &sh_red[c_sh_wr + c_sh_wr_delta * i],
               &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) +
                  c_gl_wr_delta_i * (i % 2)],
               i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m);
@@ -576,7 +1080,7 @@ __global__ void Marlin(
       for (int i = 0; i < thread_m_blocks * 4; i++) {
         if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
           if (!first) {
-            int4 c_red = sh[c_sh_wr + i * c_sh_wr_delta];
+            int4 c_red = sh_red[c_sh_wr + i * c_sh_wr_delta];
   #pragma unroll
             for (int j = 0; j < 2 * 4; j++) {
               reinterpret_cast<float*>(
@@ -629,11 +1133,12 @@ __global__ void Marlin(
 
       // For per-column quantization we finally apply the scale here (only for
       // 4-bit)
-      if constexpr (group_blocks == -1) {
+      if constexpr (!has_act_order && group_blocks == -1 &&
+                    num_bits == 4) {
         res = __hmul2(res, s[0]);
       }
 
-      ((scalar_t2*)sh)[idx] = res;
+      ((scalar_t2*)sh_red)[idx] = res;
     };
 
     if (threadIdx.x / 32 < thread_n_blocks / 4) {
@@ -661,7 +1166,7 @@ __global__ void Marlin(
          i < ceildiv(16 * thread_m_blocks, threads / (2 * thread_n_blocks));
          i++) {
       if (c_gl_wr < c_gl_wr_end) {
-        C[c_gl_wr] = sh[c_sh_rd];
+        C[c_gl_wr] = sh_red[c_sh_rd];
         c_gl_wr += c_gl_wr_delta;
         c_sh_rd += c_sh_rd_delta;
       }
@@ -670,37 +1175,87 @@ __global__ void Marlin(
 
   // Start global fetch and register load pipelines.
   auto start_pipes = [&]() {
+
   #pragma unroll
-    for (int i = 0; i < stages - 1; i++) fetch_to_shared(i, i, i < slice_iters);
+    for (int i = 0; i < stages - 1; i++) {
+      if (has_act_order && i == 0) {
+        int last_g_idx = slice_k_start + stages * tb_k * 2;
+        if (last_g_idx >= prob_k) {
+          last_g_idx = prob_k - 1;
+        }
+        fetch_scales_to_shared(true, g_idx[slice_k_start], g_idx[last_g_idx]);
+      }
+
+      if constexpr (has_zp && group_blocks == -1) {
+        if (i == 0) {
+          fetch_zp_to_shared();
+        }
+      }
+      fetch_to_shared(i, i, i < slice_iters);
+    }
+
     zero_accums();
     wait_for_stage();
+    init_same_group(0);
     fetch_to_registers(0, 0);
+    fetch_scales_to_registers(0, 0);
+    if constexpr (has_zp) {
+      fetch_zp_to_registers(0, 0);
+    }
     a_gl_rd += a_gl_rd_delta_o * (stages - 1);
+    slice_k_start_shared_fetch += tb_k * (stages - 1);
   };
-  start_pipes();
+  if (slice_iters) {
+    start_pipes();
+  }
 
   // Main loop.
   while (slice_iters) {
-  // We unroll over both the global fetch and the register load pipeline to
-  // ensure all shared memory accesses are static. Note that both pipelines have
-  // even length meaning that the next iteration will always start at index 0.
+    // We unroll over both the global fetch and the register load pipeline to
+    // ensure all shared memory accesses are static. Note that both pipelines
+    // have even length meaning that the next iteration will always start at
+    // index 0.
+
   #pragma unroll
     for (int pipe = 0; pipe < stages;) {
   #pragma unroll
       for (int k = 0; k < b_sh_wr_iters; k++) {
         fetch_to_registers(k + 1, pipe % stages);
+        fetch_scales_to_registers(k + 1, pipe);
+        if constexpr (has_zp) {
+          fetch_zp_to_registers(k + 1, pipe);
+        }
         if (k == b_sh_wr_iters - 2) {
           fetch_to_shared((pipe + stages - 1) % stages, pipe,
                           slice_iters >= stages);
           pipe++;
           wait_for_stage();
+          init_same_group(pipe % stages);
         }
         matmul(k);
       }
       slice_iters--;
-      if (slice_iters == 0) break;
+      if (slice_iters == 0) {
+        break;
+      }
     }
+
     a_gl_rd += a_gl_rd_delta_o * stages;
+    slice_k_start += tb_k * stages;
+    slice_k_start_shared_fetch += tb_k * stages;
+
+    if constexpr (has_act_order) {
+      int first_group_id = g_idx[slice_k_start];
+      int last_g_idx = slice_k_start + stages * tb_k * 2;
+      if (last_g_idx >= prob_k) {
+        last_g_idx = prob_k - 1;
+      }
+      int last_group_id = g_idx[last_g_idx];
+      if (last_group_id >= sh_first_group_id + sh_num_groups) {
+        fetch_scales_to_shared(false, first_group_id, last_group_id);
+        __syncthreads();
+      }
+    }
 
     // Process results and, if necessary, proceed to the next column slice.
     // While this pattern may not be the most readable, other ways of writing
@@ -711,7 +1266,7 @@ __global__ void Marlin(
       // For per-column scales, we only fetch them here in the final step before
       // write-out
       if (group_blocks == -1 && last) {
-        if (s_sh_wr_pred) cp_async4(&sh_s[s_sh_wr], &s[s_gl_rd]);
+        if (s_sh_wr_pred) cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
         cp_async_fence();
       }
       thread_block_reduce();
@@ -745,7 +1300,19 @@ __global__ void Marlin(
   #pragma unroll
           for (int i = 0; i < b_sh_wr_iters; i++) B_ptr[i] -= b_gl_stride;
         }
-        s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+
+        // Update slice k/n for scales loading
+        if constexpr (has_act_order) {
+          slice_k_start = tb_k * slice_row;
+          slice_k_finish = slice_k_start + tb_k * slice_iters;
+          slice_k_start_shared_fetch = slice_k_start;
+          slice_n_offset = act_s_col_tb_stride * slice_col;
+
+        } else {
+          s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+          zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+        }
+
         start_pipes();
       }
     }
@@ -768,12 +1335,12 @@ static constexpr int pack_factor_4bit = 8;  // We have 8 4-bit vals inside a 32 
            thread_k_blocks == THREAD_K_BLOCKS &&                               \
            group_blocks == GROUP_BLOCKS && num_threads == NUM_THREADS) {       \
     cudaFuncSetAttribute(Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, \
-                                THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>,        \
+                                THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS, w_type_id, has_act_order, has_zp, num_bits>,        \
                          cudaFuncAttributeMaxDynamicSharedMemorySize,          \
                          SHARED_MEM);                                          \
     Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS,     \
-           STAGES, GROUP_BLOCKS><<<blocks, NUM_THREADS, SHARED_MEM, stream>>>( \
-        A_ptr, B_ptr, C_ptr, s_ptr, prob_m, prob_n, prob_k, locks);            \
+           STAGES, GROUP_BLOCKS, w_type_id, has_act_order, has_zp, num_bits><<<blocks, NUM_THREADS, SHARED_MEM, stream>>>( \
+        A_ptr, B_ptr, C_ptr, s_ptr, zp_ptr, g_idx_ptr, prob_m, prob_n, prob_k, num_groups, locks);            \
   }
 
 typedef struct {
@@ -781,6 +1348,11 @@ typedef struct {
   int thread_n;
   int num_threads;
 } thread_config_t;
+
+typedef struct {
+  int max_m_blocks;
+  thread_config_t tb_cfg;
+} exec_config_t;
 
 thread_config_t small_batch_thread_configs[] = {
     // Ordered by priority
@@ -800,8 +1372,80 @@ thread_config_t large_batch_thread_configs[] = {
     {128, 64, 128},   // Reduce N 4X, increase K 2X
 };
 
-bool is_valid_config(thread_config_t const& th_config, int prob_m, int prob_n,
-                     int prob_k) {
+int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
+                          int prob_n, int prob_k, int num_bits, int group_size,
+                          bool has_act_order, bool is_k_full) {
+  bool cache_scales_chunk = has_act_order && !is_k_full;
+
+  int tb_n = th_config.thread_n;
+  int tb_k = th_config.thread_k;
+
+  // Get max scale groups per thread-block
+  int tb_groups;
+  if (group_size == -1) {
+    tb_groups = 1;
+  } else if (group_size == 0) {
+    tb_groups = div_ceil(tb_k, 32);  // Worst case is 32 group size
+  } else {
+    tb_groups = div_ceil(tb_k, group_size);
+  }
+
+  if (cache_scales_chunk) {
+    int load_groups =
+        tb_groups * pipe_stages * 2;     // Chunk size is 2x pipeline over dim K
+    load_groups = max(load_groups, 32);  // We load at least 32 scale groups
+    return load_groups * tb_n * 2;
+
+  } else {
+    int tb_scales = tb_groups * tb_n * 2;
+
+    return tb_scales * pipe_stages;
+  }
+}
+
+bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
+                         int prob_m, int prob_n, int prob_k, int num_bits,
+                         int scales_cache_size, int max_shared_mem) {
+  int pack_factor = 32 / num_bits;
+
+  // Get B size
+  int tb_k = th_config.thread_k;
+  int tb_n = th_config.thread_n;
+
+  int b_size = (tb_k * tb_n / pack_factor) * 4;
+
+  // Get A size
+  int m_blocks = div_ceil(prob_m, 16);
+  int tb_max_m = 16;
+
+  while (true) {
+    if (m_blocks >= max_m_blocks) {
+      tb_max_m *= max_m_blocks;
+      break;
+    }
+
+    max_m_blocks--;
+    if (max_m_blocks == 0) {
+      CHECK(false, "Unexpected m_blocks = ", m_blocks);
+    }
+  }
+
+  int a_size = (tb_max_m * tb_k) * 2;
+
+  float pipe_size = (a_size + b_size) * pipe_stages;
+
+  float reduce_size = max(th_config.num_threads * 32 * 4,
+                          (tb_n / 64) * 32 * (tb_max_m / 16) * 4 * 2 * 4 * 2);
+
+  CHECK(max_shared_mem / 2 > scales_cache_size);  // Sanity
+
+  return pipe_size + reduce_size < 0.95f * (max_shared_mem - scales_cache_size);
+}
+
+bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
+                     int prob_m, int prob_n, int prob_k, int num_bits,
+                     int group_size, bool has_act_order, bool is_k_full,
+                     int max_shared_mem) {
   // Sanity
   if (th_config.thread_k == -1 || th_config.thread_n == -1 ||
       th_config.num_threads == -1) {
@@ -810,12 +1454,6 @@ bool is_valid_config(thread_config_t const& th_config, int prob_m, int prob_n,
 
   // Verify K/N are divisible by thread K/N
   if (prob_k % th_config.thread_k != 0 || prob_n % th_config.thread_n != 0) {
-    return false;
-  }
-
-  // thread_k can be only 128 or 64 (because it must be less than groupsize
-  // which is 128)
-  if (th_config.thread_k != 128 && th_config.thread_k != 64) {
     return false;
   }
 
@@ -829,42 +1467,72 @@ bool is_valid_config(thread_config_t const& th_config, int prob_m, int prob_n,
     return false;
   }
 
+  //  Determine cache for scales
+  int scales_cache_size =
+      get_scales_cache_size(th_config, prob_m, prob_n, prob_k, num_bits,
+                            group_size, has_act_order, is_k_full);
+
+  // Check that pipeline fits into cache
+  if (!is_valid_cache_size(th_config, max_m_blocks, prob_m, prob_n, prob_k,
+                           num_bits, scales_cache_size, max_shared_mem)) {
+    return false;
+  }
+
   return true;
 }
 
-thread_config_t determine_thread_config(int prob_m, int prob_n, int prob_k) {
-  if (prob_m <= 16) {
-    for (auto th_config : small_batch_thread_configs) {
-      if (is_valid_config(th_config, prob_m, prob_n, prob_k)) {
-        return th_config;
+exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
+                                      int num_bits, int group_size,
+                                      bool has_act_order, bool is_k_full,
+                                      int max_shared_mem) {
+  int max_m_blocks = 4;
+  while (max_m_blocks > 0) {
+    if (prob_m <= 16) {
+      for (auto th_config : small_batch_thread_configs) {
+        if (is_valid_config(th_config, max_m_blocks, prob_m, prob_n, prob_k,
+                            num_bits, group_size, has_act_order, is_k_full,
+                            max_shared_mem)) {
+          return exec_config_t{max_m_blocks, th_config};
+        }
+      }
+    } else {
+      for (auto th_config : large_batch_thread_configs) {
+        if (is_valid_config(th_config, max_m_blocks, prob_m, prob_n, prob_k,
+                            num_bits, group_size, has_act_order, is_k_full,
+                            max_shared_mem)) {
+          return exec_config_t{max_m_blocks, th_config};
+        }
       }
     }
 
-  } else {
-    for (auto th_config : large_batch_thread_configs) {
-      if (is_valid_config(th_config, prob_m, prob_n, prob_k)) {
-        return th_config;
-      }
-    }
+    max_m_blocks--;  // Process less M blocks per invocation to reduce cache
+                     // usage
   }
 
-  return thread_config_t{-1, -1, -1};
+  return exec_config_t{0, {-1, -1, -1}};
 }
 
 #define CALL_IF(N_BLOCKS, K_BLOCKS, NUM_THREADS)    \
   __CALL_IF(1, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
-  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
-  __CALL_IF(1, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
+  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
   __CALL_IF(1, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
   __CALL_IF(2, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
+  __CALL_IF(2, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
   __CALL_IF(2, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
   __CALL_IF(3, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
+  __CALL_IF(3, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
   __CALL_IF(3, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
+  __CALL_IF(4, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS) \
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)
 
-template<typename scalar_t>
-void marlin_matmul(const void* A, const void* B, void* s, void* C, int prob_m, int prob_k, 
+template<typename scalar_t,
+          const ScalarTypeID w_type_id,
+          const bool has_act_order,     // whether act_order is enabled
+          const bool has_zp,            // whether zero-points are enabled
+          const int num_bits
+>
+void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
                  int prob_n, void* workspace, int groupsize, int64_t stream_
                  ) {
   
@@ -879,32 +1547,35 @@ void marlin_matmul(const void* A, const void* B, void* s, void* C, int prob_m, i
   int tot_m_blocks = ceildiv(tot_m, 16);
   int pad = 16 * tot_m_blocks - tot_m;
 
+  bool is_k_full = true;
   if (sms == -1)
     cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
-
+  int max_shared_mem = 0;
+  cudaDeviceGetAttribute(&max_shared_mem,
+                         cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  CHECK(max_shared_mem > 0, "error");
   // Set thread config
-  thread_config_t th_config;
+  exec_config_t exec_cfg;
   if (thread_k != -1 && thread_n != -1) {
     // User-defined config
-    th_config = thread_config_t{thread_k, thread_n, USER_THREADS};
+    exec_cfg =
+        exec_config_t{4, thread_config_t{thread_k, thread_n, default_threads}};
   } else {
     // Auto config
-    th_config = determine_thread_config(prob_m, prob_n, prob_k);
+    exec_cfg =
+        determine_thread_config(prob_m, prob_n, prob_k, num_bits, groupsize,
+                                has_act_order, is_k_full, max_shared_mem);
   }
 
-  if (!is_valid_config(th_config, prob_m, prob_n, prob_k)) {
-    throw std::runtime_error(
-        "Invalid thread config");
-  }
-
-  int num_threads = th_config.num_threads;
-  thread_k = th_config.thread_k;
-  thread_n = th_config.thread_n;
+  int num_threads = exec_cfg.tb_cfg.num_threads;
+  thread_k = exec_cfg.tb_cfg.thread_k;
+  thread_n = exec_cfg.tb_cfg.thread_n;
 
   int thread_k_blocks = thread_k / 16;
   int thread_n_blocks = thread_n / 16;
   int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
   int blocks = sms;
+  int num_groups = prob_k / groupsize;
 
   if (prob_m == 0 || prob_n == 0 || prob_k == 0) {
     return;
@@ -913,23 +1584,41 @@ void marlin_matmul(const void* A, const void* B, void* s, void* C, int prob_m, i
   const int4* A_ptr = (const int4*)A;
   const int4* B_ptr = (const int4*)B;
   int4* C_ptr = (int4*)C;
-  const int4* s_ptr = (const int4*)s;
-
+  const int4* s_ptr = (const int4*)scales;
+  const int4* zp_ptr = (const int4*)zeros;
+  const int* g_idx_ptr = (const int*)g_idx;
   int* locks = (int*)workspace;
 
-  for (int i = 0; i < tot_m_blocks; i += 4) {
+
+  // if (has_act_order) {
+  //   // Permute A columns
+  //   int block_rows = div_ceil(prob_m, blocks);
+  //   permute_cols_kernel<<<blocks, default_threads, 0, stream>>>(
+  //       A_ptr, perm_ptr, a_tmp_ptr, prob_m, prob_k, prob_k, block_rows);
+  //   A_ptr = a_tmp_ptr;
+  // }
+
+  // // If we have a full K, then we can run the non-act-order version of Marlin
+  // // (since the weight rows are reordered by increasing group ids, and by having
+  // // a full K, we have full original groups)
+  // if (is_k_full) {
+  //   has_act_order = false;
+  // }
+
+  for (int i = 0; i < tot_m_blocks; i += exec_cfg.max_m_blocks) {
     int thread_m_blocks = tot_m_blocks - i;
     prob_m = tot_m - 16 * i;
     int par = 1;
-    if (thread_m_blocks > 4) {
+    if (thread_m_blocks > exec_cfg.max_m_blocks) {
       // Note that parallel > 1 currently only works for inputs without any
       // padding
-      par = (16 * thread_m_blocks - pad) / 64;
+      par = (16 * thread_m_blocks - pad) / (16 * exec_cfg.max_m_blocks);
       if (par > max_par) par = max_par;
-      prob_m = 64 * par;
-      i += 4 * (par - 1);
-      thread_m_blocks = 4;
+      prob_m = (16 * exec_cfg.max_m_blocks) * par;
+      i += exec_cfg.max_m_blocks * (par - 1);
+      thread_m_blocks = exec_cfg.max_m_blocks;
     }
+
 
     // For compilation speed, we only define the kernel configurations that have
     // seemed useful (in terms of performance) in our testing, however many more
@@ -941,26 +1630,40 @@ void marlin_matmul(const void* A, const void* B, void* s, void* C, int prob_m, i
     CALL_IF(8, 4, 128)
     CALL_IF(4, 8, 128)
     else {
+      // printf("Unsupported shapes: block_m %d, block_k %d, block_n %d\n", thread_m_blocks, thread_k_blocks, thread_n_blocks);
       throw std::runtime_error("Unsupported shapes: MKN");
     }
 
     A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
     C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
   }
+  cudaStreamSynchronize(stream);
+
 }
 
-extern "C" void marlin_4bit_f16(const void* A, const void* B, void* s, void* C, int prob_m, int prob_k, 
+extern "C" void marlin_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
                  int prob_n, void* workspace, int groupsize, int64_t stream
                  ) {
-    marlin_matmul<half>(A, B, s, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+    marlin_matmul<half, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
 }
 
-extern "C" void marlin_4bit_bf16(const void* A, const void* B, void* s, void* C, int prob_m, int prob_k, 
+extern "C" void marlin_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
                  int prob_n, void* workspace, int groupsize, int64_t stream
                  ) {
-    marlin_matmul<nv_bfloat16>(A, B, s, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
 }
 
+extern "C" void marlin_awq_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<half, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}
+
+extern "C" void marlin_awq_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}
 
 __global__ void gptq_repack_kernel(
   uint32_t* in,
@@ -1041,6 +1744,234 @@ extern "C" void gptq_repack(
     m,
     n
   );
+}
+
+template <int const num_threads, int const num_bits>
+__global__ void awq_marlin_repack_kernel(
+    uint32_t const* __restrict__ b_q_weight_ptr, uint32_t* __restrict__ out_ptr,
+    int size_k, int size_n) {
+  constexpr int pack_factor = 32 / num_bits;
+
+  int k_tiles = size_k / tile_k_size;
+  int n_tiles = size_n / tile_n_size;
+  int block_k_tiles = ceildiv(k_tiles, gridDim.x);
+
+  auto start_k_tile = blockIdx.x * block_k_tiles;
+  if (start_k_tile >= k_tiles) {
+    return;
+  }
+
+  int finish_k_tile = min(start_k_tile + block_k_tiles, k_tiles);
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&]() {
+    // We only have `stages - 2` active fetches since we are double buffering
+    // and can only issue the next fetch when it is guaranteed that the previous
+    // shared memory load is fully complete (as it may otherwise be
+    // overwritten).
+    cp_async_wait<repack_stages - 2>();
+    __syncthreads();
+  };
+
+  extern __shared__ int4 sh[];
+
+  constexpr int tile_n_ints = tile_n_size / pack_factor;
+
+  constexpr int stage_n_threads = tile_n_ints / 4;
+  constexpr int stage_k_threads = tile_k_size;
+  constexpr int stage_size = stage_k_threads * stage_n_threads;
+
+  auto fetch_to_shared = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      cp_async_fence();
+      return;
+    }
+
+    int first_n = n_tile_id * tile_n_size;
+    int first_n_packed = first_n / pack_factor;
+
+    int4* sh_ptr = sh + stage_size * pipe;
+
+    if (threadIdx.x < stage_size) {
+      auto k_id = threadIdx.x / stage_n_threads;
+      auto n_id = threadIdx.x % stage_n_threads;
+
+      int first_k = k_tile_id * tile_k_size;
+
+      cp_async4(&sh_ptr[k_id * stage_n_threads + n_id],
+                reinterpret_cast<int4 const*>(
+                    &(b_q_weight_ptr[(first_k + k_id) * (size_n / pack_factor) +
+                                     first_n_packed + (n_id * 4)])));
+    }
+
+    cp_async_fence();
+  };
+
+  auto repack_tile = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      return;
+    }
+
+    auto warp_id = threadIdx.x / 32;
+    auto th_id = threadIdx.x % 32;
+
+    if (warp_id >= 4) {
+      return;
+    }
+
+    int tc_col = th_id / 4;
+    int tc_row = (th_id % 4) * 2;
+
+    constexpr int tc_offsets[4] = {0, 1, 8, 9};
+
+    int cur_n = warp_id * 16 + tc_col;
+    int cur_n_packed = cur_n / pack_factor;
+    int cur_n_pos = cur_n % pack_factor;
+
+    constexpr int sh_stride = tile_n_ints;
+    constexpr uint32_t mask = (1 << num_bits) - 1;
+
+    int4* sh_stage_ptr = sh + stage_size * pipe;
+    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
+
+    // Undo interleaving
+    int cur_n_pos_unpacked;
+    if constexpr (num_bits == 4) {
+      constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
+      cur_n_pos_unpacked = undo_pack[cur_n_pos];
+    } else {
+      constexpr int undo_pack[4] = {0, 2, 1, 3};
+      cur_n_pos_unpacked = undo_pack[cur_n_pos];
+    }
+
+    uint32_t vals[8];
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int cur_elem = tc_row + tc_offsets[i];
+
+      int packed_src_0 = sh_stage_int_ptr[cur_n_packed + sh_stride * cur_elem];
+      int packed_src_1 = sh_stage_int_ptr[cur_n_packed + (8 / pack_factor) +
+                                          sh_stride * cur_elem];
+
+      vals[i] = (packed_src_0 >> (cur_n_pos_unpacked * num_bits)) & mask;
+      vals[4 + i] = (packed_src_1 >> (cur_n_pos_unpacked * num_bits)) & mask;
+    }
+
+    constexpr int tile_size = tile_k_size * tile_n_size / pack_factor;
+    int out_offset = (k_tile_id * n_tiles + n_tile_id) * tile_size;
+
+    // Result of:
+    // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+    if constexpr (num_bits == 4) {
+      constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
+
+      uint32_t res = 0;
+#pragma unroll
+      for (int i = 0; i < 8; i++) {
+        res |= vals[pack_idx[i]] << (i * 4);
+      }
+
+      out_ptr[out_offset + th_id * 4 + warp_id] = res;
+
+    } else {
+      constexpr int pack_idx[4] = {0, 2, 1, 3};
+
+      uint32_t res1 = 0;
+      uint32_t res2 = 0;
+#pragma unroll
+      for (int i = 0; i < 4; i++) {
+        res1 |= vals[pack_idx[i]] << (i * 8);
+        res2 |= vals[4 + pack_idx[i]] << (i * 8);
+      }
+
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 0] = res1;
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 1] = res2;
+    }
+  };
+
+  auto start_pipes = [&](int k_tile_id, int n_tile_id) {
+#pragma unroll
+    for (int pipe = 0; pipe < repack_stages - 1; pipe++) {
+      fetch_to_shared(pipe, k_tile_id, n_tile_id + pipe);
+    }
+
+    wait_for_stage();
+  };
+#pragma unroll
+  for (int k_tile_id = start_k_tile; k_tile_id < finish_k_tile; k_tile_id++) {
+    int n_tile_id = 0;
+
+    start_pipes(k_tile_id, n_tile_id);
+
+    while (n_tile_id < n_tiles) {
+#pragma unroll
+      for (int pipe = 0; pipe < repack_stages; pipe++) {
+        fetch_to_shared((pipe + repack_stages - 1) % repack_stages, k_tile_id,
+                        n_tile_id + pipe + repack_stages - 1);
+        repack_tile(pipe, k_tile_id, n_tile_id + pipe);
+        wait_for_stage();
+      }
+      n_tile_id += repack_stages;
+    }
+  }
+}
+
+#define CALL_IF2(NUM_BITS)                                                   \
+  else if (num_bits == NUM_BITS) {                                          \
+    cudaFuncSetAttribute(                                                   \
+        awq_marlin_repack_kernel<repack_threads, NUM_BITS>, \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem);       \
+    awq_marlin_repack_kernel<repack_threads, NUM_BITS>      \
+        <<<blocks, repack_threads, max_shared_mem, stream>>>(       \
+            weight_ptr, out_ptr, size_k, size_n);                       \
+  }
+
+extern "C" void awq_repack(void* in, void* out, int k,
+                                int n, int num_bits, int64_t stream_) {
+
+  //in_dim 4096, out_dim 1024 (/pack_factor)
+  //ws shape [4096, 128]
+  //out_shape [256, 2048]
+
+   //recover original size_k and size_n
+   int const pack_factor = 32 / num_bits;
+   int size_k = k;
+   int size_n = n * pack_factor;
+
+  // Verify compatibility with marlin tile of 16x64
+  CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
+              " is not divisible by tile_k_size = ", marlin::tile_k_size);
+  CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
+              " is not divisible by tile_n_size = ", marlin::tile_n_size);
+
+  CHECK(num_bits == 4 || num_bits == 8,
+              "num_bits must be 4 or 8. Got = ", num_bits);
+  cudaStream_t stream = (cudaStream_t)stream_;
+
+  uint32_t const* weight_ptr =
+      reinterpret_cast<uint32_t const*>(in);
+  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out);
+
+  // cudaPointerAttributes attributes;
+  // cudaPointerGetAttributes(
+  //   &attributes,
+  //   in
+  // );
+
+  int blocks;
+  cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, 0);
+  int max_shared_mem = 0;
+  cudaDeviceGetAttribute(&max_shared_mem,
+                         cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  CHECK(max_shared_mem > 0, "error max_shared_mem");
+
+  if (false) {
+  }
+  CALL_IF2(4)
+  CALL_IF2(8)
+  else {
+    CHECK(false, "Unsupported repack config: num_bits = ", num_bits);
+  }
 }
 
 #endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,13 @@ pub enum ModelSelected {
 
         #[arg(long)]
         quant: Option<String>,
+
+        //the number of experts offloaded per rank,
+        //suppose there are 256 experts in total which split into 8 devices (rank 8),
+        //each rank has 32 experts, num-experts-offload-per-rank=16 means
+        //half of the experts can be offloaded to cpu memory
+        #[arg(long)]
+        num_experts_offload_per_rank: Option<usize>,
     },
 }
 
@@ -300,6 +307,7 @@ pub struct SpecificConfig {
     penalty: Option<f32>,
     max_gen_tokens: Option<usize>,
     quant: Option<String>,
+    num_experts_offload_per_rank: Option<usize>,
 }
 
 impl SpecificConfig {
@@ -311,6 +319,7 @@ impl SpecificConfig {
         penalty: Option<f32>,
         max_gen_tokens: Option<usize>,
         quant: Option<String>,
+        num_experts_offload_per_rank: Option<usize>,
     ) -> Self {
         Self {
             repeat_last_n,
@@ -320,6 +329,7 @@ impl SpecificConfig {
             penalty,
             max_gen_tokens,
             quant,
+            num_experts_offload_per_rank,
         }
     }
 }
@@ -347,6 +357,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "llama".to_string(),
             )),
@@ -375,6 +386,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "llama3".to_string(),
             )),
@@ -403,6 +415,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "phi2".to_string(),
             )),
@@ -431,6 +444,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "phi3".to_string(),
             )),
@@ -459,6 +473,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "qwen2".to_string(),
             )),
@@ -487,6 +502,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "gemma".to_string(),
             )),
@@ -515,6 +531,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "mistral".to_string(),
             )),
@@ -544,6 +561,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "yi".to_string(),
             )),
@@ -571,6 +589,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    None,
                 ),
                 "stablelm".to_string(),
             )),
@@ -589,6 +608,7 @@ pub fn get_model_loader(
             penalty,
             max_gen_tokens,
             quant,
+            num_experts_offload_per_rank,
         } => (
             Box::new(DefaultLoader::new(
                 SpecificConfig::new(
@@ -599,6 +619,7 @@ pub fn get_model_loader(
                     penalty,
                     max_gen_tokens,
                     quant.clone(),
+                    num_experts_offload_per_rank,
                 ),
                 "deepseek".to_string(),
             )),

--- a/src/openai/distributed.rs
+++ b/src/openai/distributed.rs
@@ -356,4 +356,20 @@ impl ReplicatedLinear {
         }
         Ok(xs)
     }
+
+    pub fn offload(&mut self) -> Result<()> {
+        if cfg!(feature = "cuda") {
+            self.linear.offload()
+        } else {
+            panic!("tensor offload not available on this device!");
+        }
+    }
+
+    pub fn reload(&mut self) -> Result<()> {
+        if cfg!(feature = "cuda") {
+            self.linear.reload()
+        } else {
+            panic!("tensor offload not available on this device!");
+        }
+    }
 }

--- a/src/openai/models/deepseek.rs
+++ b/src/openai/models/deepseek.rs
@@ -1000,7 +1000,7 @@ impl DeepSeek {
                 comm.clone(),
             )?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
 
         Ok(Self {

--- a/src/openai/models/deepseek.rs
+++ b/src/openai/models/deepseek.rs
@@ -15,11 +15,13 @@ use candle::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_core as candle;
 use candle_nn::{Activation, Embedding, Module, RmsNorm};
 use serde::Deserialize;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::f32::consts::PI;
 use std::iter::{zip, FromIterator};
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! serde_default_fn {
@@ -117,6 +119,7 @@ impl DeepSeekConfig {
             q_lora_rank: self.q_lora_rank,
             n_group: self.n_group,
             topk_group: self.topk_group,
+            num_experts_offload_per_rank: scfg.num_experts_offload_per_rank,
         };
 
         Config {
@@ -566,10 +569,12 @@ impl Attention {
 }
 
 struct Mlp {
-    gate: ReplicatedLinear,
-    up: ReplicatedLinear,
-    down: ReplicatedLinear,
+    gate: RefCell<ReplicatedLinear>,
+    up: RefCell<ReplicatedLinear>,
+    down: RefCell<ReplicatedLinear>,
     act: Activation,
+    preloaded: Cell<bool>,
+    can_be_offloaded: bool,
 }
 
 impl Mlp {
@@ -578,40 +583,72 @@ impl Mlp {
         vb: VarBuilder,
         hidden_size: Option<usize>,
         intermediate_size: Option<usize>,
+        offload: bool,
     ) -> Result<Self> {
         let hidden_size = hidden_size.unwrap_or(cfg.hidden_size);
         let intermediate_size = intermediate_size.unwrap_or(cfg.intermediate_size);
 
+        let mut gate = ReplicatedLinear::load_no_bias(
+            hidden_size,
+            intermediate_size,
+            vb.pp("gate_proj"),
+            &cfg.specific_config.quant,
+            &cfg.quantization_config,
+        )?;
+
+        let mut up = ReplicatedLinear::load_no_bias(
+            hidden_size,
+            intermediate_size,
+            vb.pp("up_proj"),
+            &cfg.specific_config.quant,
+            &cfg.quantization_config,
+        )?;
+
+        let mut down = ReplicatedLinear::load_no_bias(
+            intermediate_size,
+            hidden_size,
+            vb.pp("down_proj"),
+            &cfg.specific_config.quant,
+            &cfg.quantization_config,
+        )?;
+
+        if offload {
+            gate.offload()?;
+            up.offload()?;
+            down.offload()?;
+        }
         Ok(Self {
-            gate: ReplicatedLinear::load_no_bias(
-                hidden_size,
-                intermediate_size,
-                vb.pp("gate_proj"),
-                &cfg.specific_config.quant,
-                &cfg.quantization_config,
-            )?,
-            up: ReplicatedLinear::load_no_bias(
-                hidden_size,
-                intermediate_size,
-                vb.pp("up_proj"),
-                &cfg.specific_config.quant,
-                &cfg.quantization_config,
-            )?,
-            down: ReplicatedLinear::load_no_bias(
-                intermediate_size,
-                hidden_size,
-                vb.pp("down_proj"),
-                &cfg.specific_config.quant,
-                &cfg.quantization_config,
-            )?,
+            gate: RefCell::new(gate),
+            up: RefCell::new(up),
+            down: RefCell::new(down),
+            preloaded: Cell::new(!offload),
+            can_be_offloaded: offload,
             act: cfg.hidden_act.unwrap(),
         })
     }
 
+    pub fn reload(&self) {
+        if !self.preloaded.get() {
+            let _ = self.gate.borrow_mut().reload();
+            let _ = self.up.borrow_mut().reload();
+            let _ = self.down.borrow_mut().reload();
+            self.preloaded.set(true);
+        }
+    }
+
+    pub fn offload(&self) {
+        if self.can_be_offloaded && self.preloaded.get() {
+            let _ = self.gate.borrow_mut().offload();
+            let _ = self.up.borrow_mut().offload();
+            let _ = self.down.borrow_mut().offload();
+            self.preloaded.set(false);
+        }
+    }
+
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.gate.forward(xs)?.apply(&self.act)?;
-        let rhs = self.up.forward(xs)?;
-        self.down.forward(&(&lhs * &rhs)?)
+        let lhs = self.gate.borrow().forward(xs)?.apply(&self.act)?;
+        let rhs = self.up.borrow().forward(xs)?;
+        self.down.borrow().forward(&(&lhs * &rhs)?)
     }
 }
 
@@ -769,15 +806,20 @@ impl Moe {
         let n_local_experts = n_routed_experts / comm.world_size();
         let experts_start_idx = comm.rank() * n_local_experts;
         let experts_end_idx = experts_start_idx + n_local_experts;
+        let n_local_experts_need_offload = moe_cfg.num_experts_offload_per_rank.unwrap_or(0);
+        let mut offloaded_count = 0;
         for i in 0..n_routed_experts {
             if i >= experts_start_idx && i < experts_end_idx {
                 let vb_e = vb.pp("experts").pp(i);
+                let offload = offloaded_count < n_local_experts_need_offload;
                 experts.push(Some(Mlp::new(
                     cfg,
                     vb_e,
                     None,
                     Some(moe_cfg.moe_intermediate_size),
+                    offload,
                 )?));
+                offloaded_count += 1;
             } else {
                 experts.push(None);
             }
@@ -790,6 +832,7 @@ impl Moe {
                 vb.pp("shared_experts"),
                 None,
                 Some(intermediate_size),
+                false,
             )?)
         } else {
             None
@@ -816,14 +859,22 @@ impl Moe {
         };
         let unique_ids: HashSet<u32> =
             HashSet::from_iter(topk_ids.to_device(&Device::Cpu)?.flatten_all()?.to_vec1()?);
+        let mut cur_used_experts = Vec::<u32>::new();
         for i in self.experts_start_idx..self.experts_end_idx {
-            if !unique_ids.contains(&(i as u32)) {
-                continue;
+            if unique_ids.contains(&(i as u32)) {
+                cur_used_experts.push(i as u32);
+                let expert = self.experts[i]
+                    .as_ref()
+                    .expect("Expert is not present for this rank.");
+                expert.reload(); //make sure the current used expert is loaded on device
             }
-            let idx_top = topk_ids.eq(i as f64)?.nonzero()?.t()?.contiguous()?;
+        }
+
+        for i in &cur_used_experts {
+            let idx_top = topk_ids.eq(*i as u32)?.nonzero()?.t()?.contiguous()?;
             let idx = &idx_top.i(0)?.contiguous()?;
             let top = &idx_top.i(1)?.contiguous()?;
-            let expert = self.experts[i]
+            let expert = self.experts[*i as usize]
                 .as_ref()
                 .expect("Expert is not present for this rank.");
 
@@ -842,6 +893,13 @@ impl Moe {
 
         if self.world_size > 1 {
             y = self.all_reduce.apply(&y)?;
+        }
+
+        for i in &cur_used_experts {
+            let expert = self.experts[*i as usize]
+                .as_ref()
+                .expect("Expert is not present for this rank.");
+            expert.offload();
         }
         Ok(y)
     }
@@ -912,7 +970,7 @@ impl DecoderLayer {
                 comm.clone(),
             )?)
         } else {
-            MoeOrMlp::Mlp(Mlp::new(cfg, vb.pp("mlp"), None, None)?)
+            MoeOrMlp::Mlp(Mlp::new(cfg, vb.pp("mlp"), None, None, false)?)
         };
 
         Ok(Self {

--- a/src/openai/models/gemma.rs
+++ b/src/openai/models/gemma.rs
@@ -484,7 +484,7 @@ impl Gemma {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
         let lm_head = ReplicatedLinear::from_weight_bias(embed_tokens.embeddings().clone(), None)?;

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -457,7 +457,7 @@ impl Llama {
                     comm.clone(),
                 )
                 .unwrap();
-                reporter.write().unwrap().set_progress(i);
+                reporter.write().unwrap().set_progress(i + 1);
                 b
             })
             .collect();

--- a/src/openai/models/mistral.rs
+++ b/src/openai/models/mistral.rs
@@ -409,7 +409,7 @@ impl Mistral {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
         let lm_head = ReplicatedLinear::load_no_bias(

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -72,6 +72,7 @@ pub struct MoEConfig {
     pub rope_scaling: Option<DeepSeekRopeScaling>,
     pub n_group: usize,
     pub topk_group: usize,
+    pub num_experts_offload_per_rank: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/openai/models/phi2.rs
+++ b/src/openai/models/phi2.rs
@@ -397,7 +397,7 @@ impl Phi2 {
         for layer_idx in 0..cfg.num_hidden_layers {
             let layer = DecoderLayer::new(cfg, vb_m.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let lm_head = ReplicatedLinear::load_no_bias(
             cfg.hidden_size,

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -495,7 +495,7 @@ impl Phi {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
         let lm_head = ReplicatedLinear::load_no_bias(

--- a/src/openai/models/quantized_llama.rs
+++ b/src/openai/models/quantized_llama.rs
@@ -497,7 +497,7 @@ impl GGUFLLaMa {
                 )?,
                 dtype,
             });
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         Ok(Self {
             tok_embeddings: Embedding::new(tok_embeddings, embedding_length),

--- a/src/openai/models/quantized_phi3.rs
+++ b/src/openai/models/quantized_phi3.rs
@@ -319,7 +319,7 @@ impl GGUFPhi3 {
                 )?,
                 dtype,
             });
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         Ok(Self {
             tok_embeddings: Embedding::new(tok_embeddings, embedding_length),

--- a/src/openai/models/quantized_qwen2.rs
+++ b/src/openai/models/quantized_qwen2.rs
@@ -319,7 +319,7 @@ impl GGUFQWen2 {
                 )?,
                 dtype,
             });
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
 
         Ok(Self {

--- a/src/openai/models/qwen2.rs
+++ b/src/openai/models/qwen2.rs
@@ -411,7 +411,7 @@ impl Qwen2 {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
         let lm_head = ReplicatedLinear::load_no_bias(

--- a/src/openai/models/stable_lm.rs
+++ b/src/openai/models/stable_lm.rs
@@ -419,7 +419,7 @@ impl StableLM {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = layer_norm(cfg.hidden_size, cfg.rms_norm_eps, true, vb_m.pp("norm"))?;
         let lm_head = ReplicatedLinear::load_no_bias(

--- a/src/openai/models/yi.rs
+++ b/src/openai/models/yi.rs
@@ -408,7 +408,7 @@ impl Yi {
             let layer =
                 DecoderLayer::new(rotary_emb.clone(), cfg, vb_l.pp(layer_idx), comm.clone())?;
             layers.push(layer);
-            reporter.write().unwrap().set_progress(layer_idx);
+            reporter.write().unwrap().set_progress(layer_idx + 1);
         }
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
 

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -621,6 +621,16 @@ impl DefaultLoader {
                     }
                 }
 
+                if chat_template.is_some() {
+                    if chat_template.as_ref().unwrap().find("<|eom_id|>").is_some() {
+                        tracing::warn!("custom stop token <|eom_id|> in chat template");
+                        stop_token_ids.push(128008)
+                    }
+                    if chat_template.as_ref().unwrap().find("<|eot_id|>").is_some() {
+                        tracing::warn!("custom stop token <|eot_id|> in chat template");
+                        stop_token_ids.push(128009)
+                    }
+                }
                 if stop_token_ids.is_empty() {
                     //if no eos_token defined in the config, use default
                     if let Some(token) = tokenizer.get_token("<|endoftext|>") {
@@ -633,6 +643,7 @@ impl DefaultLoader {
                         stop_token_ids.push(token);
                     }
                 }
+                tracing::warn!("stop_token_ids {:?}", stop_token_ids);
                 Box::new(DefaultPipeline {
                     model,
                     args: specific_args.clone(),


### PR DESCRIPTION
This PR:

1) Add support for AWQ model (repack awq model to marlin format);
2) Add tensor offloading (use custom candle branch, default candle implementation is not efficient);
3) Revise linear and distributed module to support offloading of linear layers (current ReplicatedLinear for DeepSeek);
4) DeepSeek Expert layers can be offloaded to CPU (number of experts for offloading can be configured);

Example:

GPU: 8 x A100 (8 X 48GB)
```shell
//repack qzeros to marlin format
python3 examples/convert_awq_marlin.py --src /home/DeepSeek-R1-awq/ --dst /home/DeepSeek-R1-awq-Marlin/ --bits 4 --method awq --group 128 --nk False
//run the model
RUST_LOG=warn cargo run --release --features cuda,nccl -- --log --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/DeepSeek-R1-awq-Marlin/ deep-seek --quant awq --temperature 0. --penalty 1.0 --num-experts-offload-per-rank 10
```
**Note:** This setup offloads 10 experts per rank (a total of 80 out of 256 experts) to the CPU (around 120GB additional host memory required). During inference, these offloaded experts are swapped back into GPU memory as needed. If you have even less GPU memory, consider increasing the `--num-experts-offload-per-rank` parameter (up to a maximum of 32 experts per rank in this case).