### PR TITLE
Fix attention_bias for qwen2

### DIFF
--- a/src/openai/models/qwen.rs
+++ b/src/openai/models/qwen.rs
@@ -74,7 +74,7 @@ impl QwenConfig {
             tie_word_embeddings: self.tie_word_embeddings,
             rope_scaling: None,
             original_max_position_embeddings: None,
-            attention_bias: self.attention_bias.unwrap_or(false),
+            attention_bias: self.attention_bias.unwrap_or(true),
             partial_rotary_factor: None,
             qk_layer_rms_norm: None,
             kv_cache_dtype,


### PR DESCRIPTION
Default attention bias for qwen2 is true, not false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing bias tensors, preventing errors when the bias is not present.
  - Updated default behavior for the attention bias setting in Qwen model configurations, now enabling it by default if unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->