### PR TITLE
Optional BF16 for CUDA platform

### DIFF
--- a/kernels/src/marlin/marlin_dtypes.cuh
+++ b/kernels/src/marlin/marlin_dtypes.cuh
@@ -71,6 +71,26 @@ class ScalarType<nv_bfloat16> {
   static __host__ __device__ nv_bfloat16 inline float2num(const float x) {
     return __float2bfloat16(x);
   }
+
+#else
+
+  static __device__ float inline num2float(const nv_bfloat16 x) {
+    return 0.0f;
+  }
+
+  static __device__ nv_bfloat162 inline num2num2(const nv_bfloat16 x) {
+    return nv_bfloat162();
+  }
+
+  static __device__ nv_bfloat162 inline nums2num2(const nv_bfloat16 x1,
+                                                  const nv_bfloat16 x2) {
+    return nv_bfloat162();
+  }
+
+  static __host__ __device__ nv_bfloat16 inline float2num(const float x) {
+    return nv_bfloat16();
+  }
+
 #endif
 };
 

--- a/kernels/src/pagedattention.cu
+++ b/kernels/src/pagedattention.cu
@@ -430,6 +430,12 @@ __global__ void paged_attention_v1_kernel(
   const int kv_block_stride,
   const int kv_head_stride,
   const float softscapping) {
+  if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+      return;
+    #endif
+  }
+
   paged_attention_kernel<scalar_t, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS>(
     /* exp_sums */ nullptr, /* max_logits */ nullptr,
     out, q, k_cache, v_cache, num_kv_heads, scale, block_tables, context_lens,
@@ -460,6 +466,11 @@ __global__ void paged_attention_v2_kernel(
   const int kv_block_stride,
   const int kv_head_stride,
   const float softscapping) {
+  if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+      return;
+    #endif
+  }
   paged_attention_kernel<scalar_t, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS, PARTITION_SIZE>(
     exp_sums, max_logits, tmp_out, q, k_cache, v_cache, num_kv_heads, scale,
     block_tables, context_lens, max_num_blocks_per_seq, alibi_slopes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,12 +197,12 @@ fn get_dtype(dtype: Option<String>) -> DType {
                     )
                 };
                 info!(
-                    "CUDA compute compability: {}.{}",
+                    "CUDA compute capability: {}.{}",
                     compute_major, compute_minor,
                 );
                 if dtype != DType::F32 && compute_major < 8 {
                     warn!(
-                        "CUDA compute compability: {} (<8), switched to F16 cause no BF16 support.",
+                        "CUDA compute capability: {} (<8), switched to F16 cause no BF16 support.",
                         compute_major
                     );
                     DType::F16


### PR DESCRIPTION
This PR aims to provide compatibility for older Nvidia hardware by making BF16 optional. This feature has not been validated, as I do not have access to older devices. This PR first needs to be evaluated on Nvidia devices with **CUDA capability < 8**.

**How to Test**

Build and run the program without the `dtype` parameter — this lets the program automatically determine whether BF16 can be enabled.

Example Command:

```shell
cargo run --release --features cuda,nccl -- \
  --multi-process \
  --port 2000 \
  --device-ids "0,1" \
  --weight-path /home/data/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/ \
  llama3 \
  --quant awq \
  --temperature 0. \
  --penalty 1.0
```

```
2025-06-10T11:23:21.638553Z  INFO candle_vllm: /home/data/Meta-Llama-3.1-8B-Instruct-AWQ-INT4-Marlin/model.safetensors.index.json
2025-06-10T11:23:21.823983Z  INFO candle_vllm: CUDA compute capability: 8.9
2025-06-10T11:23:21.824008Z  INFO candle_vllm::openai::communicator: Running on single node!
2025-06-10T11:23:21.840253Z  INFO candle_vllm::openai::communicator: build data channel for the main process!
2025-06-10T11:23:21.884443Z  INFO candle_vllm::openai::communicator: accept one daemon process in data channel!
2025-06-10T11:23:21.884524Z  INFO candle_vllm::openai::communicator: one daemon process connected to the data channel!
2025-06-10T11:23:21.884539Z  WARN candle_vllm::openai::communicator: data channel is built!
2025-06-10T11:23:21.884566Z  WARN candle_vllm::openai::communicator: All subprocess workers have connected to the main processes!
2025-06-10T11:23:21.884575Z  INFO candle_vllm::openai::communicator: local_rank 0, global_rank 0, local_world_size 2, global_world_size 2
2025-06-10T11:23:21.884588Z  WARN candle_vllm: subprocess rank 0 started!
2025-06-10T11:23:21.884913Z  INFO candle_vllm::openai::communicator: build command channel for the main process!
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added automatic detection of CUDA device capabilities to select the appropriate data type, ensuring compatibility with hardware that does not support BF16.
    - Users are now warned and automatically switched to FP16 if BF16 is requested on unsupported CUDA architectures.
    - Added safeguards to prevent execution of BF16-specific operations on unsupported CUDA architectures, improving stability.

- **Refactor**
    - Centralized data type selection logic for improved maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->