### PR TITLE
Reduce peak memory usage with chunked attention & split marlin kernel for faster build

### DIFF
--- a/kernels/build.rs
+++ b/kernels/build.rs
@@ -1,18 +1,5 @@
 use anyhow::Result;
-use std::fs::read_to_string;
-use std::fs::OpenOptions;
-use std::io::prelude::*;
 use std::path::PathBuf;
-
-fn read_lines(filename: &str) -> Vec<String> {
-    let mut result = Vec::new();
-
-    for line in read_to_string(filename).unwrap().lines() {
-        result.push(line.to_string())
-    }
-
-    result
-}
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
@@ -24,12 +11,23 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=src/nonzero_bitwise.cu");
     println!("cargo:rerun-if-changed=src/sort.cu");
     let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap_or("".to_string()));
-    let builder = bindgen_cuda::Builder::default().arg("--expt-relaxed-constexpr");
+    let mut builder = bindgen_cuda::Builder::default()
+        .arg("--expt-relaxed-constexpr")
+        .arg("-g");
+    let mut is_target_msvc = false;
+    if let Ok(target) = std::env::var("TARGET") {
+        if target.contains("msvc") {
+            is_target_msvc = true;
+            builder = builder.arg("-D_USE_MATH_DEFINES");
+        }
+    }
+
+    if !is_target_msvc {
+        builder = builder.arg("-Xcompiler").arg("-fPIC");
+    }
+
     println!("cargo:info={builder:?}");
     builder.build_lib(build_dir.join("libpagedattention.a"));
-
-    let bindings = builder.build_ptx().unwrap();
-    bindings.write("src/lib.rs").unwrap();
 
     let kernel_dir = PathBuf::from("../kernels/");
     let absolute_kernel_dir = std::fs::canonicalize(&kernel_dir).unwrap();
@@ -41,22 +39,5 @@ fn main() -> Result<()> {
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=pagedattention");
     println!("cargo:rustc-link-lib=dylib=cudart");
-
-    let contents = read_lines("src/lib.rs");
-    for line in contents {
-        if line == "pub mod ffi;" {
-            return Ok(());
-        }
-    }
-    let mut file = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open("src/lib.rs")
-        .unwrap();
-    //Expose paged attention interface to Rust
-    if let Err(e) = writeln!(file, "pub mod ffi;") {
-        anyhow::bail!("error while building dependencies: {:?}\n", e,)
-    } else {
-        Ok(())
-    }
+    Ok(())
 }

--- a/kernels/src/copy_blocks_kernel.cu
+++ b/kernels/src/copy_blocks_kernel.cu
@@ -29,40 +29,11 @@ __device__ void copy_blocks_internal_kernel(
   }
 }
 
-// Monomorphize the generics ourselves
-extern "C" __global__ void copy_blocks_kernel_u8(int64_t* key_cache_ptrs,
-  int64_t* value_cache_ptrs,
-  const int64_t* __restrict__ block_mapping,
-  const int numel_per_block) {
-  copy_blocks_internal_kernel<uint8_t>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
-}
-
-extern "C" __global__ void copy_blocks_kernel_u32(int64_t* key_cache_ptrs,
-  int64_t* value_cache_ptrs,
-  const int64_t* __restrict__ block_mapping,
-  const int numel_per_block) {
-  copy_blocks_internal_kernel<uint32_t>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
-}
-
-extern "C" __global__ void copy_blocks_kernel_i64(int64_t* key_cache_ptrs,
-  int64_t* value_cache_ptrs,
-  const int64_t* __restrict__ block_mapping,
-  const int numel_per_block) {
-  copy_blocks_internal_kernel<int64_t>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
-}
-
 extern "C" __global__ void copy_blocks_kernel_f32(int64_t* key_cache_ptrs,
   int64_t* value_cache_ptrs,
   const int64_t* __restrict__ block_mapping,
   const int numel_per_block) {
   copy_blocks_internal_kernel<float>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
-}
-
-extern "C" __global__ void copy_blocks_kernel_f64(int64_t* key_cache_ptrs,
-  int64_t* value_cache_ptrs,
-  const int64_t* __restrict__ block_mapping,
-  const int numel_per_block) {
-  copy_blocks_internal_kernel<double>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
 }
 
 // f16, bf16 are special cases: We use a 16-bit integer to simulate the bit width. 
