### PR TITLE
Support NUMA binding for multi-rank inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ parking_lot = "0.12"
 akin = "0.4.0"
 itertools = "0.13.0"
 chrono = "0.4.41"
+which = "5"
 
 [features]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]

--- a/README-CN.md
+++ b/README-CN.md
@@ -318,6 +318,33 @@ cargo build --release --features cuda,nccl,mpi #构建MPI功能
     ```
   </details>
 
+- 在多核CPU机器上使用 **NUMA绑定**运行模型
+  <details>
+    <summary>显示命令</summary>
+
+    **前置条件**
+    请确保你的机器有多个 NUMA 节点（即多个物理 CPU），并安装 numactl：
+
+    ```shell
+    sudo apt-get install numactl
+    ```
+
+    假设你的机器有 8 张 GPU 和 2 个 NUMA 节点，每 4 张 GPU 绑定到一个不同的 NUMA 节点。
+    如果你想使用全部 GPU 进行推理，下面的 NUMA 绑定配置可以获得最佳性能：
+
+    ```shell
+    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    ```
+
+    如果你只使用 4 张 GPU，可以使用如下的 NUMA 绑定方式：
+    
+    ```shell
+    MAP_NUMA_NODE=0,0,0,0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    ```
+
+    注意： 绑定顺序可能会根据你的硬件配置有所不同。
+  </details>
+
 ## 如何向后端发送请求？
 
 **启动后端服务后运行聊天前端**

--- a/README-CN.md
+++ b/README-CN.md
@@ -333,15 +333,17 @@ cargo build --release --features cuda,nccl,mpi #构建MPI功能
     如果你想使用全部 GPU 进行推理，下面的 NUMA 绑定配置可以获得最佳性能：
 
     ```shell
-    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 numactl --cpunodebind=0 --membind=0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
     ```
 
     如果你只使用 4 张 GPU，可以使用如下的 NUMA 绑定方式：
     
     ```shell
-    MAP_NUMA_NODE=0,0,0,0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    MAP_NUMA_NODE=0,0,0,0 numactl --cpunodebind=0 --membind=0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
     ```
 
+    以上命令中 `numactl --cpunodebind=0 --membind=0`指定了master进程（master rank）绑定的NUMA node，其必须与 `MAP_NUMA_NODE`相匹配。
+    
     注意： 绑定顺序可能会根据你的硬件配置有所不同。
   </details>
 

--- a/README.md
+++ b/README.md
@@ -336,14 +336,15 @@ cargo build --release --features cuda,nccl,mpi #build with mpi feature
     To achieve optimal performance during inference using all GPUs, use the following NUMA binding:
 
     ```shell
-    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 numactl --cpunodebind=0 --membind=0 target/release/candle-vllm --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
     ```
 
     To use only 4 GPUs, you can apply this NUMA binding:
     
     ```shell
-    MAP_NUMA_NODE=0,0,0,0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    MAP_NUMA_NODE=0,0,0,0 numactl --cpunodebind=0 --membind=0 target/release/candle-vllm --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
     ```
+    *where* `numactl --cpunodebind=0 --membind=0` above indicates NUMA binding for the master rank (master process) which should be matched to `MAP_NUMA_NODE`.
 
     Note: The exact NUMA binding sequence may vary depending on your hardware configuration.
   </details>

--- a/README.md
+++ b/README.md
@@ -322,6 +322,32 @@ cargo build --release --features cuda,nccl,mpi #build with mpi feature
     ```
   </details>
 
+- Run with **NUMA binding**
+  <details>
+    <summary>Show command</summary>
+
+    **Prerequisite**
+    Ensure your machine has more than one NUMA node (i.e., more than one physical CPU), and install numactl:
+    ```shell
+    sudo apt-get install numactl
+    ```
+
+    Suppose your machine has 8 GPUs and 2 NUMA nodes, with each set of 4 GPUs bound to a different NUMA node.
+    To achieve optimal performance during inference using all GPUs, use the following NUMA binding:
+
+    ```shell
+    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    ```
+
+    To use only 4 GPUs, you can apply this NUMA binding:
+    
+    ```shell
+    MAP_NUMA_NODE=0,0,0,0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
+    ```
+
+    Note: The exact NUMA binding sequence may vary depending on your hardware configuration.
+  </details>
+
 ## How to send request(s) to the backend?
 
 **Run chat frontend after starting the backend service**

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,7 +428,7 @@ async fn main() -> Result<(), APIError> {
     }
 
     if global_rank == 0 {
-        info!("Maximum Model Length (affected by `--kvcache-mem-gpu` and the number of ranks):");
+        warn!("Maximum Model Length (affected by `--kvcache-mem-gpu` and the number of ranks):");
         for batch in [1, 8] {
             println!(
                 "-> Batch {}: {}",

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -241,7 +241,7 @@ impl LLMEngine {
                             task.use_logprobs,
                             None,
                         );
-                        info!("Daemon process: add_sequence to group {}", task.group_id);
+                        tracing::debug!("Daemon process: add_sequence to group {}", task.group_id);
                         self.scheduler.add_sequence(seq_group);
                     }
                 }


### PR DESCRIPTION
To achieve optimal performance on **multi-socket, multi-core** machine

- Run with **NUMA binding**
    
    **Prerequisite**
    Ensure your machine has more than one NUMA node (i.e., more than one physical CPU), and install numactl:
    ```shell
    sudo apt-get install numactl
    ```

    Suppose your machine has 8 GPUs and 2 NUMA nodes, with each set of 4 GPUs bound to a different NUMA node.
    To achieve optimal performance during inference using all GPUs, use the following NUMA binding:

    ```shell
    MAP_NUMA_NODE=0,0,0,0,1,1,1,1 numactl --cpunodebind=0 --membind=0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3,4,5,6,7" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
    ```

    To use only 4 GPUs, you can apply this NUMA binding:
    
    ```shell
    MAP_NUMA_NODE=0,0,0,0 numactl --cpunodebind=0 --membind=0 cargo run --release --features cuda,nccl -- --multi-process --dtype bf16 --port 2000 --device-ids "0,1,2,3" --weight-path /home/data/DeepSeek-V2-Chat-AWQ-Marlin deep-seek --quant awq --temperature 0. --penalty 1.0
    ```

    *where* `numactl --cpunodebind=0 --membind=0` above indicates NUMA binding for the master rank (master process) which should be matched to `MAP_NUMA_NODE`.

    Note: The exact NUMA binding sequence may vary depending on your hardware configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NUMA node binding via the MAP_NUMA_NODE environment variable, allowing improved performance on multi-NUMA-node machines.
- **Documentation**
  - Updated README and README-CN with instructions and examples for running with NUMA binding, including prerequisites and usage scenarios.
- **Style**
  - Adjusted log levels for certain messages to improve clarity and relevance in log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->