### PR TITLE
Qwen3-Reranker guideline & fix system prompt for next mini-chat session

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -347,6 +347,38 @@ cargo build --release --features cuda,nccl,mpi #构建MPI功能
     注意： 绑定顺序可能会根据你的硬件配置有所不同。
   </details>
 
+- 使用**Qwen3-Reranker**进行知识检索
+  <details>
+    <summary>显示命令</summary>
+
+    1) 启动`Qwen3-Reranker`模型服务
+    ```shell
+    target/release/candle-vllm --port 2000 --multi-process --weight-file /home/data/Qwen3-Reranker-4B-q4_k_m.gguf qwen3 --quant gguf
+    ```
+
+    2) 启动迷你聊天机器人并传入`system prompt`
+    ```shell
+    python3 examples/chat.py --thinking True --system_prompt "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\"."
+    ```
+
+    3) 使用query/doc对进行知识检查，例如：
+    ```shell
+    <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
+    ```
+
+    观察输出结果：
+    
+    ```shell
+    🙋 Please Input (Ctrl+C to start a new chat or exit): <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
+    Candle-vLLM: ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    <think>
+    Okay, the user is asking for the capital of China. The document provided is a direct answer: "The capital of China is Beijing." I need to check if this is correct. From my knowledge, Beijing is indeed the capital of China. The answer is correct and straightforward. The document meets the requirement as it provides the accurate information. So the answer is yes.
+    </think>
+
+    yes
+    ```
+  </details>
+
 ## 如何向后端发送请求？
 
 **启动后端服务后运行聊天前端**

--- a/README.md
+++ b/README.md
@@ -349,6 +349,38 @@ cargo build --release --features cuda,nccl,mpi #build with mpi feature
     Note: The exact NUMA binding sequence may vary depending on your hardware configuration.
   </details>
 
+- Run **Qwen3-Reranker**
+  <details>
+    <summary>Show command</summary>
+
+    1) Start the backend service for `Qwen3-Reranker` model
+    ```shell
+    target/release/candle-vllm --port 2000 --multi-process --weight-file /home/data/Qwen3-Reranker-4B-q4_k_m.gguf qwen3 --quant gguf
+    ```
+
+    2) Start the chatbot with `system prompt` for qwen3-reranker
+    ```shell
+    python3 examples/chat.py --thinking True --system_prompt "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\"."
+    ```
+
+    3) Chat with chatbot for any query/doc pairs, for example,
+    ```shell
+    <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
+    ```
+
+    Observe the answer:
+    
+    ```shell
+    🙋 Please Input (Ctrl+C to start a new chat or exit): <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
+    Candle-vLLM: ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    <think>
+    Okay, the user is asking for the capital of China. The document provided is a direct answer: "The capital of China is Beijing." I need to check if this is correct. From my knowledge, Beijing is indeed the capital of China. The answer is correct and straightforward. The document meets the requirement as it provides the accurate information. So the answer is yes.
+    </think>
+
+    yes
+    ```
+  </details>
+
 ## How to send request(s) to the backend?
 
 **Run chat frontend after starting the backend service**

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -138,10 +138,14 @@ def chatloop(system_prompt: Optional[str], stream: bool, live: bool,
                 console.log(f"Unexpected OpenAI error: {e}", style="bold red")
         
         except KeyboardInterrupt:
-            if len(messages) == 0:
+            if len(messages) == 0 or (len(messages) == 1 and messages[0]["role"]=="system"):
                 console.print("\nExiting.", style="bold green")
                 break
+
             messages.clear()
+            # Reinsert the system prompt for the next chat session
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
             console.clear()
             console.log("A new chat is started. Press Ctrl+C again to exit.", style="yellow")
             continue


### PR DESCRIPTION
This PR adds a guideline for running `Qwen3-reranker` model:

- Run **Qwen3-Reranker**

    1) Start the backend service for `Qwen3-Reranker` model
    ```shell
    target/release/candle-vllm --port 2000 --multi-process --weight-file /home/data/Qwen3-Reranker-4B-q4_k_m.gguf qwen3 --quant gguf
    ```

    2) Start the chatbot with `system prompt` for qwen3-reranker
    ```shell
    python3 examples/chat.py --thinking True --system_prompt "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\"."
    ```

    3) Chat with chatbot for any query/doc pairs, for example,
    ```shell
    <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
    ```

    Observe the answer:
    
    ```shell
    🙋 Please Input (Ctrl+C to start a new chat or exit): <Query>: What is the capital of China?\n\n<Document>: The capital of China is Beijing.
    Candle-vLLM: ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    <think>
    Okay, the user is asking for the capital of China. The document provided is a direct answer: "The capital of China is Beijing." I need to check if this is correct. From my knowledge, Beijing is indeed the capital of China. The answer is correct and straightforward. The document meets the requirement as it provides the accurate information. So the answer is yes.
    </think>

    yes
    ```

This PR also address the issue of missing system prompt in the next mini-chat session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions in both English and Chinese READMEs for running the Qwen3-Reranker model, including setup steps, usage guidance, and example interactions.

- **Bug Fixes**
  - Improved chat session handling to ensure proper exit conditions and consistent persistence of the system prompt after interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->