### PR TITLE
Mixed precision for ISQ & fix bug for prefill chunk size == 0

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -75,7 +75,7 @@ export PATH=$PATH:/usr/local/cuda/bin/
 #CUDA平台：单节点（单机单卡或单机多卡）编译命令
 cargo build --release --features cuda,nccl
 
-#CUDA平台：单节点（使用flash attention kernel，适用于长上下文推理）编译命令
+#CUDA平台：单节点（使用flash attention kernel，适用于长上下文推理，需要CUDA_ARCH >= 800）编译命令
 cargo build --release --features cuda,nccl,flash-attn
 
 #CUDA平台：多节点（多机推理）编译命令
@@ -107,7 +107,7 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #同时包含flash att
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507
 
-    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--isq`将权重在加载过程中量化为`q4k`格式；`--prefill-chunk-size`指定分块prefill时的块大小（默认8K），`--penalty` 重复输出惩罚项 (1.0 : 无惩罚 至 2.0 : 最大惩罚)，`--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存。
+    其中，`--p`: 服务端口; `--d`: 设备序列号; `--w`: 权重路径 (safetensors路径); `--f`: 权重文件 (GGUF模型使用); `--m`: Huggingface model-id; `--isq`将权重在加载过程中量化为`q4k`格式；`--prefill-chunk-size`指定分块prefill时的块大小（默认8K，`0`为禁用），`--penalty` 重复输出惩罚项 (1.0 : 无惩罚 至 2.0 : 最大惩罚)，`--mem` (`kvcache-mem-gpu`) 参数控制KV Cache缓存，长文本或批量推理量请增大缓存。
   </details>
 
 ## 如何运行？

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export PATH=$PATH:/usr/local/cuda/bin/
 #CUDA: single-node compilation (single gpu, or multi-gpus on single machine)
 cargo build --release --features cuda,nccl
 
-#CUDA: single-node compilation with flash attention (takes few minutes for the first build, faster inference for long-context)
+#CUDA: single-node compilation with flash attention (takes few minutes for the first build, faster inference for long-context, requires CUDA_ARCH >= 800)
 cargo build --release --features cuda,nccl,flash-attn
 
 #CUDA: multinode compilation with MPI (multi-gpus, multiple machines)
@@ -107,7 +107,7 @@ cargo build --release --features cuda,nccl,flash-attn,mpi #build with flash-attn
 
     `MODEL_ID/MODEL_WEIGHT_PATH`: --w /home/weights/Qwen3-30B-A3B-Instruct-2507 (or `--m` specify model-id)
 
-    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--isq q4k`: convert weights into `q4k` format during model loading; `--prefill-chunk-size` chunk the prefill into size defined in this flag (default 8K); `--penalty` repetition penalty (1.0 : no penalty to 2.0 : maximum penalty); `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch).
+    where, `--p`: server port; `--d`: device ids; `--w`: weight path (safetensors folder); `--f`: weight file (for gguf); `--m`: huggingface model-id; `--isq q4k`: convert weights into `q4k` format during model loading; `--prefill-chunk-size` chunk the prefill into size defined in this flag (default 8K, `0` for disable); `--penalty` repetition penalty (1.0 : no penalty to 2.0 : maximum penalty); `--mem` (`kvcache-mem-gpu`) is the key parameter to control KV cache usage (increase this for large batch).
   </details>
 
 

--- a/src/openai/models/glm4.rs
+++ b/src/openai/models/glm4.rs
@@ -189,13 +189,23 @@ impl SelfAttention {
             &cfg.quantization_config,
         )?;
 
+        let q8_0_quant = Some("q8_0".to_string());
         let v_proj = TensorParallelColumnLinear::load_with_hints(
             hidden_sz,
             num_kv_heads * head_dim,
             attention_bias,
             vb.pp("v_proj"),
             comm.clone(),
-            &cfg.quant,
+            if cfg.quant.is_some()
+                && !matches!(
+                    cfg.quant.as_ref().unwrap().as_str(),
+                    "gptq" | "awq" | "marlin"
+                )
+            {
+                &q8_0_quant
+            } else {
+                &cfg.quant
+            },
             &cfg.quantization_config,
         )?;
 

