### PR TITLE
Support continuous batching of multiple requests (over time)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-vllm"
-version = "0.1.2"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -56,6 +56,7 @@ bincode = { version = "1.3.1" }
 ftail = "0.2"
 indicatif = "0.17.11"
 mpi = { version = "0.8.0", optional = true}
+parking_lot = "0.12"
 
 [features]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,8 +432,8 @@ async fn main() -> Result<(), APIError> {
 
     #[cfg(feature = "nccl")]
     if args.multi_process {
-        let e = server_data.model.read().unwrap();
-        let mut daemon_manager = e.daemon_manager.write().unwrap();
+        let e = server_data.model.read();
+        let mut daemon_manager = e.daemon_manager.write();
         daemon_manager.as_mut().unwrap().mpi_sync();
     }
 

--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -1,8 +1,8 @@
-use candle_core::Device;
-use std::sync::{Arc, RwLock};
-use tokenizers::{EncodeInput, Encoding, Tokenizer};
-
 use self::{pipelines::llm_engine::LLMEngine, responses::APIError};
+use candle_core::Device;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use tokenizers::{EncodeInput, Encoding, Tokenizer};
 
 #[cfg(feature = "nccl")]
 pub mod communicator;

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -185,7 +185,7 @@ impl Config {
     }
 }
 
-//chat tempalte embeded in the gguf file
+//chat template embedded in the gguf file
 pub fn get_tokenizer_cfg(ct: &candle_core::quantized::gguf_file::Content) -> Option<String> {
     use serde_json::json;
     let md_get = |s: &str| match ct.metadata.get(s) {

--- a/src/openai/openai_server.rs
+++ b/src/openai/openai_server.rs
@@ -36,7 +36,7 @@ async fn get_gen_prompt(
     data: &OpenAIServerData,
     request: &ChatCompletionRequest,
 ) -> Result<String, APIError> {
-    let mut model = data.model.write().unwrap();
+    let mut model = data.model.write();
     let conversation = model
         .get_mut_pipeline(0)
         .unwrap()
@@ -81,7 +81,7 @@ async fn check_length(
     data: &OpenAIServerData,
 ) -> Result<Encoding, APIError> {
     let token_ids = {
-        let model = data.model.read().unwrap();
+        let model = data.model.read();
         model
             .get_pipeline(0)
             .unwrap()
@@ -209,7 +209,7 @@ pub async fn chat_completions(
         tokio::runtime::Handle::current().block_on(async move {
             {
                 //send completion request to inference engine
-                let mut model = data.model.write().unwrap();
+                let mut model = data.model.write();
                 model.add_request(
                     token_ids,
                     request_id.clone(),
@@ -248,7 +248,7 @@ pub async fn chat_completions(
         // wait until current response finished
         tracing::warn!("waiting response for sync request {}", request_id_clone);
         sync_notify.as_ref().notified().await;
-        let model = data_clone.model.read().unwrap();
+        let model = data_clone.model.read();
         if !model.completion_records.contains_key(&request_id_clone) {
             return ChatResponder::ModelError(APIError::from(format!(
                 "Unable to generate response for request {}",


### PR DESCRIPTION
# First usuable version of candle-vllm for batching requests

This PR enables candle-vllm to support continuous batching, allowing it to handle multiple incoming requests over time and process them simultaneously in batches. This improves throughput and better utilizes system resources by grouping temporally distributed requests.

By simplely replacing Rust `std::sync::RwLock` with `parking_lot::RwLock`, it enhance concurrency in a heavily loaded environment. Previously, the working thread was fully occupied and couldn't accept new requests while processing tasks.
With parking_lot::RwLock, the thread can now efficiently spare time to accept and batch new incoming requests—even under heavy load—enabling smoother and more continuous request handling.