@@ -79,4 +50,51 @@ extern "C" __global__ void copy_blocks_kernel_bf16(int64_t* key_cache_ptrs,
   const int64_t* __restrict__ block_mapping,
   const int numel_per_block) {
   copy_blocks_internal_kernel<int16_t>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
+}
+
+//
+extern "C" void copy_blocks_f32(int64_t* key_cache_ptrs,
+  int64_t* value_cache_ptrs,
+  const int64_t* __restrict__ block_mapping,
+  const int num_layers,
+  const int num_pairs,
+  int numel_per_block,
+  int64_t stream_
+) {
+  cudaStream_t stream = (cudaStream_t)stream_;
+  if (numel_per_block > 1024) {
+    numel_per_block = 1024;
+  }
+  copy_blocks_kernel_f32<<<dim3(num_layers, num_pairs, 1), numel_per_block, 0, stream>>>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
+}
+
+
+extern "C" void copy_blocks_f16(int64_t* key_cache_ptrs,
+  int64_t* value_cache_ptrs,
+  const int64_t* __restrict__ block_mapping,
+  const int num_layers,
+  const int num_pairs,
+  int numel_per_block,
+  int64_t stream_
+) {
+  cudaStream_t stream = (cudaStream_t)stream_;
+  if (numel_per_block > 1024) {
+    numel_per_block = 1024;
+  }
+  copy_blocks_kernel_f16<<<dim3(num_layers, num_pairs, 1), numel_per_block, 0, stream>>>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
+}
+
+extern "C" void copy_blocks_bf16(int64_t* key_cache_ptrs,
+  int64_t* value_cache_ptrs,
+  const int64_t* __restrict__ block_mapping,
+  const int num_layers,
+  const int num_pairs,
+  int numel_per_block,
+  int64_t stream_
+) {
+  cudaStream_t stream = (cudaStream_t)stream_;
+  if (numel_per_block > 1024) {
+    numel_per_block = 1024;
+  }
+  copy_blocks_kernel_bf16<<<dim3(num_layers, num_pairs, 1), numel_per_block, 0, stream>>>(key_cache_ptrs, value_cache_ptrs, block_mapping, numel_per_block);
 }

--- a/kernels/src/ffi.rs
+++ b/kernels/src/ffi.rs
@@ -374,4 +374,34 @@ extern "C" {
         inplace: bool,
         stream: i64,
     );
+
+    pub fn copy_blocks_kernel_bf16(
+        key_cache_ptrs: *mut c_void,
+        value_cache_ptrs: *mut c_void,
+        block_mapping: *const c_void,
+        num_layers: i32,
+        num_pairs: i32,
+        numel_per_block: i32,
+        stream: i64,
+    );
+
+    pub fn copy_blocks_kernel_f16(
+        key_cache_ptrs: *mut c_void,
+        value_cache_ptrs: *mut c_void,
+        block_mapping: *const c_void,
+        num_layers: i32,
+        num_pairs: i32,
+        numel_per_block: i32,
+        stream: i64,
+    );
+
+    pub fn copy_blocks_kernel_f32(
+        key_cache_ptrs: *mut c_void,
+        value_cache_ptrs: *mut c_void,
+        block_mapping: *const c_void,
+        num_layers: i32,
+        num_pairs: i32,
+        numel_per_block: i32,
+        stream: i64,
+    );
 }

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -1,11 +1,1 @@
-pub const COPY_BLOCKS_KERNEL: &str =
-    include_str!(concat!(env!("OUT_DIR"), "/copy_blocks_kernel.ptx"));
-pub const GPTQ_CUDA_KERNEL: &str = include_str!(concat!(env!("OUT_DIR"), "/gptq_cuda_kernel.ptx"));
-pub const MARLIN_CUDA_KERNEL: &str =
-    include_str!(concat!(env!("OUT_DIR"), "/marlin_cuda_kernel.ptx"));
-pub const NONZERO_BITWISE: &str = include_str!(concat!(env!("OUT_DIR"), "/nonzero_bitwise.ptx"));
-pub const PAGEDATTENTION: &str = include_str!(concat!(env!("OUT_DIR"), "/pagedattention.ptx"));
-pub const RESHAPE_AND_CACHE_KERNEL: &str =
-    include_str!(concat!(env!("OUT_DIR"), "/reshape_and_cache_kernel.ptx"));
-pub const SORT: &str = include_str!(concat!(env!("OUT_DIR"), "/sort.ptx"));
 pub mod ffi;

--- a/kernels/src/marlin/marlin.cuh
+++ b/kernels/src/marlin/marlin.cuh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _marlin_cuh
+#define _marlin_cuh
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -129,3 +130,5 @@ enum ScalarTypeID {
 };
 
 }  // namespace marlin
+
+#endif

--- a/kernels/src/marlin_cuda_kernel.cuh
+++ b/kernels/src/marlin_cuda_kernel.cuh
@@ -1354,7 +1354,7 @@ typedef struct {
   thread_config_t tb_cfg;
 } exec_config_t;
 
