### PR TITLE
chore: Dockerfile - Align CUDA CC to match `mistral.rs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY . .
 
 # Rayon threads are limited to minimize memory requirements in CI, avoiding OOM
 # Rust threads are increased with a nightly feature for faster compilation (single-threaded by default)
-ARG CUDA_COMPUTE_CAP=70
+ARG CUDA_COMPUTE_CAP=80
 ARG RAYON_NUM_THREADS=4
 ARG RUST_NUM_THREADS=4
 ARG RUSTFLAGS="-Z threads=${RUST_NUM_THREADS}"


### PR DESCRIPTION
Match CUDA [Compute Capability (CC) used at the `mistral.rs` repo](https://github.com/EricLBuehler/mistral.rs/blob/53ebc7480cd08b124bc99ca9f6365af6152c6fa7/Dockerfile.cuda-all#L27).

This PR reverts the lowered CC default https://github.com/EricLBuehler/candle-vllm/pull/220 introduced, as this change does not prevent building for older CC, but adjusts to a **saner default** that still covers a broad demographic.

---

More details for restoring this default:
- [CC relevance regarding build and runtime stages](https://github.com/EricLBuehler/mistral.rs/pull/1468#issuecomment-2982103003).
- CC 7.5 (_and more recently 8.0_) are [commonly the base/default CC for projects supporting with builds](https://github.com/EricLBuehler/mistral.rs/pull/1468#issuecomment-3113113147), deferring to CI for automated builds across the range of CC the project itself supports and users request.
- CC 7.5 support is sometimes with limitations such as with FlashAttention. The contributor that set CC 7.0 appears to still be unsatisfied and requesting workarounds for older GPU support there as [lowering CC was not sufficient](https://github.com/EricLBuehler/candle-vllm/issues/234) (_and since the CC target default was set to 7.0, users on newer hardware also miss out on that benefit by default_).
- The lower CC level opts-out of performance improvements available to much newer GPUs, as such similar to how it is with CPU packages default micro-arch level with x86_64 in distro packages, it's better to serve the bulk of the demographic on hardware that [benefits from features introduced since CC 8.0](https://github.com/EricLBuehler/mistral.rs/pull/1468#issuecomment-2982103003), [inconveniencing their performance](https://github.com/EricLBuehler/mistral.rs/pull/1468#issuecomment-2976198064) to appease a smaller legacy demographic (decade old hardware).
- CUDA 13.0 [drops support prior to Turing architecture](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#id2) (CC 7.5), which will then require additional workarounds to support earlier CC versions.

Should CI publishing of images be added (_the current workflow for this at `mistral.rs` [needs to be refined first](https://github.com/EricLBuehler/mistral.rs/issues/1457)_), that can support alternative CC [as was advised](https://github.com/EricLBuehler/mistral.rs/pull/1468#discussion_r2159873649) at the associated `mistral.rs` PR.

Otherwise all that changes currently from merging this PR is the user on older hardware needs to set the build ARG explicitly to adjust `CUDA_COMPUTE_CAP` which is a fair expectation.