### PR TITLE
chore: Dockerfile - Remove NCCL symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,6 @@ ARG WITH_FEATURES="cuda,cudnn,nccl,mkl,mpi"
 RUN cargo build --release --workspace --features "${WITH_FEATURES}"
 
 FROM docker.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS base
-ENV HUGGINGFACE_HUB_CACHE=/data \
-    PORT=80
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -72,9 +70,7 @@ HEREDOC
 
 FROM base
 
-COPY --from=builder /candle-vllm/target/release/candle-vllm /usr/local/bin/candle-vllm
-RUN chmod +x /usr/local/bin/candle-vllm
+COPY --chmod=755 --from=builder /candle-vllm/target/release/candle-vllm /usr/local/bin/candle-vllm
 
-# Only the `devel` builder image provides symlinks, restore the `libnccl.so` symlink:
-RUN ln -s libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so
-
+ENV HUGGINGFACE_HUB_CACHE=/data \
+    PORT=80


### PR DESCRIPTION
If the project is built properly with dynamic linking, this step should not be necessary (_as was [recently handled at `mistral.rs`](https://github.com/EricLBuehler/mistral.rs/pull/1504) equivalent `Dockerfile`_).

The `ENV` and `COPY` changes are minor and reflect the [same changes done at `mistral.rs`](https://github.com/EricLBuehler/mistral.rs/pull/1612).

---

## Further context on removed symlink

The symlink addition for NCCL was snuck in via https://github.com/EricLBuehler/candle-vllm/pull/220 among other changes that aren't reflected by the actual `Dockerfile` at `mistral.rs`. Potentially as a means to cheat / disrespect the [review process that contributor was already involved in with `mistral.rs`](https://github.com/EricLBuehler/mistral.rs/pull/1468).

In particular, for this symlink I had [requested more information](https://github.com/EricLBuehler/mistral.rs/pull/1468#pullrequestreview-2947571984) regarding [it's relevancy](https://github.com/EricLBuehler/mistral.rs/pull/1468#discussion_r2159869529).

This contributor has previously reported unexpected linking errors, then closed as resolved [without any context as to what changed](https://github.com/EricLBuehler/mistral.rs/issues/1529#issuecomment-3134538078).

Personally this behaviour warrants concern when they contribute, so caution may be encouraged going forward when their changes lack context. This isn't uncommon with contributors, which while their additions can be valuable, it can accumulate with time and become a burden for maintainers to understand when they need to interact with these contributions to make decisions.