### PR TITLE
Support flash attention kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
-candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "0334796" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "0334796" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "0334796" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.1"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "0334796" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -33,7 +33,7 @@ accelerate-src = { version = "0.3.2", optional = true }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], optional = true }
 cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", branch = "candle-main", optional = true }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "0334796" }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"
@@ -68,7 +68,7 @@ accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/acceler
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:kernels"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels", "dep:metal"]
 cudnn = ["candle-core/cudnn"]
-flash-attn = ["cuda", "candle-transformers/flash-attn"]
+flash-attn = ["cuda", "candle-transformers/flash-attn", "dep:candle-flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]
 nccl = ["cuda", "cudarc/nccl"]
 mpi = ["cuda", "cudarc/nccl", "dep:mpi"]

--- a/README-CN.md
+++ b/README-CN.md
@@ -65,17 +65,25 @@ sudo apt install libssl-dev pkg-config -y
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
 
-#确保CUDA Toolkit在系统PATH中
+#Mac/Metal平台编译命令
+cargo build --release --features metal
+
+#CUDA平台：确保CUDA Toolkit在系统PATH中
 export PATH=$PATH:/usr/local/cuda/bin/
 
-#单节点（单机单卡或单机多卡）编译命令
+#CUDA平台：单节点（单机单卡或单机多卡）编译命令
 cargo build --release --features cuda,nccl
 
-#多节点（多机推理）编译命令
+#CUDA平台：单节点（使用flash attention kernel，适用于长上下文推理）编译命令
+cargo build --release --features cuda,nccl,flash-attn
+
+#CUDA平台：多节点（多机推理）编译命令
 sudo apt update
 sudo apt install libopenmpi-dev openmpi-bin -y #安装MPI
 sudo apt install clang libclang-dev
-cargo build --release --features cuda,nccl,mpi #构建MPI功能
+cargo build --release --features cuda,nccl,mpi #包含MPI功能
+#或
+cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash attention与MPI功能
 ```
 
 ### 构建/运行参数

--- a/README.md
+++ b/README.md
@@ -65,17 +65,25 @@ sudo apt install libssl-dev pkg-config -y
 git clone git@github.com:EricLBuehler/candle-vllm.git
 cd candle-vllm
 
+## Mac/Metal (single-node only)
+cargo build --release --features metal
+
 #Make sure the CUDA Toolkit can be found in the system PATH
 export PATH=$PATH:/usr/local/cuda/bin/
 
-#single-node compilation (single gpu, or multi-gpus on single machine)
+#CUDA: single-node compilation (single gpu, or multi-gpus on single machine)
 cargo build --release --features cuda,nccl
 
-#multinode compilation (multi-gpus, multiple machines)
+#CUDA: single-node compilation with flash attention (takes few minutes for the first build, faster inference for long-context)
+cargo build --release --features cuda,nccl,flash-attn
+
+#CUDA: multinode compilation with MPI (multi-gpus, multiple machines)
 sudo apt update
 sudo apt install libopenmpi-dev openmpi-bin -y #install mpi
 sudo apt install clang libclang-dev
 cargo build --release --features cuda,nccl,mpi #build with mpi feature
+# or
+cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn and mpi features
 ```
 
 ### Build/Run Parameters

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -60,7 +60,7 @@ def chatloop(system_prompt: Optional[str], stream: bool, live: bool,
     while True:
         try:
             # User input
-            user_input = input("🙋 Please Input (Ctrl+C to start a new chat or exit): ")
+            user_input = input("\n🙋 Please Input (Ctrl+C to start a new chat or exit): ")
             if user_input == "":
                 console.print("Multiline input: press Ctrl+D to finish, Ctrl+C to exit.")
                 user_input = sys.stdin.read()

--- a/src/backend/gguf.rs
+++ b/src/backend/gguf.rs
@@ -71,11 +71,9 @@ impl<'a, R: std::io::Seek + std::io::Read> Content<'a, R> {
                 }
                 accum
             });
-        if n_splits.len() > 1 {
-            candle_core::bail!("GGUF files have differing `split.count` values: {n_splits:?}. Perhaps the GGUF files do not match?");
-        }
+
         #[allow(clippy::cast_possible_truncation)]
