### PR TITLE
refactor: Dockerfile - MKL oneAPI support - Use DEB822 `.sources`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,16 +22,32 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup update nightly
 RUN rustup default nightly
 
-# MKL build dependencies
-RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
-    tee /etc/apt/sources.list.d/oneAPI.list \
-    && apt-get update \
-    && apt-get install -y libomp-dev intel-oneapi-mkl-devel
+### Add support for the MKL feature ###
+# 1. Add the upstream package repository for Intel oneAPI:
+COPY <<HEREDOC /etc/apt/sources.list.d/upstream-intel-oneapi.sources
+Types: deb
+URIs: https://apt.repos.intel.com/oneapi
+Suites: all
+Components: main
+Signed-By: /usr/share/keyrings/upstream-intel-oneapi.gpg
+HEREDOC
+
+# 2. Install required packages:
+RUN <<HEREDOC
+    # Add the associated package signing key to verify trust:
+    curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+      | gpg --dearmor > /usr/share/keyrings/upstream-intel-oneapi.gpg
+
+    # Refresh the package index and install packages + cleanup:
+    apt-get -qq update
+    apt-get -qq install --no-install-recommends \
+        libomp-dev \
+        intel-oneapi-hpc-toolkit
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
 
 WORKDIR /candle-vllm
-
 COPY . .
 
 # Rayon threads are limited to minimize memory requirements in CI, avoiding OOM
@@ -48,24 +64,28 @@ ENV HUGGINGFACE_HUB_CACHE=/data \
     PORT=80
 
 ARG DEBIAN_FRONTEND=noninteractive
-
-RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
-    tee /etc/apt/sources.list.d/oneAPI.list
-
 RUN <<HEREDOC
-    apt-get update
-    apt-get install -y --no-install-recommends \
+    apt-get -qq update
+
+    # NOTE: `openmpi-bin` is only provided for convenience when using the NCCL crate feature.
+    apt-get -qq install --no-install-recommends \
         libomp-dev \
         ca-certificates \
         libssl-dev \
         curl \
         pkg-config \
-        # Provided for convenience when using the NCCL crate feature:
-        openmpi-bin \
-        # Provided for MKL feature runtime:
-        intel-oneapi-hpc-toolkit
+        openmpi-bin
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
+
+# Add runtime support for the MKL feature:
+COPY --from builder /etc/apt/sources.list.d/upstream-intel-oneapi.sources /etc/apt/sources.list.d/upstream-intel-oneapi.sources
+COPY --from builder /usr/share/keyrings/upstream-intel-oneapi.gpg /usr/share/keyrings/upstream-intel-oneapi.gpg
+RUN <<HEREDOC
+    apt-get -qq update
+    apt-get -qq install --no-install-recommends \
+      intel-oneapi-hpc-toolkit
 
     rm -rf /var/lib/apt/lists/*
 HEREDOC


### PR DESCRIPTION
This PR addresses [feedback from another PR](https://github.com/EricLBuehler/candle-vllm/pull/238#discussion_r2252967000) I gave:
- APT: Use [DEB822 `.sources` format](https://repolib.readthedocs.io/en/latest/deb822-format.html) instead of deprecated `.list` format.
- Use Dockerfile HereDoc syntax.
- Use `-qq` ([implies `-y`](https://manpages.ubuntu.com/manpages/lunar/man8/apt-get.8.html)) for `apt-get` commands, and ensure consistent cleanup via `rm` is used in related `RUN` steps.

---

**NOTE:** I am not familiar with oneAPI or supporting it.

As this feature is not part of the official `mistral.rs` Dockerfile (_that it was [claimed to have been imported from](https://github.com/EricLBuehler/candle-vllm/pull/220)_), there is a `libomp-dev` runtime dependency (_since the original [`Dockerfile` contribution at `mistral.rs`](https://github.com/EricLBuehler/mistral.rs/pull/56)_), but not one associated to oneAPI as has been added into the `builder` stage (_presumably just for headers and symlink, at which point I wonder if the original runtime stage package had ever been required previously_ 🤷‍♂️).

Since the package has existed in the runtime stage from the beginning I've avoided shifting it into the MKL associated `RUN` or adding commentary, as I do not know if that is used by anything else?

---

## Regarding size of this dependency

Personally I am against monolithic images and mixing concerns from a maintenance and user perspectives. Mixing the MKL/oneAPI support with CUDA seems unnecessary and is definitely wasteful to users interested in building the image that aren't using either of these heavy dependencies.

Installing the `intel-oneapi-hpc-toolkit` package appears to add approx 12GB of weight, which in this case will be double due to it being additive to both build and runtime stages. It could possibly be optimized there but I don't have the hardware available to investigate.

CUDA is of similar weight for it's build image, but the runtime image is notably slimmer by comparison.

I presently lack a system with the disk space to build the full `Dockerfile`, but I assume it's rather large. The test `Dockerfile` I used spent the bulk of it's build time just installing the dep (_500 secs, about 80% of build time_), and that is with no builder stage involved.

---

I'd encourage separate image variants for such going forward.

The [existing support was snuck in](https://github.com/EricLBuehler/candle-vllm/pull/220) despite the contributor having already been advised for their related contribution at `mistral.rs` to [add `mkl` feature support as a separate image variant](https://github.com/EricLBuehler/mistral.rs/pull/1468#issuecomment-3042975846).
