### PR TITLE
Dockerfile: Ignore GPG signatures on oneapi repo (behind TLS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC
-    apt-get update
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         libssl-dev \
@@ -12,7 +12,7 @@ RUN <<HEREDOC
         clang \
         libclang-dev \
         libopenmpi-dev \
-        openmpi-bin
+        openmpi-bin && \
 
     rm -rf /var/lib/apt/lists/*
 HEREDOC
@@ -23,9 +23,7 @@ RUN rustup update nightly
 RUN rustup default nightly
 
 # MKL build dependencies
-RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+RUN echo "deb [trusted=yes] https://apt.repos.intel.com/oneapi all main" | \
     tee /etc/apt/sources.list.d/oneAPI.list \
     && apt-get update \
     && apt-get install -y libomp-dev intel-oneapi-mkl-devel
@@ -49,23 +47,19 @@ ENV HUGGINGFACE_HUB_CACHE=/data \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN curl -s https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+RUN echo "deb [trusted=yes] https://apt.repos.intel.com/oneapi all main" | \
     tee /etc/apt/sources.list.d/oneAPI.list
 
 RUN <<HEREDOC
-    apt-get update
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         libomp-dev \
         ca-certificates \
         libssl-dev \
         curl \
         pkg-config \
-        # Provided for convenience when using the NCCL crate feature:
         openmpi-bin \
-        # Provided for MKL feature runtime:
-        intel-oneapi-hpc-toolkit
+        intel-oneapi-hpc-toolkit && \
 
     rm -rf /var/lib/apt/lists/*
 HEREDOC


### PR DESCRIPTION
When the Dockerfile catches all exceptions through command chaining using `&&`, its fairly common to hit GPG validation error for the OneAPI repository key. The repository uses TLS with a cert under the Intel domain name for which the key is presumably a closely held secret.

Drop signature validation by setting the repo to `trusted=yes` and skip the key acquisition as well. Keep strict command chaining to ensure all other dependencies are installed correctly and every RUN step of the build completes without silently ignoring errors from commands before the last one in the RUN block. Drop comment lines between package name lines in the runtime container as those break the newline-escaped chains.