### PR TITLE
Fix LLama gguf model & use chat_template within gguf file

### DIFF
--- a/src/openai/models/deepseek.rs
+++ b/src/openai/models/deepseek.rs
@@ -39,7 +39,7 @@ serde_default_fn!(usize, first_k_dense_replace, 0);
 serde_default_fn!(bool, norm_topk_prob, false);
 serde_default_fn!(ScoringFunc, scoring_func, ScoringFunc::Softmax);
 serde_default_fn!(Activation, hidden_act, Activation::Silu);
-serde_default_fn!(bool, tie_word_embeddings, false);
+// serde_default_fn!(bool, tie_word_embeddings, false);
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct DeepSeekConfig {

--- a/src/openai/models/quantized_phi3.rs
+++ b/src/openai/models/quantized_phi3.rs
@@ -251,7 +251,7 @@ impl GGUFPhi3 {
     }
 
     pub fn from_gguf<R: std::io::Seek + std::io::Read>(
-        ct: gguf_file::Content,
+        ct: &gguf_file::Content,
         reader: &mut R,
         device: &Device,
         dtype: DType,

--- a/src/openai/models/quantized_qwen.rs
+++ b/src/openai/models/quantized_qwen.rs
@@ -258,7 +258,7 @@ impl GGUFQWen {
 
     pub fn from_gguf<R: std::io::Seek + std::io::Read>(
         qwen3: bool,
-        ct: gguf_file::Content,
+        ct: &gguf_file::Content,
         reader: &mut R,
         device: &Device,
         dtype: DType,
@@ -464,6 +464,10 @@ impl GGUFQWen {
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
         let (b_sz, seq_len) = x.dims2()?;
+        assert!(
+            seq_len < self.cfg.max_seq_len,
+            "Input token length exceed maximum context allowed for this model."
+        );
         let mask = if seq_len == 1 {
             None
         } else {


### PR DESCRIPTION
This PR address the accuracy issue in gguf llama models. It also reduce the needs for obtaining certain config files online (by extracting configs from gguf file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for extracting and using tokenizer configuration directly from model files, improving compatibility with quantized models.
- **Improvements**
	- Enhanced handling of context length and rotary embedding dimensions for greater flexibility and accuracy in model loading.
	- Input sequence length is now validated to ensure it does not exceed the model’s maximum supported length, providing clearer error messages.
- **Bug Fixes**
	- Streamlined tokenizer configuration retrieval, reducing unnecessary warnings and fallback behavior.
- **Other Changes**
	- Updated default memory usage settings for improved resource efficiency.
	- Removed unused configuration fields for cleaner model setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->