-thread_config_t small_batch_thread_configs[] = {
+static thread_config_t small_batch_thread_configs[] = {
     // Ordered by priority
     // thread_k, thread_n, num_threads
     {128, 128, 256},  // Default
@@ -1363,7 +1363,7 @@ thread_config_t small_batch_thread_configs[] = {
     {64, 128, 128},   // Reduce K 2X, same N
 };
 
-thread_config_t large_batch_thread_configs[] = {
+static thread_config_t large_batch_thread_configs[] = {
     // Ordered by priority
     // thread_k, thread_n, num_threads
     {64, 256, 256},   // Default
@@ -1372,7 +1372,7 @@ thread_config_t large_batch_thread_configs[] = {
     {128, 64, 128},   // Reduce N 4X, increase K 2X
 };
 
-int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
+inline int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
                           int prob_n, int prob_k, int num_bits, int group_size,
                           bool has_act_order, bool is_k_full) {
   bool cache_scales_chunk = has_act_order && !is_k_full;
@@ -1403,7 +1403,7 @@ int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
   }
 }
 
-bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
+inline bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
                          int prob_m, int prob_n, int prob_k, int num_bits,
                          int scales_cache_size, int max_shared_mem) {
   int pack_factor = 32 / num_bits;
@@ -1442,7 +1442,7 @@ bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
   return pipe_size + reduce_size < 0.95f * (max_shared_mem - scales_cache_size);
 }
 
-bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
+inline bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
                      int prob_m, int prob_n, int prob_k, int num_bits,
                      int group_size, bool has_act_order, bool is_k_full,
                      int max_shared_mem) {
@@ -1481,7 +1481,7 @@ bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
   return true;
 }
 
-exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
+inline exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
                                       int num_bits, int group_size,
                                       bool has_act_order, bool is_k_full,
                                       int max_shared_mem) {
@@ -1639,337 +1639,8 @@ void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void
   }
 }
 
-extern "C" void marlin_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<half, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
-}
 
-extern "C" void marlin_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
-}
 
-extern "C" void marlin_awq_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<half, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
-}
 
