### PR TITLE
Correctly build tokenizer from metadata decoded from gguf models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,12 @@ interprocess = "2.2.2"
 serde-big-array = "0.5.1"
 bincode = { version = "1.3.1" }
 ftail = "0.2"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 indicatif = "0.17.11"
 mpi = { version = "0.8.0", optional = true}
 parking_lot = "0.12"
+akin = "0.4.0"
+itertools = "0.13.0"
 
 [features]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]

--- a/src/backend/gguf.rs
+++ b/src/backend/gguf.rs
@@ -1,0 +1,620 @@
+use anyhow::Result;
+use candle_core::quantized::gguf_file::{self, Value};
+use itertools::Itertools;
+use std::collections::HashMap;
+use tokenizers::pre_tokenizers::{
+    sequence::Sequence,
+    split::{Split, SplitPattern},
+    PreTokenizerWrapper,
+};
+use tokenizers::tokenizer::normalizer::SplitDelimiterBehavior;
+use tokenizers::{
+    decoders::{
+        self, byte_fallback::ByteFallback, byte_level::ByteLevel, fuse::Fuse, strip::Strip,
+    },
+    models::{bpe::BpeBuilder, unigram::Unigram},
+    normalizers::{self, Prepend, Replace},
+    processors, AddedToken, DecoderWrapper, ModelWrapper, NormalizerWrapper, Tokenizer,
+};
+use tracing::info;
+// use indexmap::IndexMap;
+
+fn parse_gguf_value(value: &Value) -> String {
+    match value {
+        Value::Array(vs) => vs
+            .iter()
+            .map(parse_gguf_value)
+            .collect::<Vec<String>>()
+            .join(", "),
+        Value::Bool(b) => b.to_string(),
+        Value::F32(x) => x.to_string(),
+        Value::F64(x) => x.to_string(),
+        Value::I8(x) => x.to_string(),
+        Value::I16(x) => x.to_string(),
+        Value::I32(x) => x.to_string(),
+        Value::I64(x) => x.to_string(),
+        Value::String(x) => x.to_string(),
+        Value::U8(x) => x.to_string(),
+        Value::U16(x) => x.to_string(),
+        Value::U32(x) => x.to_string(),
+        Value::U64(x) => x.to_string(),
+    }
+}
+
+// Internal invariant: contents and readers must be paired.
+/// This abstracts the files for a GGUF model and enables multiple files to be used.
+#[allow(dead_code)]
+pub struct Content<'a, R: std::io::Seek + std::io::Read> {
+    contents: Vec<gguf_file::Content>,
+    readers: &'a mut [&'a mut R],
+    all_metadata: HashMap<String, Value>,
+}
+
+impl<'a, R: std::io::Seek + std::io::Read> Content<'a, R> {
+    /// Create a `Content` from a set of file readers.
+    pub fn from_readers(readers: &'a mut [&'a mut R]) -> candle_core::Result<Self> {
+        let mut contents = Vec::new();
+        let n_readers = readers.len();
+        for reader in readers.iter_mut() {
+            contents.push(gguf_file::Content::read(reader)?);
+        }
+        let n_splits = contents
+            .iter()
+            .filter_map(|ct| {
+                ct.metadata
+                    .get("split.count")
+                    .map(|val| val.to_u64().unwrap())
+            })
+            .fold(Vec::new(), |mut accum, x| {
+                if !accum.contains(&x) {
+                    accum.push(x);
+                }
+                accum
+            });
+        if n_splits.len() > 1 {
+            candle_core::bail!("GGUF files have differing `split.count` values: {n_splits:?}. Perhaps the GGUF files do not match?");
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        if !n_splits.is_empty() && n_readers != n_splits[0] as usize {
+            candle_core::bail!(
+                "Number of GGUF files does not match the number of splits, expected {} files.",
+                n_splits[0]
+            );
+        } else if n_splits.len() == 1 {
+            info!("GGUF file has been split into {} shards", n_splits[0]);
+        }
+
+        let mut all_metadata = HashMap::new();
+        for content in &contents {
+            all_metadata.extend(content.metadata.clone())
+        }
+
+        Ok(Self {
+            contents,
+            readers,
+            all_metadata,
+        })
+    }
+
+    /// Get all metadatas
+    pub fn get_metadata(&self) -> &HashMap<String, Value> {
+        &self.all_metadata
+    }
+}
+
+pub struct ContentMetadata<'a> {
+    pub path_prefix: &'a str,
+    pub metadata: &'a HashMap<String, gguf_file::Value>,
+}
+
+impl ContentMetadata<'_> {
+    // Retrieve a prop the struct needs by querying the metadata content:
+    pub fn get_value<T: TryFromValue>(&self, field_name: &str) -> Result<T, anyhow::Error> {
+        let prop_key = format!("{prefix}.{field_name}", prefix = self.path_prefix);
+        let value = self.metadata.get(&prop_key).cloned();
+
+        // Unwrap the inner value of the `Value` enum via trait method,
+        // otherwise format error with prop key as context:
+        value
+            .try_value_into()
+            .or_else(|e| anyhow::bail!("`{prop_key}` `{e}`"))
+    }
+
+    // Retrieve a prop the struct needs by querying the metadata content:
+    pub fn get_option_value<T: TryFromValue>(
+        &self,
+        field_name: &str,
+    ) -> Result<Option<T>, anyhow::Error> {
+        let prop_key = format!("{prefix}.{field_name}", prefix = self.path_prefix);
+        let value = self.metadata.get(&prop_key).cloned();
+
+        // Unwrap the inner value of the `Value` enum via trait method,
+        // otherwise format error with prop key as context:
+        value
+            .map(|v| {
+                v.try_value_into()
+                    .or_else(|e| anyhow::bail!("`{prop_key}` `{e}`"))
+            })
+            .map_or(Ok(None), |res| res.map(Some))
+    }
+
+    // Fail early - Catch all missing mandatory keys upfront:
+    pub fn has_required_keys(&self, fields: &[&str]) -> Result<()> {
+        let mut all_props_are_present = true;
+
+        for field_name in fields {
+            let prop_key = format!("{prefix}.{field_name}", prefix = self.path_prefix);
+
+            if !self.metadata.contains_key(&prop_key) {
+                all_props_are_present = false;
+                tracing::warn!("Expected GGUF metadata to have key: `{prop_key}`");
+            }
+        }
+
+        anyhow::ensure!(all_props_are_present, "Tokenizer is missing required props");
+        Ok(())
+    }
+}
+
+// These traits below are a workaround for converting candles GGUF `Value` enum type wrapper.
+// A better upstream approach would instead be to provide serialize/deserialize support?
+pub trait TryFromValue {
+    fn try_from_value(value: gguf_file::Value) -> Result<Self, candle_core::Error>
+    where
+        Self: Sized;
+}
+
+use akin::akin;
+
+// Value wrapped types, each has a different conversion method:
+// NOTE: Type conversion methods internally bail with "not a <into type> <input value>"
+// https://docs.rs/candle-core/latest/candle_core/quantized/gguf_file/enum.Value.html#variants
+akin! {
+    let &types = [String, bool, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64];
+    let &to_type = [
+        value.to_string().cloned(),
+        value.to_bool(),
+        value.to_f32(),
+        value.to_f64(),
+        value.to_i8(),
+        value.to_i16(),
+        value.to_i32(),
+        value.to_i64(),
+        value.to_u8(),
+        value.to_u16(),
+        value.to_u32(),
+        value.to_u64(),
+    ];
+
+    impl TryFromValue for *types {
+        fn try_from_value(value: gguf_file::Value) -> Result<Self, candle_core::Error> {
+            *to_type.or_else(|_| candle_core::bail!("value is not a `*types`"))
+        }
+    }
+}
+
+// Vec<Value> to Vec<T> from above types:
+impl<T: TryFromValue> TryFromValue for Vec<T> {
+    fn try_from_value(value_vec: gguf_file::Value) -> Result<Self, candle_core::Error> {
+        value_vec
+            .to_vec()
+            .or_else(|_| candle_core::bail!("value is not a `Vec`"))?
+            .clone()
+            .into_iter()
+            .map(|item| T::try_from_value(item))
+            .collect()
+    }
+}
+
+pub trait TryValueInto<T>: Sized {
+    fn try_value_into(self) -> Result<T, candle_core::Error>;
+}
+
+impl<T: TryFromValue> TryValueInto<T> for gguf_file::Value {
+    fn try_value_into(self) -> Result<T, candle_core::Error> {
+        T::try_from_value(self)
+    }
+}
+
+impl<T: TryFromValue> TryValueInto<T> for Option<gguf_file::Value> {
+    fn try_value_into(self) -> Result<T, candle_core::Error> {
+        match self {
+            Some(value) => value.try_value_into(),
+            None => candle_core::bail!("Expected `Option<gguf_file::Value>` to contain a value"),
+        }
+    }
+}
+
+struct PropsGGUFTemplate {
+    chat_template: Option<String>,
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUFTemplate {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> Result<Self, Self::Error> {
+        // No required keys
+
+        let props = Self {
+            chat_template: c.get_option_value("chat_template")?,
+        };
+
+        Ok(props)
+    }
+}
+
+// Get chat template from GGUF metadata if it exists
+pub fn get_gguf_chat_template<R: std::io::Seek + std::io::Read>(
+    content: &Content<'_, R>,
+) -> Result<Option<String>> {
+    let metadata = ContentMetadata {
+        path_prefix: "tokenizer",
+        metadata: content.get_metadata(),
+    };
+    let props = PropsGGUFTemplate::try_from(metadata)?;
+    let chat_template = match props.chat_template {
+        Some(chat_template) => Some(chat_template.replace('\n', "\\n")),
+        _ => None,
+    };
+    Ok(chat_template)
+}
+
+pub struct GGUFInfo {
+    pub tokenizer: Tokenizer,
+    pub bos: Option<String>,
+    pub eos: Option<String>,
+    pub unk: Option<String>,
+    pub context_length: Option<usize>,
+    pub chat_template: Option<String>,
+}
+
+struct PropsGGUF {
+    model: String,
+    tokens: Vec<String>,
+    added_tokens: Option<Vec<String>>,
+    scores: Option<Vec<f32>>,
+    merges: Option<Vec<String>>,
+    unk: Option<u32>,
+    eos: u32,
+    bos: u32,
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> Result<Self, Self::Error> {
+        let required = ["model", "tokens", "eos_token_id", "bos_token_id"];
+        c.has_required_keys(&required)?;
+
+        let props = Self {
+            model: c.get_value("model")?,
+            tokens: c.get_value("tokens")?,
+            added_tokens: c.get_value("added_tokens").ok(),
+            scores: c.get_value("scores").ok(),
+            merges: c.get_value("merges").ok(),
+            unk: c.get_value("unknown_token_id").ok(),
+            eos: c.get_value("eos_token_id")?,
+            bos: c.get_value("bos_token_id")?,
+        };
+
+        Ok(props)
+    }
+}
+
+pub fn get_gguf_info<R: std::io::Seek + std::io::Read>(
+    content: &Content<'_, R>,
+) -> Result<GGUFInfo> {
+    let chat_template = {
+        match get_gguf_chat_template(content) {
+            Ok(c) => c,
+            _ => None,
+        }
+    };
+
+    let metadata = ContentMetadata {
+        path_prefix: "tokenizer.ggml",
+        metadata: content.get_metadata(),
+    };
+    let md_get = |s: &str| match metadata.metadata.get(s) {
+        None => candle_core::bail!("cannot find {s} in metadata"),
+        Some(v) => Ok(v),
+    };
+
+    let mut context_length = 4096;
+    let mut token_types = Vec::<i32>::new();
+    for key in metadata.metadata.keys() {
+        if key.find(".context_length").is_some() {
+            context_length = md_get(key).unwrap().to_u32().unwrap();
+        }
+        if key.find("tokenizer.ggml.token_type").is_none()
+            && key.find("tokenizer.ggml.tokens").is_none()
+            && key.find("tokenizer.ggml.merges").is_none()
+            && key.find("tokenizer.chat_template").is_none()
+        {
+            tracing::info!("{key} : {:?}", parse_gguf_value(&md_get(key).unwrap()));
+        }
+
+        if key.find("tokenizer.ggml.token_type").is_some() {
+            let vtypes: &Vec<Value> = md_get(key).unwrap().to_vec().unwrap();
+            let v: Vec<i32> = vtypes.into_iter().map(|v| v.to_i32().unwrap()).collect();
+            token_types.extend(v);
+        }
+    }
+    let props = PropsGGUF::try_from(metadata)?;
+
+    let (mut tokenizer, kind) = match props.model.as_str() {
+        "llama" | "replit" => unigram_tokenizer(&props)?,
+        "gpt2" => bpe_tokenizer(&props)?,
+        other => {
+            anyhow::bail!("Tokenizer model `{other}` not supported.");
+        }
+    };
+
+    //token type other than 1 treated as special token
+    let mut num_special_tokens = 0;
+    if token_types.len() == props.tokens.len() {
+        for i in 0..props.tokens.len() {
+            if token_types[i] != 1i32 {
+                let tk = props.tokens[i].clone();
+                tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
+                num_special_tokens += 1;
+            }
+        }
+    }
+
+    info!(
+        "GGUF tokenizer model is `{model}`, kind: `{kind:?}`, num tokens: {}, num special tokens: {}, num added tokens: {}, num merges: {}, num scores: {}",
+        tokenizer.get_vocab_size(true),
+        num_special_tokens,
+        props.added_tokens.as_ref().map(|x| x.len()).unwrap_or(0),
+        props.merges.as_ref().map(|x| x.len()).unwrap_or(0),
+        props.scores.as_ref().map(|x| x.len()).unwrap_or(0),
+        model = props.model,
+    );
+
+    let unk = match props.unk {
+        Some(u) => Some(props.tokens[u as usize].clone()),
+        _ => None,
+    };
+
+    Ok(GGUFInfo {
+        tokenizer,
+        bos: Some(props.tokens[props.bos as usize].clone()),
+        eos: Some(props.tokens[props.eos as usize].clone()),
+        unk,
+        context_length: Some(context_length as usize),
+        chat_template,
+    })
+}
+
+// TODO: Add support for additional tokenizer models: WordPiece, WordLevel
+// https://docs.rs/tokenizers/latest/tokenizers/models/enum.ModelWrapper.html
+#[derive(Debug)]
+enum TokenizerKind {
+    Unigram,
+    Bpe,
+}
+
+fn bpe_tokenizer(p: &PropsGGUF) -> Result<(Tokenizer, TokenizerKind)> {
+    // BPE merges have each string item as a space-delimited pair:
+    // https://github.com/EricLBuehler/mistral.rs/pull/397#discussion_r1631988370
+    let merges = p
+        .merges
+        .as_ref()
+        .ok_or(anyhow::Error::msg("BPE tokenizer must include merges"))?
+        .iter()
+        .map(|merge| {
+            let split: (&str, &str) = merge
+                .splitn(2, ' ')
+                .collect_tuple()
+                .expect("Failed to convert split into 2-tuple");
+            (split.0.to_string(), split.1.to_string())
+        })
+        .collect::<Vec<_>>();
+
+    let mut vocab = HashMap::new();
+    for (i, token) in p.tokens.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        vocab.insert(token.clone(), i as u32);
+    }
+
+    let PropsGGUF { eos, bos, unk, .. } = *p;
+
+    let mut bpe = BpeBuilder::new().vocab_and_merges(vocab, merges);
+    if let Some(unk) = unk {
+        bpe = bpe.unk_token(p.tokens[unk as usize].to_string());
+    };
+
+    let bpe = bpe.build().map_err(anyhow::Error::msg)?;
+
+    let mut tokenizer = TokenizerX::new(
+        ModelWrapper::BPE(bpe),
+        Some(Decoder::ByteLevel(true, true, true)),
+        None,
+    )?;
+
+    let split = Split::new(
+        SplitPattern::Regex("(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+".to_string()),
+        SplitDelimiterBehavior::Isolated,
+        false,
+    ).unwrap();
+
+    // example:
+    // "type": "ByteLevel",
+    // "add_prefix_space": false,
+    // "trim_offsets": false,
+    // "use_regex": false
+    let pre_tokenizer = Sequence::new(vec![
+        PreTokenizerWrapper::Split(split),
+        PreTokenizerWrapper::ByteLevel(ByteLevel::new(false, false, false)),
+    ]);
+
+    tokenizer.with_pre_tokenizer(Some(pre_tokenizer));
+
+    tokenizer.with_decoder(Some(decoders::byte_level::ByteLevel::new(
+        false, false, false,
+    )));
+    tokenizer.with_post_processor(Some(processors::byte_level::ByteLevel::new(
+        false, false, false,
+    )));
+
+    for i in [bos, eos] {
+        let tk = p.tokens[i as usize].clone();
+        tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
+    }
+    if unk.is_some() {
+        let tk = p.tokens[unk.unwrap() as usize].clone();
+        tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
+    }
+
+    Ok((tokenizer, TokenizerKind::Bpe))
+}
+
+fn unigram_tokenizer(p: &PropsGGUF) -> Result<(Tokenizer, TokenizerKind)> {
+    let PropsGGUF { unk, eos, bos, .. } = *p;
+    // Unigram (SentencePiece) default UNK is 0
+    let unk = unk.unwrap_or(0);
+
+    // Create the Tokenizer model:
+    let model = {
+        let vocab: Vec<(String, f64)> = {
+            let Some(s) = p.scores.as_ref() else {
+                anyhow::bail!(
+                    "`llama` unigram tokenizer is missing required metadata `tokenizer.ggml.scores`"
+                );
+            };
+            let scores = s.iter().cloned().map(|f_32| f_32 as f64);
+
+            p.tokens.iter().cloned().zip(scores).collect()
+        };
+
+        Unigram::from(vocab, Some(unk as usize), true).map_err(anyhow::Error::msg)?
+    };
+
+    // Decoder + Normalizer config reference:
+    // https://github.com/EricLBuehler/mistral.rs/pull/389#discussion_r1630620763
+    let decoder = Decoder::Sequence(vec![
+        Decoder::Replace("▁", " "),
+        Decoder::ByteFallback,
+        Decoder::Fuse,
+        Decoder::Strip(' ', 1, 0),
+    ]);
+
+    let normalizer = Normalizer::Sequence(vec![
+        Normalizer::Prepend("▁"),
+        Normalizer::Replace(" ", "▁"),
+    ]);
+
+    let mut tokenizer: Tokenizer = TokenizerX::new(
+        ModelWrapper::Unigram(model),
+        Some(decoder),
+        Some(normalizer),
+    )?;
+
+    // Add special tokens (bos, eos, unk):
+    for i in [bos, eos, unk] {
+        let tk = p.tokens[i as usize].clone();
+        tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
+    }
+
+    Ok((tokenizer, TokenizerKind::Unigram))
+}
+
+// This is a workaround to have a better builder API.
+// Upstream `TokenizerBuilder` is difficult to work with:
+// https://github.com/huggingface/tokenizers/issues/1549
+struct TokenizerX;
+
+impl TokenizerX {
+    #[allow(clippy::new_ret_no_self)]
+    fn new<'a>(
+        model: ModelWrapper,
+        decoder: Option<Decoder<'a>>,
+        normalizer: Option<Normalizer<'a>>,
+    ) -> Result<Tokenizer> {
+        let mut tokenizer = Tokenizer::new(model);
+
+        // Handle local enum to remote enum type:
+        if let Some(decoder) = decoder {
+            let d = DecoderWrapper::try_from(decoder)?;
+            tokenizer.with_decoder(Some(d));
+        }
+        if let Some(normalizer) = normalizer {
+            let n: NormalizerWrapper = NormalizerWrapper::try_from(normalizer)?;
+            tokenizer.with_normalizer(Some(n));
+        }
+
+        Ok(tokenizer)
+    }
+}
+
+// Convenient alternative to upstream:
+// https://docs.rs/tokenizers/latest/tokenizers/decoders/enum.DecoderWrapper.html
+enum Decoder<'a> {
+    ByteFallback,
+    Fuse,
+    Replace(&'a str, &'a str),
+    Strip(char, usize, usize),
+    Sequence(Vec<Self>),
+    ByteLevel(bool, bool, bool),
+}
+
+// Convert into upstream type wrapped enum variants:
+impl TryFrom<Decoder<'_>> for DecoderWrapper {
+    type Error = anyhow::Error;
+
+    fn try_from(variant: Decoder) -> Result<Self, Self::Error> {
+        let value: DecoderWrapper = match variant {
+            Decoder::ByteFallback => ByteFallback::default().into(),
+            Decoder::Fuse => Fuse::default().into(),
+            Decoder::Replace(pattern, content) => Replace::new(pattern, content)
+                .map_err(anyhow::Error::msg)?
+                .into(),
+            Decoder::Strip(content, start, stop) => Strip::new(content, start, stop).into(),
+            Decoder::Sequence(decoders) => {
+                let seq = decoders
+                    .into_iter()
+                    .map(DecoderWrapper::try_from)
+                    .collect::<Result<Vec<DecoderWrapper>>>()?;
+
+                decoders::sequence::Sequence::new(seq).into()
+            }
+            Decoder::ByteLevel(add_prefix_space, trim_offsets, use_regex) => {
+                ByteLevel::new(add_prefix_space, trim_offsets, use_regex).into()
+            }
+        };
+
+        Ok(value)
+    }
+}
+
+// Convenient alternative to upstream:
+// https://docs.rs/tokenizers/latest/tokenizers/normalizers/enum.NormalizerWrapper.html
+enum Normalizer<'a> {
+    Prepend(&'a str),
+    Replace(&'a str, &'a str),
+    Sequence(Vec<Self>),
+}
+
+impl TryFrom<Normalizer<'_>> for NormalizerWrapper {
+    type Error = anyhow::Error;
+
+    fn try_from(variant: Normalizer) -> Result<Self, Self::Error> {
+        let value: NormalizerWrapper = match variant {
+            Normalizer::Prepend(prepend) => Prepend::new(prepend.to_owned()).into(),
+            Normalizer::Replace(pattern, content) => Replace::new(pattern, content)
+                .map_err(anyhow::Error::msg)?
+                .into(),
+            Normalizer::Sequence(decoders) => {
+                let seq = decoders
+                    .into_iter()
+                    .map(NormalizerWrapper::try_from)
+                    .collect::<Result<Vec<NormalizerWrapper>>>()?;
+
+                normalizers::Sequence::new(seq).into()
+            }
+        };
+
+        Ok(value)
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 mod cache;
+pub mod gguf;
 pub mod gptq;
 mod paged_attention;
 #[cfg(feature = "cuda")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use clap::Subcommand;
 use openai::pipelines::pipeline::DefaultLoader;
 use std::fmt::Display;
 use std::path::Path;
-
+use tracing::warn;
 pub mod backend;
 pub mod openai;
 pub mod paged_attention;
@@ -853,7 +853,7 @@ pub fn hub_load_local_safetensors(
     path: &String,
     json_file: &str,
 ) -> Result<Vec<std::path::PathBuf>> {
-    println!("{:}", Path::new(path).join(json_file).display());
+    tracing::info!("{:}", Path::new(path).join(json_file).display());
     let jsfile = std::fs::File::open(Path::new(path).join(json_file))?;
     let json: serde_json::Value = serde_json::from_reader(&jsfile).map_err(candle::Error::wrap)?;
     let weight_map = match json.get("weight_map") {
@@ -884,13 +884,13 @@ pub fn new_device(ordinal: usize) -> Result<Device> {
     } else {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            println!(
+            warn!(
                 "Running on CPU, to run on GPU(metal), build this example with `--features metal`"
             );
         }
         #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
         {
-            println!("Running on CPU, to run on GPU, build this example with `--features cuda`");
+            warn!("Running on CPU, to run on GPU, build this example with `--features cuda`");
         }
         Ok(Device::Cpu)
     }

--- a/src/openai/models/gemma.rs
+++ b/src/openai/models/gemma.rs
@@ -14,7 +14,7 @@ use candle_nn::{Activation, RmsNorm};
 use std::iter::zip;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
-
+use tracing::warn;
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct GemmaConfig {
     pub attention_bias: bool,
@@ -49,7 +49,7 @@ impl GemmaConfig {
         let hidden_act = match (self.hidden_act, self.hidden_activation) {
             (None, Some(act)) | (Some(act), None) => Some(act),
             (Some(act), Some(_)) => {
-                println!("both hidden_act and hidden_activation are set");
+                warn!("both hidden_act and hidden_activation are set");
                 Some(act)
             }
             (None, None) => panic!("none of hidden_act and hidden_activation are set"),

--- a/src/openai/models/linear.rs
+++ b/src/openai/models/linear.rs
@@ -30,7 +30,7 @@ pub use candle_nn::var_builder::Shard;
 pub use candle_nn::var_builder::ShardedVarBuilder as VarBuilder;
 use either::Either;
 use std::sync::Arc;
-
+use tracing::warn;
 #[derive(Clone, Debug)]
 pub struct Linear {
     weight: Tensor,
@@ -318,7 +318,7 @@ pub fn qlinear(
                 {
                     //only model with 4-bit and desc_act==false can be repacked to marlin format
                     if cfg.quant_method == "marlin" {
-                        println!("The current GPTQ model does no compatible with marlin format because one of the following conditions: !cfg.sym || cfg.bits != 4 || (cfg.group_size != 128 && cfg.group_size != -1) || (cfg.desc_act == true)");
+                        warn!("The current GPTQ model does no compatible with marlin format because one of the following conditions: !cfg.sym || cfg.bits != 4 || (cfg.group_size != 128 && cfg.group_size != -1) || (cfg.desc_act == true)");
                     }
                     //conventional gptq format
                     Ok(Linear {

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -185,54 +185,6 @@ impl Config {
     }
 }
 
-//chat template embedded in the gguf file
-pub fn get_tokenizer_cfg(ct: &candle_core::quantized::gguf_file::Content) -> Option<String> {
-    use serde_json::json;
-    let md_get = |s: &str| match ct.metadata.get(s) {
-        None => candle_core::bail!("cannot find {s} in metadata"),
-        Some(v) => Ok(v),
-    };
-
-    if ct.metadata.contains_key("tokenizer.chat_template")
-        && ct.metadata.contains_key("tokenizer.ggml.bos_token_id")
-        && ct.metadata.contains_key("tokenizer.ggml.eos_token_id")
-    {
-        match ct.metadata.get("tokenizer.chat_template") {
-            Some(v) => {
-                let chat_template = v.to_string().unwrap().clone();
-                let bos_token_id = md_get("tokenizer.ggml.bos_token_id")
-                    .unwrap()
-                    .to_u32()
-                    .unwrap();
-                let eos_token_id = md_get("tokenizer.ggml.eos_token_id")
-                    .unwrap()
-                    .to_u32()
-                    .unwrap();
-
-                let mut context_length = 4096;
-                for key in ct.metadata.keys() {
-                    if key.find(".context_length").is_some() {
-                        context_length = md_get(key).unwrap().to_u32().unwrap();
-                        println!("{key} : {}", context_length);
-                        break;
-                    }
-                }
-
-                let json_value = json!({
-                    "bos_token": bos_token_id.to_string(),
-                    "eos_token": eos_token_id.to_string(),
-                    "model_max_length": context_length as usize,
-                    "chat_template": chat_template,
-                });
-                Some(json_value.to_string())
-            }
-            _ => None,
-        }
-    } else {
-        None
-    }
-}
-
 pub fn get_attention_casual_mask(
     device: &Device,
     dtype: DType,

--- a/src/openai/openai_server.rs
+++ b/src/openai/openai_server.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use tokenizers::Encoding;
 use tokio::sync::Notify;
 use tokio::time::Duration;
+use tracing::info;
 use uuid::Uuid;
 // fn verify_model(data: &OpenAIServerData<'_>, model_name: &String) -> Result<(), APIError> {
 //     let current_name = {
@@ -157,7 +158,7 @@ pub async fn chat_completions(
     }
     let token_ids: Encoding = token_ids.unwrap();
 
-    println!("\n\n\nPrompt {:?}", prompt);
+    info!("\n\n\nPrompt {:?}", prompt);
 
     let request_id = format!("cmpl-{}", Uuid::new_v4());
 

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -180,13 +180,13 @@ impl LLMEngine {
                             .unwrap_or(0),
                     };
 
-                    println!(
+                    warn!(
                         "\r\n [{} requests] Prefilling: {} prompt tokens processed in {} seconds",
                         result.len(),
                         overall_usage.prompt_tokens,
                         overall_usage.prompt_time_costs / 1000
                     );
-                    println!(
+                    warn!(
                         "\r\n [{} requests] Decoding: {} tokens processed in {} seconds ({:.02} tokens/s)",
                         result.len(),
                         overall_usage.completion_tokens,
@@ -428,7 +428,7 @@ impl LLMEngine {
         let mut prompt_finish_times = HashMap::<usize, SystemTime>::new();
         #[cfg(feature = "nccl")]
         {
-            warn!("Start processing...");
+            info!("Start processing...");
             let e = engine.read();
             let (pipeline, _) = e.get_pipeline(rank).unwrap();
             let device = pipeline.device();
@@ -441,7 +441,7 @@ impl LLMEngine {
                 }
                 let e = engine.read();
                 if !e.scheduler.has_unfinished_sequences() {
-                    warn!("generate_once: no unfinished_sequences, break");
+                    info!("generate_once: no unfinished_sequences, break");
                     break;
                 }
             }
@@ -602,7 +602,7 @@ impl LLMEngine {
                             );
                             let ret = sender.send(ChatResponse::Chunk(chunk));
                             if ret.is_err() {
-                                println!(
+                                warn!(
                                     "Send stream response error! (sequence id {})",
                                     seq.deref().get_id()
                                 );
@@ -625,7 +625,7 @@ impl LLMEngine {
                             );
                             let ret = sender.send(ChatResponse::Chunk(chunk));
                             if ret.is_err() {
-                                println!("Send stream finish response error!");
+                                warn!("Send stream finish response error!");
                             }
                         };
                         seq.deref_mut().set_finish_reason(finish_reason)
@@ -654,7 +654,7 @@ impl LLMEngine {
                     #[cfg(not(feature = "nccl"))]
                     let do_log = true;
                     if do_log {
-                        println!(
+                        warn!(
                             "Request {} decoding {} tokens finished in {} seconds",
                             group.request_id,
                             decoded_tokens,
@@ -1078,7 +1078,7 @@ impl LLMEngine {
         #[cfg(not(feature = "nccl"))]
         let do_log = true;
         if do_log {
-            println!(
+            warn!(
                 "Request {} with length {} added to sequence waiting group.",
                 request_id.clone(),
                 prompt_len

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -10,7 +10,7 @@ pub mod block_engine;
 /// operations issued by the scheduler.
 pub mod cache_engine;
 pub mod sequence;
-
+use tracing::warn;
 type CPUBlockFrom = usize;
 type GPUBlockFrom = usize;
 type CPUBlockTo = usize;
@@ -93,7 +93,7 @@ impl Scheduler {
                 match can_allocate {
                     AllocStatus::Later => break, //If we can only allocate later, do not bother iterating over the rest.
                     AllocStatus::Impossible => {
-                        println!(
+                        warn!(
                             "Input prompt with length of {} tokens is too long and exceeds capacity of block engine.",
                             seq_group.get_prompt_len()
                         );


### PR DESCRIPTION
This PR adds support for decoding metadata from GGUF files, eliminating the need to download `tokenizer.json` and `tokenizer_config.json` from the web. It also supports metadata from the latest Qwen3 GGUF models, enabling correct reasoning.

The key point is to ensure that tokenizers built from GGUF metadata work the same way as those built from JSON files: by correctly identifying `special` tokens using the `token_type` stored in the metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting tokenizer metadata and constructing tokenizers directly from GGUF quantized model files, including chat templates and special tokens.

- **Bug Fixes**
  - Improved handling of tokenizer and chat template loading for quantized models, ensuring correct extraction and configuration.

- **Refactor**
  - Centralized tokenizer and chat template loading logic for improved maintainability.
  - Removed redundant tokenizer configuration extraction from GGUF files.

- **Style**
  - Replaced all direct print statements with structured logging using the `tracing` crate for consistent and informative output.

- **Chores**
  - Updated dependencies to include `tracing-subscriber`, `akin`, and `itertools`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->