--- a/src/openai/models/llama.rs
+++ b/src/openai/models/llama.rs
@@ -186,13 +186,24 @@ impl CausalSelfAttention {
             &cfg.quant,
             &cfg.quantization_config,
         )?;
+
+        let q8_0_quant = Some("q8_0".to_string());
         let v_proj = TensorParallelColumnLinear::load_with_hints(
             size_in,
             size_kv,
             false,
             vb.pp("v_proj"),
             comm.clone(),
-            &cfg.quant,
+            if cfg.quant.is_some()
+                && !matches!(
+                    cfg.quant.as_ref().unwrap().as_str(),
+                    "gptq" | "awq" | "marlin"
+                )
+            {
+                &q8_0_quant
+            } else {
+                &cfg.quant
+            },
             &cfg.quantization_config,
         )?;
 

--- a/src/openai/models/mistral.rs
+++ b/src/openai/models/mistral.rs
@@ -293,13 +293,23 @@ impl Attention {
             &cfg.quant,
             &cfg.quantization_config,
         )?;
+        let q8_0_quant = Some("q8_0".to_string());
         let v_proj = TensorParallelColumnLinear::load_with_hints(
             hidden_sz,
             num_kv_heads * head_dim,
             false,
             vb.pp("v_proj"),
             comm.clone(),
-            &cfg.quant,
+            if cfg.quant.is_some()
+                && !matches!(
+                    cfg.quant.as_ref().unwrap().as_str(),
+                    "gptq" | "awq" | "marlin"
+                )
+            {
+                &q8_0_quant
+            } else {
+                &cfg.quant
+            },
             &cfg.quantization_config,
         )?;
 

--- a/src/openai/models/qwen.rs
+++ b/src/openai/models/qwen.rs
@@ -198,13 +198,23 @@ impl Attention {
             &cfg.quant,
             &cfg.quantization_config,
         )?;
+        let q8_0_quant = Some("q8_0".to_string());
         let v_proj = TensorParallelColumnLinear::load_with_hints(
             hidden_sz,
             num_kv_heads * head_dim,
             attention_bias,
             vb.pp("v_proj"),
             comm.clone(),
-            &cfg.quant,
+            if cfg.quant.is_some()
+                && !matches!(
+                    cfg.quant.as_ref().unwrap().as_str(),
+                    "gptq" | "awq" | "marlin"
+                )
+            {
+                &q8_0_quant
+            } else {
+                &cfg.quant
+            },
             &cfg.quantization_config,
         )?;
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -247,13 +247,12 @@ impl Scheduler {
     ) -> (Vec<u32>, VecDeque<Arc<SequenceGroup>>) {
         let mut finished_indices = Vec::new();
         let mut remove_ids = Vec::new();
+        assert!(chunk_size > 0, "Invalid prefill chunk size!");
         for (i, group) in scheduled.iter().enumerate() {
             let seq = group.get_seqs().values().nth(0).unwrap();
             let prompt_len = seq.deref().get_prompt_len();
             let num_cached_tokens = seq.deref().get_num_cached_tokens();
-            if chunk_size > 0
-                && (prompt_len < chunk_size || num_cached_tokens + chunk_size >= prompt_len)
-            {
+            if prompt_len < chunk_size || num_cached_tokens + chunk_size >= prompt_len {
                 if prompt_len > chunk_size {
                     tracing::info!(
                         "Seq {} chunk prefill finished ({} tokens)",


### PR DESCRIPTION
Loading **safetensors** models as quantized **GGUF** format (ISQ or *in-situ quantization*) can introduce accuracy degradation. This PR introduces **mixed precision** for ISQ, assigning accuracy-sensitive weights (such as `v_proj` and `ffn_down_experts`) to higher-precision formats (e.g., `q8_0`), while leaving others in lower-precision formats (e.g., `q4k`, `q5_0`, etc.). This approach helps mitigate accuracy degradation, especially for **MoE models**.

**Usage:**

```shell
cargo run --release --features cuda,nccl -- --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --isq q4k --d 0,1 --prefill-chunk-size 4096
```

Additionally, this PR fixes an issue where **chunked prefill** could not be disabled. It can now be disabled by setting `--prefill-chunk-size` to `0`.