-extern "C" void marlin_awq_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
-}
-
-__global__ void gptq_repack_kernel(
-  uint32_t* in,
-  uint32_t* out,
-  int m,
-  int n
-) {
-  uint32_t row = blockIdx.x * 2;
-  uint32_t col = blockIdx.y * 64;
-  uint32_t t = threadIdx.x;
-
-  // marlin packs 4 16x16 blocks one time;
-  const int pad_len = 18;
-  __shared__ uint8_t block[4][16][pad_len];
-
-  // unpack
-  int block_idx = t / 8;
-  int block_offset = t % 8;
-  for (int offset = block_offset; offset < 16; offset += 8) {
-    uint32_t v1 = in[row * n + col + block_idx * 16 + offset];
-    uint32_t v2 = in[(row + 1) * n + col + block_idx * 16 + offset];
-#pragma unroll
-    for (int i = 0; i < 8; i += 1) {
-      block[block_idx][i][offset] = v1 & 0xf;
-      v1 >>= 4;
-      block[block_idx][i + 8][offset] = v2 & 0xf;
-      v2 >>= 4;
-    }
-  }
-
-  // repack
-  uint32_t srow = (t % 4) * 2;
-  uint32_t scol = t / 4;
-
-  uint32_t idx[8][2];
-  idx[0][0] = srow;     idx[0][1] = scol;
-  idx[1][0] = srow + 8; idx[1][1] = scol;
-  idx[2][0] = srow;     idx[2][1] = scol + 8;
-  idx[3][0] = srow + 8; idx[3][1] = scol + 8;
-
-  idx[4][0] = srow + 1; idx[4][1] = scol;
-  idx[5][0] = srow + 9; idx[5][1] = scol;
-  idx[6][0] = srow + 1; idx[6][1] = scol + 8;
-  idx[7][0] = srow + 9; idx[7][1] = scol + 8;
-
-#pragma unroll
-  for (int i = 0; i < 4; i += 1) {
-    uint32_t v[8];
-#pragma unroll
-    for (int j = 0; j < 8; ++j) {
-      v[j] = block[i][idx[j][0]][idx[j][1]];
-    }
-
-    uint32_t pack = (v[7] << 28) | (v[6] << 24) | (v[5] << 20) | (v[4] << 16) |
-        (v[3] << 12) | (v[2] << 8) | (v[1] << 4) | v[0];
-
-    out[blockIdx.x * n * 2 + blockIdx.y * 128 + t * 4 + i] = pack;
-  }
-}
-
-extern "C" void gptq_repack(
-  void* in,
-  void* out,
-  int m,
-  int n,
-  int64_t stream_
-) {
-
-  assert(m % 2 == 0);
-  assert(n % 64 == 0);
-  const dim3 threads(32);
-  // marlin packs 16 x 64 block and gptq packs 8 x 1
-  const dim3 blocks(m / 2, n / 64);
-  cudaStream_t stream = (cudaStream_t)stream_;
-  gptq_repack_kernel<<<blocks, threads, 0, stream>>>(
-    (uint32_t*)in,
-    (uint32_t*)out,
-    m,
-    n
-  );
-}
-
-template <int const num_threads, int const num_bits>
-__global__ void awq_marlin_repack_kernel(
-    uint32_t const* __restrict__ b_q_weight_ptr, uint32_t* __restrict__ out_ptr,
-    int size_k, int size_n) {
-  constexpr int pack_factor = 32 / num_bits;
-
-  int k_tiles = size_k / tile_k_size;
-  int n_tiles = size_n / tile_n_size;
-  int block_k_tiles = ceildiv(k_tiles, gridDim.x);
-
-  auto start_k_tile = blockIdx.x * block_k_tiles;
-  if (start_k_tile >= k_tiles) {
-    return;
-  }
-
-  int finish_k_tile = min(start_k_tile + block_k_tiles, k_tiles);
-
-  // Wait until the next thread tile has been loaded to shared memory.
-  auto wait_for_stage = [&]() {
-    // We only have `stages - 2` active fetches since we are double buffering
-    // and can only issue the next fetch when it is guaranteed that the previous
-    // shared memory load is fully complete (as it may otherwise be
-    // overwritten).
-    cp_async_wait<repack_stages - 2>();
-    __syncthreads();
-  };
-
-  extern __shared__ int4 sh[];
-
-  constexpr int tile_n_ints = tile_n_size / pack_factor;
-
-  constexpr int stage_n_threads = tile_n_ints / 4;
-  constexpr int stage_k_threads = tile_k_size;
-  constexpr int stage_size = stage_k_threads * stage_n_threads;
-
-  auto fetch_to_shared = [&](int pipe, int k_tile_id, int n_tile_id) {
-    if (n_tile_id >= n_tiles) {
-      cp_async_fence();
-      return;
-    }
-
-    int first_n = n_tile_id * tile_n_size;
-    int first_n_packed = first_n / pack_factor;
-
-    int4* sh_ptr = sh + stage_size * pipe;
-
-    if (threadIdx.x < stage_size) {
-      auto k_id = threadIdx.x / stage_n_threads;
-      auto n_id = threadIdx.x % stage_n_threads;
-
-      int first_k = k_tile_id * tile_k_size;
-
-      cp_async4(&sh_ptr[k_id * stage_n_threads + n_id],
-                reinterpret_cast<int4 const*>(
-                    &(b_q_weight_ptr[(first_k + k_id) * (size_n / pack_factor) +
-                                     first_n_packed + (n_id * 4)])));
-    }
-
-    cp_async_fence();
-  };
-
-  auto repack_tile = [&](int pipe, int k_tile_id, int n_tile_id) {
-    if (n_tile_id >= n_tiles) {
-      return;
-    }
-
-    auto warp_id = threadIdx.x / 32;
-    auto th_id = threadIdx.x % 32;
-
-    if (warp_id >= 4) {
-      return;
-    }
-
-    int tc_col = th_id / 4;
-    int tc_row = (th_id % 4) * 2;
-
-    constexpr int tc_offsets[4] = {0, 1, 8, 9};
-
-    int cur_n = warp_id * 16 + tc_col;
-    int cur_n_packed = cur_n / pack_factor;
-    int cur_n_pos = cur_n % pack_factor;
-
-    constexpr int sh_stride = tile_n_ints;
-    constexpr uint32_t mask = (1 << num_bits) - 1;
-
-    int4* sh_stage_ptr = sh + stage_size * pipe;
-    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
-
-    // Undo interleaving
-    int cur_n_pos_unpacked;
-    if constexpr (num_bits == 4) {
-      constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
-      cur_n_pos_unpacked = undo_pack[cur_n_pos];
-    } else {
-      constexpr int undo_pack[4] = {0, 2, 1, 3};
-      cur_n_pos_unpacked = undo_pack[cur_n_pos];
-    }
-
-    uint32_t vals[8];
-#pragma unroll
-    for (int i = 0; i < 4; i++) {
-      int cur_elem = tc_row + tc_offsets[i];
-
-      int packed_src_0 = sh_stage_int_ptr[cur_n_packed + sh_stride * cur_elem];
-      int packed_src_1 = sh_stage_int_ptr[cur_n_packed + (8 / pack_factor) +
-                                          sh_stride * cur_elem];
-
-      vals[i] = (packed_src_0 >> (cur_n_pos_unpacked * num_bits)) & mask;
-      vals[4 + i] = (packed_src_1 >> (cur_n_pos_unpacked * num_bits)) & mask;
-    }
-
-    constexpr int tile_size = tile_k_size * tile_n_size / pack_factor;
-    int out_offset = (k_tile_id * n_tiles + n_tile_id) * tile_size;
-
-    // Result of:
-    // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
-    if constexpr (num_bits == 4) {
-      constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-
-      uint32_t res = 0;
-#pragma unroll
-      for (int i = 0; i < 8; i++) {
-        res |= vals[pack_idx[i]] << (i * 4);
-      }
-
-      out_ptr[out_offset + th_id * 4 + warp_id] = res;
-
-    } else {
-      constexpr int pack_idx[4] = {0, 2, 1, 3};
-
-      uint32_t res1 = 0;
-      uint32_t res2 = 0;
-#pragma unroll
-      for (int i = 0; i < 4; i++) {
-        res1 |= vals[pack_idx[i]] << (i * 8);
-        res2 |= vals[4 + pack_idx[i]] << (i * 8);
-      }
-
-      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 0] = res1;
-      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 1] = res2;
-    }
-  };
-
-  auto start_pipes = [&](int k_tile_id, int n_tile_id) {
-#pragma unroll
-    for (int pipe = 0; pipe < repack_stages - 1; pipe++) {
-      fetch_to_shared(pipe, k_tile_id, n_tile_id + pipe);
-    }
-
-    wait_for_stage();
-  };
-#pragma unroll
-  for (int k_tile_id = start_k_tile; k_tile_id < finish_k_tile; k_tile_id++) {
-    int n_tile_id = 0;
-
-    start_pipes(k_tile_id, n_tile_id);
-
-    while (n_tile_id < n_tiles) {
-#pragma unroll
-      for (int pipe = 0; pipe < repack_stages; pipe++) {
-        fetch_to_shared((pipe + repack_stages - 1) % repack_stages, k_tile_id,
-                        n_tile_id + pipe + repack_stages - 1);
-        repack_tile(pipe, k_tile_id, n_tile_id + pipe);
-        wait_for_stage();
-      }
-      n_tile_id += repack_stages;
-    }
-  }
-}
-
-#define CALL_IF2(NUM_BITS)                                                   \
-  else if (num_bits == NUM_BITS) {                                          \
-    cudaFuncSetAttribute(                                                   \
-        awq_marlin_repack_kernel<repack_threads, NUM_BITS>, \
-        cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem);       \
-    awq_marlin_repack_kernel<repack_threads, NUM_BITS>      \
-        <<<blocks, repack_threads, max_shared_mem, stream>>>(       \
-            weight_ptr, out_ptr, size_k, size_n);                       \
-  }
-
-extern "C" void awq_repack(void* in, void* out, int k,
-                                int n, int num_bits, int64_t stream_) {
-
-  //in_dim 4096, out_dim 1024 (/pack_factor)
-  //ws shape [4096, 128]
-  //out_shape [256, 2048]
-
-   //recover original size_k and size_n
-   int const pack_factor = 32 / num_bits;
-   int size_k = k;
-   int size_n = n * pack_factor;
-
-  // Verify compatibility with marlin tile of 16x64
-  CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
-              " is not divisible by tile_k_size = ", marlin::tile_k_size);
-  CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
-              " is not divisible by tile_n_size = ", marlin::tile_n_size);
-
-  CHECK(num_bits == 4 || num_bits == 8,
-              "num_bits must be 4 or 8. Got = ", num_bits);
-  cudaStream_t stream = (cudaStream_t)stream_;
-
-  uint32_t const* weight_ptr =
-      reinterpret_cast<uint32_t const*>(in);
-  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out);
-
-  // cudaPointerAttributes attributes;
-  // cudaPointerGetAttributes(
-  //   &attributes,
-  //   in
-  // );
-
-  int blocks;
-  cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, 0);
-  int max_shared_mem = 0;
-  cudaDeviceGetAttribute(&max_shared_mem,
-                         cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
-  CHECK(max_shared_mem > 0, "error max_shared_mem");
-
-  if (false) {
-  }
-  CALL_IF2(4)
-  CALL_IF2(8)
-  else {
-    CHECK(false, "Unsupported repack config: num_bits = ", num_bits);
-  }
-}
 
 #endif