-        if !n_splits.is_empty() && n_readers != n_splits[0] as usize {
+        if !n_splits.is_empty() && n_splits[0] > 0 && n_readers != n_splits[0] as usize {
             candle_core::bail!(
                 "Number of GGUF files does not match the number of splits, expected {} files.",
                 n_splits[0]

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,14 @@ async fn main() -> Result<(), APIError> {
         num_shards == 1,
         "More than one shard was given, but NCCL is not enabled for parallel inference!"
     );
+
+    if num_shards > 1
+        && quant.is_some()
+        && matches!(quant.as_ref().unwrap().as_str(), "ggml" | "gguf")
+    {
+        panic!("Multiple device-ids detected: ggml/gguf model is not supported for multi-rank inference!");
+    }
+
     let logger = ftail::Ftail::new();
     let mut port = args.port;
     #[cfg(feature = "nccl")]

--- a/src/openai/distributed.rs
+++ b/src/openai/distributed.rs
@@ -189,11 +189,6 @@ impl TensorParallelRowLinear {
     pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let xs = self.linear.forward(x)?;
         #[cfg(feature = "nccl")]
-        {
-            let device = x.device();
-            let _ = device.as_cuda_device().unwrap().bind_to_thread();
-        }
-        #[cfg(feature = "nccl")]
         let xs = xs.apply_op1_no_bwd(&self.all_reduce)?;
 
         if let Some(bias) = &self.bias {

--- a/src/openai/models/deepseek.rs
+++ b/src/openai/models/deepseek.rs
@@ -558,11 +558,7 @@ impl Attention {
             y = y.narrow(D::Minus1, 0, moe_cfg.v_head_dim)?;
         }
 
-        y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((bs, seq_len, ()))?
-        } else {
-            y.reshape((bs, seq_len, ()))?
-        };
+        y = y.reshape((bs, seq_len, ()))?;
 
         self.o_proj.forward(&y)
     }
@@ -1084,15 +1080,14 @@ impl DeepSeek {
         let attention_mask = if seq_len == 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 bs,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), block) in zip(kv_caches.iter(), &self.layers) {

--- a/src/openai/models/gemma3.rs
+++ b/src/openai/models/gemma3.rs
@@ -664,7 +664,7 @@ impl Gemma3 {
             seq_len,
             input_positions,
             None,
-        )?;
+        );
 
         let sliding_mask = super::get_attention_casual_mask(
             &self.device,
@@ -673,9 +673,9 @@ impl Gemma3 {
             seq_len,
             input_positions,
             self.cfg.sliding_window,
-        )?;
+        );
 
-        Ok((Some(mask), Some(sliding_mask)))
+        Ok((mask, sliding_mask))
     }
 
     pub fn forward(

--- a/src/openai/models/glm4.rs
+++ b/src/openai/models/glm4.rs
@@ -499,15 +499,14 @@ impl GLM4 {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut xs = self.embedding.forward(input_ids)?;
 

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -175,22 +175,20 @@ impl CausalSelfAttention {
         let q = self.apply_rotary_emb(&q, input_positions)?;
         let k = self.apply_rotary_emb(&k, input_positions)?;
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
-        let y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
         let y = self.o_proj.forward(&y)?;
         Ok(y)
     }
@@ -390,15 +388,14 @@ impl Llama {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut x = self.wte.forward(x)?;
         if let Some(kv_caches) = kv_caches {

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -348,22 +348,20 @@ impl Attention {
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
-        let y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
         let y = self.o_proj.forward(&y)?;
         Ok(y)
     }
@@ -530,15 +528,14 @@ impl Phi {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
 

--- a/src/openai/models/quantized_llama.rs
+++ b/src/openai/models/quantized_llama.rs
@@ -190,22 +190,19 @@ impl LayerWeights {
             v.to_dtype(self.dtype)?,
         );
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
-
-        let y = if mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
         let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
         Ok(y)
@@ -550,15 +547,14 @@ impl GGUFLLaMa {
         let mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_sz,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut layer_in = self.tok_embeddings.forward(x)?;
 

--- a/src/openai/models/quantized_qwen.rs
+++ b/src/openai/models/quantized_qwen.rs
@@ -145,22 +145,19 @@ impl LayerWeights {
             v.to_dtype(self.dtype)?,
         );
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
-
-        let y = if mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
         let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
         Ok(y)
@@ -459,15 +456,14 @@ impl GGUFQWen {
         let mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_sz,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut layer_in = self.tok_embeddings.forward(x)?;
         if let Some(kv_caches) = kv_caches {

--- a/src/openai/models/qwen.rs
+++ b/src/openai/models/qwen.rs
@@ -354,22 +354,20 @@ impl Attention {
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
-        let y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
         let y = self.o_proj.forward(&y)?;
         Ok(y)
     }
@@ -498,15 +496,14 @@ impl Qwen {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
 

--- a/src/openai/models/stable_lm.rs
+++ b/src/openai/models/stable_lm.rs
@@ -315,22 +315,20 @@ impl Attention {
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
-        let y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
         let y = self.o_proj.forward(&y)?;
         Ok(y)
     }
@@ -453,15 +451,14 @@ impl StableLM {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
         if let Some(kv_caches) = kv_caches {

--- a/src/openai/models/yi.rs
+++ b/src/openai/models/yi.rs
@@ -310,22 +310,20 @@ impl Attention {
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache.map(|(k_, _)| k_.clone()),
-            cache.map(|(_, v_)| v_.clone()),
-            input_metadata,
-            None,
-        )?;
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
 
-        let y = if attention_mask.is_some() {
-            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
-        } else {
-            y.reshape((b_sz, seq_len, ()))?
-        };
         let y = self.o_proj.forward(&y)?;
         Ok(y)
     }
@@ -444,15 +442,14 @@ impl Yi {
         let attention_mask = if seq_len <= 1 {
             None
         } else {
-            let mask = super::get_attention_casual_mask(
+            super::get_attention_casual_mask(
                 &self.device,
                 self.dtype,
                 b_size,
                 seq_len,
                 input_positions,
                 self.cfg.sliding_window,
-            )?;
-            Some(mask)
+            )
         };
         let mut xs = self.embed_tokens.forward(input_ids)?;
         if let Some(kv_caches) = kv_caches {

--- a/src/paged_attention/mod.rs
+++ b/src/paged_attention/mod.rs
@@ -1,4 +1,4 @@
-use candle_core::{DType, Device, Result, Tensor};
+use candle_core::{Device, Result, Tensor};
 
 use crate::backend::{paged_attention, reshape_and_cache};
 
@@ -79,6 +79,48 @@ impl PagedAttention {
         let (batch_size, attention_heads, seq_len, head_size) = query.shape().dims4()?;
         let (_, key_value_heads, _, _) = key.shape().dims4()?;
 
+        #[cfg(feature = "flash-attn")]
+        let att = if input_metadata.is_prompt {
+            let k = candle_transformers::utils::repeat_kv(
+                key.clone(),
+                attention_heads / key_value_heads,
+            )?
+            .contiguous()?;
+            let v = candle_transformers::utils::repeat_kv(
+                value.clone(),
+                attention_heads / key_value_heads,
+            )?
+            .contiguous()?;
+
+            let q = query.transpose(1, 2)?;
+            let k = k.transpose(1, 2)?;
+            let v = v.transpose(1, 2)?;
+            let attn = if self.sliding_window.is_some() {
+                candle_flash_attn::flash_attn_windowed_softcap(
+                    &q,
+                    &k,
+                    &v,
+                    self.scale as f32,
+                    Some(softcapping.unwrap_or(0.0f64) as f32),
+                    self.sliding_window,
+                    Some(0),
+                )?
+            } else {
+                candle_flash_attn::flash_attn_softcap(
+                    &q,
+                    &k,
+                    &v,
+                    self.scale as f32,
+                    Some(softcapping.unwrap_or(0.0f64) as f32),
+                    true,
+                )?
+            };
+            Some(attn)
+        } else {
+            None
+        };
+
+        #[cfg(not(feature = "flash-attn"))]
         let att = match attention_mask {
             None => None,
             Some(mask) => {
@@ -101,8 +143,9 @@ impl PagedAttention {
                 };
 
                 let att = att.broadcast_add(mask)?;
-                let att = candle_nn::ops::softmax_last_dim(&att.to_dtype(DType::F32)?)?
-                    .to_dtype(att.dtype())?;
+                let att =
+                    candle_nn::ops::softmax_last_dim(&att.to_dtype(candle_core::DType::F32)?)?
+                        .to_dtype(att.dtype())?;
                 if key_value_heads != attention_heads {
                     let value_repeat = if key_value_heads == 1 {
                         value.broadcast_as((batch_size, attention_heads, seq_len, head_size))?
@@ -110,9 +153,9 @@ impl PagedAttention {
                         Tensor::cat(&vec![&value; attention_heads / key_value_heads], 2)?
                             .reshape((batch_size, attention_heads, seq_len, head_size))?
                     };
-                    Some(att.matmul(&value_repeat.contiguous()?)?)
+                    Some(att.matmul(&value_repeat.contiguous()?)?.transpose(1, 2)?)
                 } else {
-                    Some(att.matmul(value)?)
+                    Some(att.matmul(value)?.transpose(1, 2)?)
                 }
             }
         };


### PR DESCRIPTION
This PR adds support for the FlashAttention kernel. The FlashAttention kernel is now used during the prefilling stage, accelerating inference for long-context inputs.

**Usage**

Add the `flash-attn` feature when using `cargo run` or `cargo build`.

```shell
cargo run --features cuda,nccl,flash-attn --release -- --multi-process --dtype bf16 --port 2000 --weight-file /home/qwq-32b-q4_k_m.gguf qwen2 --quant gguf
```