### PR TITLE
Fix bug for block allocation order & log of kvcache usage

### DIFF
--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -757,6 +757,8 @@ impl LLMEngine {
                                 "Sending completion message to client! (sequence id {})",
                                 seq.deref().get_id()
                             );
+                            let e = engine.read();
+                            e.scheduler.print_free_blocks();
                             let _ = sender.send(ChatResponse::Done);
                         } else {
                             aborted_sequences.push(seq.deref().get_id());
@@ -788,6 +790,7 @@ impl LLMEngine {
         if multi_process && DaemonManager::is_master_rank() {
             warn!("Sending finish message to subprocesses");
             let e = engine.read();
+            e.scheduler.print_free_blocks();
             let mut daemon_manager = e.daemon_manager.write();
             let _ = daemon_manager
                 .as_mut()

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -222,6 +222,15 @@ impl Scheduler {
             self._free(&group);
         }
     }
+
+    pub fn print_free_blocks(&self) {
+        let free_blocks = self.block_engine.get_num_free_blocks();
+        tracing::info!(
+            "Available kvcache blocks {} (for {} tokens)",
+            free_blocks,
+            free_blocks * self.block_engine.get_block_size()
+        );
+    }
 }
 
 impl Scheduler {


### PR DESCRIPTION
KV cache block allocation should already start from the first available chunk. Printing the available free blocks in the KV cache is useful.