--- a/kernels/src/marlin_matmul_awq_bf16.cu
+++ b/kernels/src/marlin_matmul_awq_bf16.cu
@@ -1,0 +1,6 @@
+#include "marlin_cuda_kernel.cuh"
+extern "C" void marlin_awq_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}

--- a/kernels/src/marlin_matmul_awq_f16.cu
+++ b/kernels/src/marlin_matmul_awq_f16.cu
@@ -1,0 +1,6 @@
+#include "marlin_cuda_kernel.cuh"
+extern "C" void marlin_awq_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<half, ScalarTypeID::kU4, false, true, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}

--- a/kernels/src/marlin_matmul_bf16.cu
+++ b/kernels/src/marlin_matmul_bf16.cu
@@ -1,0 +1,6 @@
+#include "marlin_cuda_kernel.cuh"
+extern "C" void marlin_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}

--- a/kernels/src/marlin_matmul_f16.cu
+++ b/kernels/src/marlin_matmul_f16.cu
@@ -1,0 +1,6 @@
+#include "marlin_cuda_kernel.cuh"
+extern "C" void marlin_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* g_idx, void* C, int prob_m, int prob_k, 
+                 int prob_n, void* workspace, int groupsize, int64_t stream
+                 ) {
+    marlin_matmul<half, ScalarTypeID::kU4B8, false, false, 4>(A, B, scales, zeros, g_idx, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+}

--- a/kernels/src/marlin_repack.cu
+++ b/kernels/src/marlin_repack.cu
@@ -1,0 +1,317 @@
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <assert.h>
+#include <iostream>
+#include "marlin/marlin.cuh"
+#include "marlin/marlin_dtypes.cuh"
+using namespace marlin;
+
+__global__ void gptq_repack_kernel(
+  uint32_t* in,
+  uint32_t* out,
+  int m,
+  int n
+) {
+  uint32_t row = blockIdx.x * 2;
+  uint32_t col = blockIdx.y * 64;
+  uint32_t t = threadIdx.x;
+
+  // marlin packs 4 16x16 blocks one time;
+  const int pad_len = 18;
+  __shared__ uint8_t block[4][16][pad_len];
+
+  // unpack
+  int block_idx = t / 8;
+  int block_offset = t % 8;
+  for (int offset = block_offset; offset < 16; offset += 8) {
+    uint32_t v1 = in[row * n + col + block_idx * 16 + offset];
+    uint32_t v2 = in[(row + 1) * n + col + block_idx * 16 + offset];
+#pragma unroll
+    for (int i = 0; i < 8; i += 1) {
+      block[block_idx][i][offset] = v1 & 0xf;
+      v1 >>= 4;
+      block[block_idx][i + 8][offset] = v2 & 0xf;
+      v2 >>= 4;
+    }
+  }
+
+  // repack
+  uint32_t srow = (t % 4) * 2;
+  uint32_t scol = t / 4;
+
+  uint32_t idx[8][2];
+  idx[0][0] = srow;     idx[0][1] = scol;
+  idx[1][0] = srow + 8; idx[1][1] = scol;
+  idx[2][0] = srow;     idx[2][1] = scol + 8;
+  idx[3][0] = srow + 8; idx[3][1] = scol + 8;
+
+  idx[4][0] = srow + 1; idx[4][1] = scol;
+  idx[5][0] = srow + 9; idx[5][1] = scol;
+  idx[6][0] = srow + 1; idx[6][1] = scol + 8;
+  idx[7][0] = srow + 9; idx[7][1] = scol + 8;
+
+#pragma unroll
+  for (int i = 0; i < 4; i += 1) {
+    uint32_t v[8];
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+      v[j] = block[i][idx[j][0]][idx[j][1]];
+    }
+
+    uint32_t pack = (v[7] << 28) | (v[6] << 24) | (v[5] << 20) | (v[4] << 16) |
+        (v[3] << 12) | (v[2] << 8) | (v[1] << 4) | v[0];
+
+    out[blockIdx.x * n * 2 + blockIdx.y * 128 + t * 4 + i] = pack;
+  }
+}
+
+extern "C" void gptq_repack(
+  void* in,
+  void* out,
+  int m,
+  int n,
+  int64_t stream_
+) {
+
+  assert(m % 2 == 0);
+  assert(n % 64 == 0);
+  const dim3 threads(32);
+  // marlin packs 16 x 64 block and gptq packs 8 x 1
+  const dim3 blocks(m / 2, n / 64);
+  cudaStream_t stream = (cudaStream_t)stream_;
+  gptq_repack_kernel<<<blocks, threads, 0, stream>>>(
+    (uint32_t*)in,
+    (uint32_t*)out,
+    m,
+    n
+  );
+}
+
+template <int const num_threads, int const num_bits>
+__global__ void awq_marlin_repack_kernel(
+    uint32_t const* __restrict__ b_q_weight_ptr, uint32_t* __restrict__ out_ptr,
+    int size_k, int size_n) {
+  constexpr int pack_factor = 32 / num_bits;
+
+  int k_tiles = size_k / tile_k_size;
+  int n_tiles = size_n / tile_n_size;
+  int block_k_tiles = ceildiv(k_tiles, gridDim.x);
+
+  auto start_k_tile = blockIdx.x * block_k_tiles;
+  if (start_k_tile >= k_tiles) {
+    return;
+  }
+
+  int finish_k_tile = min(start_k_tile + block_k_tiles, k_tiles);
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&]() {
+    // We only have `stages - 2` active fetches since we are double buffering
+    // and can only issue the next fetch when it is guaranteed that the previous
+    // shared memory load is fully complete (as it may otherwise be
+    // overwritten).
+    cp_async_wait<repack_stages - 2>();
+    __syncthreads();
+  };
+
+  extern __shared__ int4 sh[];
+
+  constexpr int tile_n_ints = tile_n_size / pack_factor;
+
+  constexpr int stage_n_threads = tile_n_ints / 4;
+  constexpr int stage_k_threads = tile_k_size;
+  constexpr int stage_size = stage_k_threads * stage_n_threads;
+
+  auto fetch_to_shared = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      cp_async_fence();
+      return;
+    }
+
+    int first_n = n_tile_id * tile_n_size;
+    int first_n_packed = first_n / pack_factor;
+
+    int4* sh_ptr = sh + stage_size * pipe;
+
+    if (threadIdx.x < stage_size) {
+      auto k_id = threadIdx.x / stage_n_threads;
+      auto n_id = threadIdx.x % stage_n_threads;
+
+      int first_k = k_tile_id * tile_k_size;
+
+      cp_async4(&sh_ptr[k_id * stage_n_threads + n_id],
+                reinterpret_cast<int4 const*>(
+                    &(b_q_weight_ptr[(first_k + k_id) * (size_n / pack_factor) +
+                                     first_n_packed + (n_id * 4)])));
+    }
+
+    cp_async_fence();
+  };
+
+  auto repack_tile = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      return;
+    }
+
+    auto warp_id = threadIdx.x / 32;
+    auto th_id = threadIdx.x % 32;
+
+    if (warp_id >= 4) {
+      return;
+    }
+
+    int tc_col = th_id / 4;
+    int tc_row = (th_id % 4) * 2;
+
+    constexpr int tc_offsets[4] = {0, 1, 8, 9};
+
+    int cur_n = warp_id * 16 + tc_col;
+    int cur_n_packed = cur_n / pack_factor;
+    int cur_n_pos = cur_n % pack_factor;
+
+    constexpr int sh_stride = tile_n_ints;
+    constexpr uint32_t mask = (1 << num_bits) - 1;
+
+    int4* sh_stage_ptr = sh + stage_size * pipe;
+    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
+
+    // Undo interleaving
+    int cur_n_pos_unpacked;
+    if constexpr (num_bits == 4) {
+      constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
+      cur_n_pos_unpacked = undo_pack[cur_n_pos];
+    } else {
+      constexpr int undo_pack[4] = {0, 2, 1, 3};
+      cur_n_pos_unpacked = undo_pack[cur_n_pos];
+    }
+
+    uint32_t vals[8];
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int cur_elem = tc_row + tc_offsets[i];
+
+      int packed_src_0 = sh_stage_int_ptr[cur_n_packed + sh_stride * cur_elem];
+      int packed_src_1 = sh_stage_int_ptr[cur_n_packed + (8 / pack_factor) +
+                                          sh_stride * cur_elem];
+
+      vals[i] = (packed_src_0 >> (cur_n_pos_unpacked * num_bits)) & mask;
+      vals[4 + i] = (packed_src_1 >> (cur_n_pos_unpacked * num_bits)) & mask;
+    }
+
+    constexpr int tile_size = tile_k_size * tile_n_size / pack_factor;
+    int out_offset = (k_tile_id * n_tiles + n_tile_id) * tile_size;
+
+    // Result of:
+    // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+    if constexpr (num_bits == 4) {
+      constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
+
+      uint32_t res = 0;
+#pragma unroll
+      for (int i = 0; i < 8; i++) {
+        res |= vals[pack_idx[i]] << (i * 4);
+      }
+
+      out_ptr[out_offset + th_id * 4 + warp_id] = res;
+
+    } else {
+      constexpr int pack_idx[4] = {0, 2, 1, 3};
+
+      uint32_t res1 = 0;
+      uint32_t res2 = 0;
+#pragma unroll
+      for (int i = 0; i < 4; i++) {
+        res1 |= vals[pack_idx[i]] << (i * 8);
+        res2 |= vals[4 + pack_idx[i]] << (i * 8);
+      }
+
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 0] = res1;
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 1] = res2;
+    }
+  };
+
+  auto start_pipes = [&](int k_tile_id, int n_tile_id) {
+#pragma unroll
+    for (int pipe = 0; pipe < repack_stages - 1; pipe++) {
+      fetch_to_shared(pipe, k_tile_id, n_tile_id + pipe);
+    }
+
+    wait_for_stage();
+  };
+#pragma unroll
+  for (int k_tile_id = start_k_tile; k_tile_id < finish_k_tile; k_tile_id++) {
+    int n_tile_id = 0;
+
+    start_pipes(k_tile_id, n_tile_id);
+
+    while (n_tile_id < n_tiles) {
+#pragma unroll
+      for (int pipe = 0; pipe < repack_stages; pipe++) {
+        fetch_to_shared((pipe + repack_stages - 1) % repack_stages, k_tile_id,
+                        n_tile_id + pipe + repack_stages - 1);
+        repack_tile(pipe, k_tile_id, n_tile_id + pipe);
+        wait_for_stage();
+      }
+      n_tile_id += repack_stages;
+    }
+  }
+}
+
+#define CALL_IF2(NUM_BITS)                                                   \
+  else if (num_bits == NUM_BITS) {                                          \
+    cudaFuncSetAttribute(                                                   \
+        awq_marlin_repack_kernel<repack_threads, NUM_BITS>, \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem);       \
+    awq_marlin_repack_kernel<repack_threads, NUM_BITS>      \
+        <<<blocks, repack_threads, max_shared_mem, stream>>>(       \
+            weight_ptr, out_ptr, size_k, size_n);                       \
+  }
+
+extern "C" void awq_repack(void* in, void* out, int k,
+                                int n, int num_bits, int64_t stream_) {
+
+  //in_dim 4096, out_dim 1024 (/pack_factor)
+  //ws shape [4096, 128]
+  //out_shape [256, 2048]
+
+   //recover original size_k and size_n
+   int const pack_factor = 32 / num_bits;
+   int size_k = k;
+   int size_n = n * pack_factor;
+
+  // Verify compatibility with marlin tile of 16x64
+  CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
+              " is not divisible by tile_k_size = ", marlin::tile_k_size);
+  CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
+              " is not divisible by tile_n_size = ", marlin::tile_n_size);
+
+  CHECK(num_bits == 4 || num_bits == 8,
+              "num_bits must be 4 or 8. Got = ", num_bits);
+  cudaStream_t stream = (cudaStream_t)stream_;
+
+  uint32_t const* weight_ptr =
+      reinterpret_cast<uint32_t const*>(in);
+  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out);
+
+  // cudaPointerAttributes attributes;
+  // cudaPointerGetAttributes(
+  //   &attributes,
+  //   in
+  // );
+
+  int blocks;
+  cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, 0);
+  int max_shared_mem = 0;
+  cudaDeviceGetAttribute(&max_shared_mem,
+                         cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  CHECK(max_shared_mem > 0, "error max_shared_mem");
+
+  if (false) {
+  }
+  CALL_IF2(4)
+  CALL_IF2(8)
+  else {
+    CHECK(false, "Unsupported repack config: num_bits = ", num_bits);
+  }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,53 +30,14 @@ pub fn get_or_load_func(
         .map_err(APIError::from)
 }
 
-#[cfg(feature = "cuda")]
-#[repr(transparent)]
-struct Conjoined<'a, T, R> {
-    raw: *mut T,
-    _ref: PhantomData<&'a mut R>,
-}
-
-#[cfg(feature = "cuda")]
-impl<'a, T, R> Conjoined<'a, T, R> {
-    fn new(raw: NonNull<T>, _ref: &'a mut R) -> Self {
-        Self {
-            raw: raw.as_ptr(),
-            _ref: PhantomData,
-        }
-    }
-}
-
-/// According to the docs: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1gb8f3dc3031b40da29d5f9a7139e52e15
-/// Each of the kernel params (*mut c_void) "must point to a region of memory from which the actual kernel parameter will be copied".
-/// This means that we must return a pointer to our pointer.
-///
-/// ## Safety
-/// - The returned pointer **must not** outlive the &self reference. Otherwise, a dangling pointer is created.
-#[cfg(feature = "cuda")]
-unsafe impl<'a, T, R> DeviceRepr for Conjoined<'a, T, R> {
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        addr_of!(self.raw) as *mut _
-    }
-}
-
+use crate::openai::responses::APIError;
 pub use cache::*;
 use candle_core::DType;
 #[cfg(feature = "cuda")]
-use candle_core::{
-    cuda_backend::cudarc::driver::{CudaFunction, DeviceRepr},
-    CudaDevice,
-};
+use candle_core::{cuda_backend::cudarc::driver::CudaFunction, CudaDevice};
 pub use gptq::*;
 pub use paged_attention::*;
 pub use std::ops::Deref;
-#[cfg(feature = "cuda")]
-use std::{
-    marker::PhantomData,
-    ptr::{addr_of, NonNull},
-};
-
-use crate::openai::responses::APIError;
 pub mod custom_ops;
 #[cfg(feature = "nccl")]
 pub mod heartbeat;


### PR DESCRIPTION
This PR addresses two important issues:

**1. Efficient memory usage for long prompts:**
For extremely long prompts, the naive sdp attention consumes significantly more GPU memory during computation. This PR chunks the sequence at the query tensor, makes the attention mechanism more memory-efficient and suitable for longer sequences.

**2. Faster kernel compilation via file split:**
The Marlin kernel has been refactored into multiple source files based on data types. This enables parallel kernel compilation and improves the overall build performance of the project.