### PR TITLE
Optimize prefill speed for Qwen3-MOE GGUF (ISQ) & adjustable prefill chunk size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
-candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.2"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -34,7 +34,7 @@ intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], option
 #cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 cudarc = {git = "https://github.com/guoqingbao/cudarc.git", version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true, rev="cc13092" }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "1f5c662" }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "cf5b1ad" }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"

--- a/README-CN.md
+++ b/README-CN.md
@@ -96,18 +96,18 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
     **示例:**
 
     ```shell
-    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
+    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k --prefill-chunk-size 8192 --penalty 1.1] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
     ```
 
     `ENV_PARAM`: RUST_LOG=warn
 
     `BUILD_PARAM`: --release --features cuda,nccl
 
-    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k
+    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k --prefill-chunk-size 8192 --penalty 1.1
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507
 
-    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--isq`将权重在加载过程中量化为`q4k`格式；`--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存；支持的模型架构有：["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "qwen3moe", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
+    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--isq`将权重在加载过程中量化为`q4k`格式；`--prefill-chunk-size`指定分块prefill时的块大小（默认8K），`--penalty` 重复输出惩罚项 (1.0 : 无惩罚 至 2.0 : 最大惩罚)，`--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存。
   </details>
 
 ## 如何运行？

--- a/README.md
+++ b/README.md
@@ -96,18 +96,18 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
     **Example:**
 
     ```shell
-    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
+    [RUST_LOG=warn] cargo run [--release --features cuda,nccl] -- [--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k --prefill-chunk-size 8192 --penalty 1.1] [--w /home/weights/Qwen3-30B-A3B-Instruct-2507]
     ```
 
     `ENV_PARAM`: RUST_LOG=warn
 
     `BUILD_PARAM`: --release --features cuda,nccl
 
-    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k
+    `PROGRAM_PARAM`：--log --dtype bf16 --p 2000 --d 0,1 --mem 4096 --isq q4k --prefill-chunk-size 8192 --penalty 1.1
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507 (or `--m` specify model-id)
 
-    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--isq q4k`: convert weights into `q4k` format during model loading; `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch); supported model archs include ["llama", "llama3", "mistral", "phi2", "phi3", "qwen2", "qwen3", "qwen3_moe", "glm4", "gemma", "gemma3", "yi", "stable-lm", "deep-seek"]
+    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--isq q4k`: convert weights into `q4k` format during model loading; `--prefill-chunk-size` chunk the prefill into size defined in this flag (default 8K); `--penalty` repetition penalty (1.0 : no penalty to 2.0 : maximum penalty); `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch).
   </details>
 
 

--- a/metal-kernels/Cargo.toml
+++ b/metal-kernels/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 metal = { version = "0.27.0", features = ["mps"] }
 thiserror = "1"
 once_cell = "1.20.2"
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "1f5c662" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
 
 [build-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/src/openai/openai_server.rs
+++ b/src/openai/openai_server.rs
@@ -184,10 +184,7 @@ pub async fn chat_completions(
         request.best_of,
         request.presence_penalty.unwrap_or(0.0),
         request.frequency_penalty.unwrap_or(0.0),
-        request
-            .repetition_penalty
-            .or(generation_cfg.penalty)
-            .or(Some(1.1)),
+        request.repetition_penalty.or(generation_cfg.penalty),
         request.repeat_last_n,
         request.temperature.or(generation_cfg.temperature),
         request.top_p.or(generation_cfg.top_p),


### PR DESCRIPTION
This PR updates the underlying Candle, where we optimized the previous indexed_moe_forward kernel to speed up the prefill stage in qwen3 moe models. Relevant code can be found here: https://github.com/guoqingbao/candle/commit/cf5b1ad79558ac2de208426a6c0f80b1ee29dd5d

Additionally, this PR makes the prefill chunk size configurable.

**Testing results:**

```
--- Performance Metrics ---
⏱️ Prompt tokens: 24328 in 23.32s (1043.05 tokens/s)
⏱️ Decoded tokens: 2608 in 49.34s (52.86 tokens/s)
```

Prefill performance improved from ~600 tokens/s to over 1000 tokens/s on two A100s when running Qwen3-MoE 32B (ISQ Q4K).

Related #253 @sempervictus 

