### PR TITLE
Compatible with non-standard models for rope scaling config

### DIFF
--- a/src/openai/models/rotary_emb.rs
+++ b/src/openai/models/rotary_emb.rs
@@ -114,6 +114,12 @@ impl ScalingRotaryEmbedding {
             .map(|factor| (factor * dim as f32) as usize)
             .unwrap_or(dim);
         if let Some(rope_scaling) = &cfg.rope_scaling {
+            let mut rope_scaling = rope_scaling.clone();
+            if !rope_scaling.contains_key("rope_type") && rope_scaling.contains_key("type") {
+                //for non-standard models that use "type" instead of "rope_type"
+                let value = rope_scaling.remove("type").unwrap();
+                rope_scaling.insert("rope_type".to_string(), value);
+            }
             if let RopeScaling(Either::Right(rope_type)) = &rope_scaling["rope_type"] {
                 let rope_result = if rope_type == "linear" {
                     if let RopeScaling(Either::Left(ScalingValue(Either::Left(factor)))) =


### PR DESCRIPTION
Some customized models use `type` instead of `rope_type` in rope_scaling config, like this:

https://huggingface.co/DavidAU/Qwen2.5-Godzilla-Coder-51B-128k/blob/main/config.json

This PR made a compatible solution. 

Related to #280 