### PR TITLE
Support multirank qwen3 MoE GGUF model inference through ISQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "17aa718" }
-candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "17aa718" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "17aa718" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.2"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "17aa718" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -34,7 +34,7 @@ intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], option
 #cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 cudarc = {git = "https://github.com/guoqingbao/cudarc.git", version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true, rev="cc13092" }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "17aa718" }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "1f5c662" }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"

--- a/README-CN.md
+++ b/README-CN.md
@@ -95,18 +95,18 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
     **示例:**
 
     ```shell
-    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
+    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
     ```
 
     `ENV_PARAM`: RUST_LOG=warn
 
     `BUILD_PARAM`: --release --features cuda,nccl
 
-    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096
+    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507
 
-    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存；支持的模型架构有：["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
+    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--isq`将权重在加载过程中量化为`q4k`格式；`--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存；支持的模型架构有：["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "qwen3moe", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
   </details>
 
 ## 如何运行？
@@ -115,10 +115,10 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
   <details open>
     <summary>显示命令</summary>
 
-    **本地路径（指定端口与设备）**
+    **本地路径（指定端口、设备及ISQ量化）**
 
     ```shell
-    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/
+    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/ --isq q4k
     ```
 
     **模型ID（从Huggingface下载）**

--- a/README.md
+++ b/README.md
@@ -95,18 +95,18 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
     **Example:**
 
     ```shell
-    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
+    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
     ```
 
     `ENV_PARAM`: RUST_LOG=warn
 
     `BUILD_PARAM`: --release --features cuda,nccl
 
-    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096
+    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507 (or `--m` specify model-id)
 
-    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch); supported model archs include ["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "qwen3_moe", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
+    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--isq q4k`: convert weights into `q4k` format during model loading; `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch); supported model archs include ["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "qwen3_moe", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
   </details>
 
 
@@ -117,10 +117,10 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
   <details open>
     <summary>Show command</summary>
 
-    **Local Path (with port and device specified)**
+    **Local Path (with port, device and isq specified)**
 
     ```shell
-    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/
+    target/release/candle-vllm --p 2000 --d 0,1 --w /home/Qwen3-30B-A3B-Instruct-2507/ --isq q4k
     ```
 
     **Model-ID (download from Huggingface)**

--- a/metal-kernels/Cargo.toml
+++ b/metal-kernels/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 metal = { version = "0.27.0", features = ["mps"] }
 thiserror = "1"
 once_cell = "1.20.2"
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "097af53" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
 
 [build-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }


### PR DESCRIPTION
This PR adds support for **multi-GPU inference** of the Qwen3 MoE GGUF model through ISQ. It works by packing safetensor expert weights and converting them to the GGUF format with ISQ during model loading. Leveraging the previously introduced fused MoE kernel #252, **fast multi-rank inference** of GGUF models is now possible.

**Typical usage**

**Two GPUs running into Q4K format**
(Block size: 256. Maximum of two GPUs is possible since Qwen3 weight dimension can be `[xxx, 768]`.)

```shell
cargo run --release --features cuda,nccl -- --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --d 0,1 --isq q4k
```

**More than two GPUs with non-QK\_K formats**
(e.g., `q8_0`, block size: 32. Maximum GPU count is `768 / 32`.)

```shell
cargo run --release --features cuda,nccl -- --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --d 0,1,2,3 --isq q8_0
```

**Throughput:** 30–50+ tokens/s, depending on cross-GPU communication performance.

Related to: #231 #229 #253 @sempervictus 