### PR TITLE
Support Qwen3 MoE GGUF & fast MoE inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "11d3240" }
-candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "11d3240" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b7624aa" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b7624aa" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "11d3240" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b7624aa" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.2"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "11d3240" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b7624aa" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -34,7 +34,7 @@ intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], option
 #cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 cudarc = {git = "https://github.com/guoqingbao/cudarc.git", version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true, rev="cc13092" }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "11d3240" }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "b7624aa" }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"

--- a/README-CN.md
+++ b/README-CN.md
@@ -112,13 +112,13 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
 ## 如何运行？
 
 - 运行**未压缩**模型 
-  <details>
+  <details open>
     <summary>显示命令</summary>
 
-    **本地路径**
+    **本地路径（指定端口与设备）**
 
     ```shell
-    target/release/candle-vllm --w /home/DeepSeek-R1-Distill-Llama-8B/
+    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/
     ```
 
     **模型ID（从Huggingface下载）**
@@ -130,19 +130,19 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
   </details>
 
 - 运行**GGUF**模型 
-  <details>
+  <details open>
     <summary>显示命令</summary>
 
-    **本地路径（指定端口、数据类型、采样参数）**
+    **本地路径**
 
     ```shell
-    target/release/candle-vllm --f /home/data/DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
+    target/release/candle-vllm --f /home/data/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
     ```
 
     **模型ID（从Huggingface下载）**
 
     ```shell
-    target/release/candle-vllm --m unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF --f DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
+    target/release/candle-vllm --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
     ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
 ## How to run?
 
 - Run **Uncompressed** models 
-  <details>
+  <details open>
     <summary>Show command</summary>
 
-    **Local Path**
+    **Local Path (with port and device specified)**
 
     ```shell
-    target/release/candle-vllm --p 2000 --w /home/DeepSeek-R1-Distill-Llama-8B/
+    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/
     ```
 
     **Model-ID (download from Huggingface)**
@@ -132,19 +132,19 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
   </details>
 
 - Run **GGUF** models 
-  <details>
+  <details open>
     <summary>Show command</summary>
 
-    **Local Path (with port, dtype, sampling parameter specified)**
+    **Local Path**
 
     ```shell
-    target/release/candle-vllm --f /home/data/DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
+    target/release/candle-vllm --f /home/data/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
     ```
 
     **Model-ID (download from Huggingface)**
 
     ```shell
