### PR TITLE
Import Dockerfile from mistralrs repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<HEREDOC
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        curl \
+        libssl-dev \
+        pkg-config \
+        clang \
+        libclang-dev \
+        libopenmpi-dev \
+        openmpi-bin
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup update nightly
+RUN rustup default nightly
+
+# MKL build dependencies
+RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+    tee /etc/apt/sources.list.d/oneAPI.list \
+    && apt-get update \
+    && apt-get install -y libomp-dev intel-oneapi-mkl-devel
+
+WORKDIR /candle-vllm
+
+COPY . .
+
+# Rayon threads are limited to minimize memory requirements in CI, avoiding OOM
+# Rust threads are increased with a nightly feature for faster compilation (single-threaded by default)
+ARG CUDA_COMPUTE_CAP=70
+ARG RAYON_NUM_THREADS=4
+ARG RUST_NUM_THREADS=4
+ARG RUSTFLAGS="-Z threads=${RUST_NUM_THREADS}"
+ARG WITH_FEATURES="cuda,cudnn,nccl,mkl,mpi"
+RUN cargo build --release --workspace --features "${WITH_FEATURES}"
+
+FROM docker.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS base
+ENV HUGGINGFACE_HUB_CACHE=/data \
+    PORT=80
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+    tee /etc/apt/sources.list.d/oneAPI.list
+
+RUN <<HEREDOC
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        libomp-dev \
+        ca-certificates \
+        libssl-dev \
+        curl \
+        pkg-config \
+        # Provided for convenience when using the NCCL crate feature:
+        openmpi-bin \
+        # Provided for MKL feature runtime:
+        intel-oneapi-hpc-toolkit
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
+
+FROM base
+
+COPY --from=builder /candle-vllm/target/release/candle-vllm /usr/local/bin/candle-vllm
+RUN chmod +x /usr/local/bin/candle-vllm
+
+# Only the `devel` builder image provides symlinks, restore the `libnccl.so` symlink:
+RUN ln -s libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so
+


### PR DESCRIPTION
Update for candle-vllm build, leave CUDA containers at 12.8 until cudarc library is brought up to date via guoqingbao/cudarc/pull/1 or similar effort.

Build for 70 target to allow running on the still common V100 and similarly available GPU types around the world.

MPI, MLK, CUDA, CUDNN, and NCCL features enabled by default for broad range of runtime compatibility and build testing.

Notes:
  Suggest use in CI/CD with matrix testing against features and
CUDA compute capability targets.