### PR TITLE
Fix sync response and qwen3-4b

### DIFF
--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -1,7 +1,6 @@
 use candle_core::Device;
 use std::sync::{Arc, RwLock};
 use tokenizers::{EncodeInput, Encoding, Tokenizer};
-use tokio::sync::Notify;
 
 use self::{pipelines::llm_engine::LLMEngine, responses::APIError};
 
@@ -81,7 +80,6 @@ pub struct OpenAIServerData {
     pub pipeline_config: PipelineConfig,
     pub record_conversation: bool,
     pub device: Device,
-    pub finish_notify: Arc<Notify>,
 }
 
 pub mod conversation;

--- a/src/openai/models/quantized_qwen.rs
+++ b/src/openai/models/quantized_qwen.rs
@@ -181,7 +181,7 @@ fn precomput_freqs_cis(
     freq_base: f32,
     context_length: usize,
     device: &Device,
-    dtype: DType,
+    _dtype: DType,
 ) -> Result<(Tensor, Tensor)> {
     let theta: Vec<_> = (0..head_dim)
         .step_by(2)

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -140,8 +140,6 @@ impl DefaultLoader {
                 default_model_id,
                 None,
                 weight_file.clone().unwrap(),
-                hf_token,
-                hf_token_path,
             );
         };
         let api = try_api!(ApiBuilder::new()
@@ -189,8 +187,6 @@ impl DefaultLoader {
         default_model_id: String,
         revision: Option<String>,
         filename: String,
-        hf_token: Option<String>,
-        hf_token_path: Option<String>,
     ) -> Result<DefaultModelPaths, APIError> {
         let api = hf_hub::api::sync::Api::new().unwrap();
         let revision = revision.unwrap_or("main".to_string());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -36,7 +36,6 @@ async fn test_llama() -> Result<(), APIError> {
         None,
     )?;
     let model = loader.load_model(paths, DType::F16, Device::Cpu)?;
-    let finish_notify = Arc::new(Notify::new());
     let llm_engine = LLMEngine::new(
         model.0,
         SchedulerConfig { max_num_seqs: 256 },
@@ -48,7 +47,6 @@ async fn test_llama() -> Result<(), APIError> {
             dtype: DType::F16,
         },
         Arc::new(Notify::new()),
-        finish_notify.clone(),
     )?;
 
     let server_data = OpenAIServerData {
@@ -56,7 +54,6 @@ async fn test_llama() -> Result<(), APIError> {
         model: llm_engine,
         device: Device::Cpu,
         record_conversation: false,
-        finish_notify: finish_notify.clone(),
     };
 
     let allow_origin = AllowOrigin::any();


### PR DESCRIPTION
This PR addresses two bugs:

1) Unable to perform response for sync request (previously introduced in multiprocess inference)

2) Qwen3-4B model (using head_dim from config.json)