### PR TITLE
DRAFT: Fix forward_no_dequant dimms to mul_mat_via_q8_1

### DIFF
--- a/src/openai/models/linear.rs
+++ b/src/openai/models/linear.rs
@@ -635,7 +635,7 @@ impl QLinear {
             }
             _ => x.to_dtype(DType::F32)?,
         };
-        let xs = match *x.dims() {
+        let xs = match *xs.dims() {
             [bsize, seq_len, dim1, _] => {
                 if seq_len > 1 {
                     QMatMul::forward(&self.inner, &xs)?


### PR DESCRIPTION
When running quantized models, forward_no_dequant was matching on x.dimms() instead of xs.dimms() to append a matmul forward into the sequence.

Fix offending line to use xs.dimms() as remedy.

This may have been the cause for #235 per qwen3-coder itself which was experiencing the crashes running quantized, while sorting through this codebase. Thank you @guoqingbao for getting the model loader working so quickly - seems its paying dividends already.

Testing:
  Builds in docker
  Loads qwen3-coder-30B locally w/ q2k on a laptop 4090, showing
at least that the fix doesn't create structural pathology.

TODO:
  Run with q4k and 8_0 quantizations on real metal over large jobs
to evaluate stability given that this problem crops up rarely.

Qwen analysis:
```
1. Tensor Reshaping Logic Problem

In forward_no_dequant, there are two separate match statements that
handle tensor reshaping. The second match statement uses *x.dims()
instead of *xs.dims() which means it's checking the original input
dimensions rather than the already-converted F32 tensor dimensions.

2. Incorrect Dimension Calculation in CUDA Path

The error occurs in the QCudaStorage::fwd method when it calls
mul_mat_via_q8_1. The parameters being passed to this function are:
- x_rows (n): rows of the weight matrix
- x_cols (k): columns of the weight matrix
- y_rows (k): should match x_cols
- y_cols (b  m): batch size times sequence length

```