-    target/release/candle-vllm --m unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF --f DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
+    target/release/candle-vllm --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
     ```
 
   </details>

--- a/metal-kernels/Cargo.toml
+++ b/metal-kernels/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 metal = { version = "0.27.0", features = ["mps"] }
 thiserror = "1"
 once_cell = "1.20.2"
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "11d3240" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b7624aa" }
 
 [build-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -11,6 +11,7 @@ pub mod quantized_glm4;
 pub mod quantized_llama;
 pub mod quantized_phi3;
 pub mod quantized_qwen;
+pub mod quantized_qwen3_moe;
 pub mod qwen;
 pub mod qwen3_moe;
 pub mod stable_lm;

--- a/src/openai/models/quantized_qwen3_moe.rs
+++ b/src/openai/models/quantized_qwen3_moe.rs
@@ -1,0 +1,620 @@
+use super::{Config, QwenMoEConfig};
+use crate::backend::progress::{ProgressLike, ProgressReporter};
+use crate::paged_attention::input_metadata::InputMetadata;
+use crate::paged_attention::PagedAttention;
+use candle_core::quantized::{gguf_file, QMatMul};
+use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{Embedding, Module};
+use candle_transformers::quantized_nn::RmsNorm;
+use either::Either;
+use std::iter::zip;
+use std::sync::{Arc, RwLock};
+#[derive(Debug, Clone)]
+struct Mlp {
+    feed_forward_w1: QMatMul,
+    feed_forward_w2: QMatMul,
+    feed_forward_w3: QMatMul,
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let w1 = self.feed_forward_w1.forward(xs)?;
+        let w3 = self.feed_forward_w3.forward(xs)?;
+        self.feed_forward_w2
+            .forward(&(candle_nn::ops::silu(&w1)? * w3)?)
+    }
+}
+
+struct FusedMoe {
+    gate: QMatMul,
+    gate_experts: QMatMul,
+    up_experts: QMatMul,
+    down_experts: QMatMul,
+    act: candle_nn::Activation,
+    norm_topk_prob: bool,
+    num_experts_per_tok: usize,
+}
+
+impl FusedMoe {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (batch, seq_len, hidden_dim) = xs.dims3()?;
+        let xs = xs.reshape(((), hidden_dim))?;
+        let original_dtype = xs.dtype();
+        let (num_tokens, hidden_dim) = xs.dims2()?;
+        let router_logits = self.gate.forward(&xs.to_dtype(DType::F32)?)?;
+        let routing_weights = candle_nn::ops::softmax_last_dim(&router_logits)?;
+
+        #[cfg(feature = "cuda")]
+        let indices = routing_weights
+            .arg_sort_last_dim(false)?
+            .narrow(D::Minus1, 0, self.num_experts_per_tok)?
+            .contiguous()?;
+
+        #[cfg(not(feature = "cuda"))]
+        let indices = routing_weights
+            .to_device(&candle_core::Device::Cpu)?
+            .arg_sort_last_dim(false)?
+            .narrow(D::Minus1, 0, self.num_experts_per_tok)?
+            .contiguous()?
+            .to_device(&xs.device())?;
+        let mut scores = routing_weights.gather(&indices, D::Minus1)?;
+
+        if self.norm_topk_prob {
+            scores = scores.broadcast_div(&scores.sum_keepdim(D::Minus1)?)?;
+        }
+
+        let ys = {
+            let xs = xs.reshape((num_tokens, 1, hidden_dim))?;
+            let gate = self.gate_experts.indexed_moe_forward(&xs, &indices)?;
+            let up = self.up_experts.indexed_moe_forward(&xs, &indices)?;
+            let xs = self
+                .down_experts
+                .indexed_moe_forward(&(up * gate.apply(&self.act)?)?, &indices)?;
+            xs
+        };
+        ys.broadcast_mul(&scores.unsqueeze(D::Minus1)?)?
+            .sum(D::Minus2)?
+            .reshape((batch, seq_len, hidden_dim))?
+            .to_dtype(original_dtype)
+    }
+}
+
+enum MoeOrMlp {
+    FusedMoe(FusedMoe),
+    Mlp(Mlp),
+}
+
+impl MoeOrMlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Mlp(m) => m.forward(xs),
+            Self::FusedMoe(m) => m.forward(xs),
+        }
+    }
+}
+
+struct LayerWeights {
+    attention_wq: QMatMul,
+    attention_wk: QMatMul,
+    attention_wv: QMatMul,
+    attention_bq: Option<Tensor>,
+    attention_bk: Option<Tensor>,
+    attention_bv: Option<Tensor>,
+    attention_wo: QMatMul,
+    attention_norm: RmsNorm,
+    q_norm: Option<RmsNorm>,
+    k_norm: Option<RmsNorm>,
+    mlp: MoeOrMlp,
+    ffn_norm: RmsNorm,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    cos: Tensor,
+    sin: Tensor,
+    attn: PagedAttention,
+    dtype: DType,
+}
+
+impl LayerWeights {
+    fn apply_rotary_emb(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        input_positions: &[Vec<usize>],
+    ) -> Result<(Tensor, Tensor)> {
+        let (b_size, _h, seq_len, _n_embd) = q.dims4()?;
+        let mut q_embeds = Vec::new();
+        let mut k_embeds = Vec::new();
+        for (b, seqlen_offset) in zip(0..b_size, input_positions) {
+            let cos = self.cos.narrow(0, seqlen_offset[0], seq_len)?;
+            let sin = self.sin.narrow(0, seqlen_offset[0], seq_len)?;
+            let x_q = q.narrow(0, b, 1)?;
+            let x_k = k.narrow(0, b, 1)?;
+            let q_embed = candle_nn::rotary_emb::rope(&x_q, &cos, &sin)?;
+            let k_embed = candle_nn::rotary_emb::rope(&x_k, &cos, &sin)?;
+            q_embeds.push(q_embed);
+            k_embeds.push(k_embed);
+        }
+        Ok((Tensor::cat(&q_embeds, 0)?, Tensor::cat(&k_embeds, 0)?))
+    }
+
+    fn forward_attn(
+        &self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        input_positions: &[Vec<usize>],
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+
+        let q = self.attention_wq.forward(x)?;
+        let k = self.attention_wk.forward(x)?;
+        let v = self.attention_wv.forward(x)?;
+
+        let q = if self.attention_bq.is_some() {
+            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
+        } else {
+            q
+        };
+
+        let k = if self.attention_bk.is_some() {
+            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
+        } else {
+            k
+        };
+
+        let v = if self.attention_bv.is_some() {
+            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
+        } else {
+            v
+        };
+
+        let (q, k, v) = if seq_len == 1 {
+            //no need transpose for seq_len == 1, change reshape dim
+            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            (q, k, v)
+        } else {
+            let q = q
+                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = k
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            (q.contiguous()?, k.contiguous()?, v.contiguous()?)
+        };
+
+        let (q, k) = if let (Some(q_norm), Some(k_norm)) = (&self.q_norm, &self.k_norm) {
+            // Per‑head RMSNorm in qwen3
+            let q_flat = q.flatten(0, 2)?; // (B*H, L, D) -> (BHL, D) after transpose later
+            let k_flat = k.flatten(0, 2)?;
+
+            // q_norm and k_norm weights stored in f32 format in qwen3 gguf
+            let q_flat = q_norm.forward(&q_flat)?;
+            let k_flat = k_norm.forward(&k_flat)?;
+
+            let q = q_flat.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k_flat.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+
+            (q, k)
+        } else {
+            (q, k)
+        };
+
+        let (q, k) = self.apply_rotary_emb(&q, &k, input_positions)?;
+        let (q, k, v) = (
+            q.to_dtype(self.dtype)?,
+            k.to_dtype(self.dtype)?,
+            v.to_dtype(self.dtype)?,
+        );
+
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((b_sz, seq_len, ()))?;
+
+        let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
+        Ok(y)
+    }
+}
+
+pub struct GGUFQWenMoE {
+    tok_embeddings: Embedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    output: QMatMul,
+    cfg: Config,
+    dtype: DType,
+    device: Device,
+}
+
+fn precomput_freqs_cis(
+    head_dim: usize,
+    freq_base: f32,
+    context_length: usize,
+    device: &Device,
+    _dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    let theta: Vec<_> = (0..head_dim)
+        .step_by(2)
+        .map(|i| 1f32 / freq_base.powf(i as f32 / head_dim as f32))
+        .collect();
+    let theta = Tensor::new(theta.as_slice(), device)?;
+    let idx_theta = Tensor::arange(0, context_length as u32, device)?
+        .to_dtype(DType::F32)?
+        .reshape((context_length, 1))?
+        .matmul(&theta.reshape((1, theta.elem_count()))?)?;
+    let cos = idx_theta.cos()?;
+    let sin = idx_theta.sin()?;
+    Ok((cos, sin))
+}
+
+impl GGUFQWenMoE {
+    pub fn into_config(
+        arch: String,
+        embedding_length: usize,
+        head_dim: usize,
+        i_size: usize,
+        block_count: usize,
+        head_count: usize,
+        head_count_kv: usize,
+        rms_eps: f64,
+        max_seq_len: usize,
+        moe_cfg: &QwenMoEConfig,
+    ) -> Config {
+        Config {
+            architectures: Some(vec![arch]),
+            hidden_size: embedding_length,
+            head_dim: Some(head_dim),
+            intermediate_size: i_size,
+            vocab_size: 0,
+            num_hidden_layers: block_count,
+            num_attention_heads: head_count,
+            num_key_value_heads: Some(head_count_kv),
+            rms_norm_eps: rms_eps,
+            rope_theta: 10_000.0f64,
+            rope_local_base_freq: None,
+            bos_token_id: Some(super::TokenID(Either::Left(Some(151644)))),
+            eos_token_id: super::TokenID(Either::Left(Some(151645))),
+            max_seq_len,
+            sliding_window: None,
+            sliding_window_pattern: None,
+            hidden_act: None,
+            hidden_activation: None,
+            tie_word_embeddings: false,
+            rope_scaling: None,
+            max_position_embeddings: Some(max_seq_len),
+            original_max_position_embeddings: max_seq_len,
+            attention_bias: Some(false),
+            partial_rotary_factor: None,
+            qk_layernorm: false,
+            use_qkv_bias: None,
+            custom_stop_tokens: None,
+            attn_logit_softcapping: None,
+            final_logit_softcapping: None,
+            quantization_config: None,
+            moe_config: None,
+            qwen_moe_config: Some(moe_cfg.clone()),
+            quant: Some("gguf".to_string()),
+        }
+    }
+
+    pub fn get_num_of_layers(qwen3: bool, ct: gguf_file::Content) -> Result<usize> {
+        let md_get = |s: &str| match ct.metadata.get(s) {
+            None => candle_core::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+        Ok(
+            md_get(format!("qwen{}.block_count", if qwen3 { 3 } else { 2 }).as_str())?.to_u32()?
+                as usize,
+        )
+    }
+
+    pub fn from_gguf<R: std::io::Seek + std::io::Read>(
+        ct: &gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+        dtype: DType,
+        progress_reporter: Arc<RwLock<ProgressReporter>>,
+    ) -> Result<Self> {
+        let md_get = |s: &str| match ct.metadata.get(s) {
+            None => candle_core::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+        let reporter = progress_reporter.clone();
+        let arch = md_get("general.architecture")?.to_string()?;
+
+        let head_count =
+            md_get(format!("{arch}.attention.head_count").as_str())?.to_u32()? as usize;
+        let head_count_kv =
+            md_get(format!("{arch}.attention.head_count_kv").as_str())?.to_u32()? as usize;
+
+        let head_dim = md_get(format!("{arch}.attention.key_length").as_str());
+        let head_dim = if head_dim.is_ok() {
+            Some(head_dim.unwrap().to_u32()? as usize)
+        } else {
+            None
+        };
+        let embedding_length =
+            md_get(format!("{arch}.embedding_length").as_str())?.to_u32()? as usize;
+        let context_length = md_get(format!("{arch}.context_length").as_str())?.to_u32()? as usize;
+        let block_count = md_get(format!("{arch}.block_count").as_str())?.to_u32()? as usize;
+        let rms_norm_eps =
+            md_get(format!("{arch}.attention.layer_norm_rms_epsilon").as_str())?.to_f32()? as f64;
+        let rope_freq_base = md_get(format!("{arch}.rope.freq_base").as_str())
+            .and_then(|m| m.to_f32())
+            .unwrap_or(10000f32);
+
+        let moe_cfg = QwenMoEConfig {
+            moe_intermediate_size: md_get(format!("{}.expert_feed_forward_length", arch).as_str())?
+                .to_u32()? as usize,
+            num_experts: Some(md_get(format!("{}.expert_count", arch).as_str())?.to_u32()? as usize),
+            mlp_only_layers: Some(vec![]),
+            decoder_sparse_step: Some(1),
+            norm_topk_prob: true,
+            num_experts_per_tok: md_get(format!("{}.expert_used_count", arch).as_str())?.to_u32()?
+                as usize,
+        };
+
+        let head_dim = head_dim.unwrap_or(embedding_length / head_count);
+        let tok_embeddings = ct.tensor(reader, "token_embd.weight", device)?;
+        let tok_embeddings = tok_embeddings.dequantize(device)?;
+        let norm = RmsNorm::from_qtensor(
+            ct.tensor(reader, "output_norm.weight", device)?,
+            rms_norm_eps,
+        )?;
+        let output = match ct.tensor(reader, "output.weight", device) {
+            Ok(v) => QMatMul::from_qtensor(v)?,
+            _ => {
+                // use tie_word_embeddings
+                QMatMul::from_qtensor(ct.tensor(reader, "token_embd.weight", device)?)?
+            }
+        };
+
+        let (cos, sin) =
+            precomput_freqs_cis(head_dim, rope_freq_base, context_length, device, dtype)?;
+
+        let mut layers = Vec::with_capacity(block_count);
+
+        for layer_idx in 0..block_count {
+            let prefix = format!("blk.{layer_idx}");
+            let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
+            let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
+            let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
+
+            let attention_bq = ct.tensor(reader, &format!("{prefix}.attn_q.bias"), device);
+            let attention_bk = ct.tensor(reader, &format!("{prefix}.attn_k.bias"), device);
+            let attention_bv = ct.tensor(reader, &format!("{prefix}.attn_v.bias"), device);
+
+            let attention_bq = if attention_bq.is_ok() {
+                Some(
+                    attention_bq
+                        .unwrap()
+                        .dequantize(device)?
+                        .to_dtype(DType::F32)?,
+                )
+            } else {
+                None
+            };
+
+            let attention_bk = if attention_bk.is_ok() {
+                Some(
+                    attention_bk
+                        .unwrap()
+                        .dequantize(device)?
+                        .to_dtype(DType::F32)?,
+                )
+            } else {
+                None
+            };
+
+            let attention_bv = if attention_bv.is_ok() {
+                Some(
+                    attention_bv
+                        .unwrap()
+                        .dequantize(device)?
+                        .to_dtype(DType::F32)?,
+                )
+            } else {
+                None
+            };
+
+            let attention_wo =
+                ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
+
+            let mlp = if !moe_cfg
+                .mlp_only_layers
+                .as_ref()
+                .unwrap()
+                .contains(&layer_idx)
+                && (moe_cfg.num_experts.unwrap() > 0
+                    && (layer_idx + 1) % moe_cfg.decoder_sparse_step.unwrap() == 0)
+            {
+                let gate = ct.tensor(reader, &format!("{prefix}.ffn_gate_inp.weight"), device)?;
+                let gate_experts =
+                    ct.tensor(reader, &format!("{prefix}.ffn_gate_exps.weight"), device)?;
+                let up_experts =
+                    ct.tensor(reader, &format!("{prefix}.ffn_up_exps.weight"), device)?;
+                let down_experts =
+                    ct.tensor(reader, &format!("{prefix}.ffn_down_exps.weight"), device)?;
+                let moe = FusedMoe {
+                    gate: QMatMul::from_qtensor(gate)?,
+                    gate_experts: QMatMul::from_qtensor(gate_experts)?,
+                    up_experts: QMatMul::from_qtensor(up_experts)?,
+                    down_experts: QMatMul::from_qtensor(down_experts)?,
+                    act: candle_nn::Activation::Silu,
+                    norm_topk_prob: moe_cfg.norm_topk_prob,
+                    num_experts_per_tok: moe_cfg.num_experts_per_tok,
+                };
+
+                MoeOrMlp::FusedMoe(moe)
+            } else {
+                let mlp = {
+                    let feed_forward_w1 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_gate.weight"), device)?;
+                    let feed_forward_w2 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_down.weight"), device)?;
+                    let feed_forward_w3 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_up.weight"), device)?;
+                    Mlp {
+                        feed_forward_w1: QMatMul::from_qtensor(feed_forward_w1)?,
+                        feed_forward_w2: QMatMul::from_qtensor(feed_forward_w2)?,
+                        feed_forward_w3: QMatMul::from_qtensor(feed_forward_w3)?,
+                    }
+                };
+                MoeOrMlp::Mlp(mlp)
+            };
+
+            let attention_norm =
+                ct.tensor(reader, &format!("{prefix}.attn_norm.weight"), device)?;
+            let ffn_norm = ct.tensor(reader, &format!("{prefix}.ffn_norm.weight"), device)?;
+            let (q_norm, k_norm) = {
+                let q_norm = ct.tensor(reader, &format!("{prefix}.attn_q_norm.weight"), device)?;
+                let k_norm = ct.tensor(reader, &format!("{prefix}.attn_k_norm.weight"), device)?;
+                let q_norm = RmsNorm::from_qtensor(q_norm, rms_norm_eps)?;
+                let k_norm = RmsNorm::from_qtensor(k_norm, rms_norm_eps)?;
+                (Some(q_norm), Some(k_norm))
+            };
+
+            layers.push(LayerWeights {
+                attention_wq: QMatMul::from_qtensor(attention_wq)?,
+                attention_wk: QMatMul::from_qtensor(attention_wk)?,
+                attention_wv: QMatMul::from_qtensor(attention_wv)?,
+                attention_bq,
+                attention_bk,
+                attention_bv,
+                attention_wo: QMatMul::from_qtensor(attention_wo)?,
+                attention_norm: RmsNorm::from_qtensor(attention_norm, rms_norm_eps)?,
+                q_norm,
+                k_norm,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                mlp,
+                ffn_norm: RmsNorm::from_qtensor(ffn_norm, rms_norm_eps)?,
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim,
+                attn: PagedAttention::new(
+                    head_count,
+                    head_dim,
+                    1. / ((head_dim as f32).sqrt()),
+                    Some(head_count_kv),
+                    None,
+                    device.clone(),
+                    None,
+                )?,
+                dtype,
+            });
+            reporter.write().unwrap().set_progress(layer_idx + 1);
+        }
+
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, embedding_length),
+            layers,
+            norm,
+            output,
+            cfg: GGUFQWenMoE::into_config(
+                arch.clone(),
+                embedding_length,
+                head_dim,
+                0,
+                block_count,
+                head_count,
+                head_count_kv,
+                rms_norm_eps,
+                context_length,
+                &moe_cfg,
+            ),
+            dtype,
+            device: device.clone(),
+        })
+    }
+
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        input_positions: &[Vec<usize>],
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len) = x.dims2()?;
+        assert!(
+            seq_len < self.cfg.max_seq_len,
+            "Input token length exceed maximum context allowed for this model."
+        );
+        let mask = if seq_len <= 1 {
+            None
+        } else {
+            super::get_attention_casual_mask(
+                &self.device,
+                self.dtype,
+                b_sz,
+                seq_len,
+                input_positions,
+                self.cfg.sliding_window,
+            )
+        };
+        let mut layer_in = self.tok_embeddings.forward(x)?;
+        if let Some(kv_caches) = kv_caches {
+            for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
+                let x = layer_in;
+                let residual = &x;
+                let x = layer.attention_norm.forward(&x)?;
+                let attn = layer.forward_attn(
+                    &x,
+                    mask.as_ref(),
+                    input_positions,
+                    Some((k_cache, v_cache)),
+                    input_metadata,
+                )?;
+                let x = (attn + residual)?;
+
+                // MLP
+                let residual = &x;
+                let x = layer.ffn_norm.forward(&x)?;
+                let x = layer.mlp.forward(&x)?;
+                let x = (x + residual)?;
+                layer_in = x
+            }
+        } else {
+            for layer in self.layers.iter() {
+                let x = layer_in;
+                let residual = &x;
+                let x = layer.attention_norm.forward(&x)?;
+                let attn =
+                    layer.forward_attn(&x, mask.as_ref(), input_positions, None, input_metadata)?;
+                let x = (attn + residual)?;
+
+                // MLP
+                let residual = &x;
+                let x = layer.ffn_norm.forward(&x)?;
+                let x = layer.mlp.forward(&x)?;
+                let x = (x + residual)?;
+                layer_in = x
+            }
+        }
+        let x = layer_in
+            .i((.., seq_len - 1, ..))?
+            .contiguous()?
+            .apply(&self.norm)?;
+        self.output.forward(&x)
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
+    }
+}

--- a/src/openai/models/qwen3_moe.rs
+++ b/src/openai/models/qwen3_moe.rs
@@ -1,6 +1,4 @@
 use super::Config;
-#[cfg(feature = "cuda")]
-use crate::backend::custom_ops::sort::ArgSortOp; //Use our custom sort kernel
 use crate::backend::progress::{ProgressLike, ProgressReporter};
 use crate::openai::distributed::{
     embedding, rms_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
@@ -218,7 +216,7 @@ impl Moe {
 
         #[cfg(feature = "cuda")]
         let experts_per_tok = routing_weights
-            .arg_sort(false)?
+            .arg_sort_last_dim(false)?
             .narrow(D::Minus1, 0, self.num_experts_per_tok)?
             .contiguous()?;
 


### PR DESCRIPTION

🔥 **4× Faster Decoding for Qwen3 MoE GGUF Models**

This PR is part of a **code migration** from our [vllm.rs](https://github.com/guoqingbao/vllm.rs) project, where we developed a [**dedicated fast MoE kernel**](https://github.com/guoqingbao/candle/commit/b7624aacc53531d0f7a224215a3c325e6046c17a) for GGUF models.

By integrating the *indexed MoE forward kernel*, we’ve unlocked **over 4× decoding speedup** — from **<20 tokens/s** to **>75 tokens/s** 🏎️ on a single A100 40G for the `Qwen3-30B-A3B-Instruct` model (Q4\_K\_M).

💡 **Similar boost** is expected across other Qwen3 MoE GGUF models.

Sample case:

```shell
cargo run --release --features cuda,nccl -- --f /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
```

**Or** 

```shell
cargo run --release --features cuda,nccl -- --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
```

💡 Note: 
1) Support for Multi-GPU inference on GGUF models is still under development.
2) Long-context prefiling in Qwen3 MoE GGUF requires further improvements.