### PR TITLE
Enable Qwen2MoeForCausalLM via Qwen3MoE handler

### DIFF
--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -362,7 +362,7 @@ impl DefaultLoader {
                     gguf::get_arch_and_num_of_layers(content).map_err(candle_core::Error::wrap)?;
                 if !matches!(
                     arch.as_str(),
-                    "llama" | "llama3" | "phi3" | "qwen2" | "qwen3" | "qwen3moe" | "glm4"
+                    "llama" | "llama3" | "phi3" | "qwen2" | "qwen2moe" | "qwen3" | "qwen3moe" | "glm4"
                 ) {
                     panic!("Model arch {} not supported!", arch);
                 } else {
@@ -426,7 +426,7 @@ impl DefaultLoader {
                     let cfg = model.get_config().clone();
                     (LLMModel::QWenGGUF(model), cfg, SeparatorStyle::Qwen)
                 }
-                "qwen3moe" => {
+                "qwen2moe | qwen3moe" => {
                     let model = GGUFQWenMoE::from_gguf(
                         &content,
                         &mut file,
@@ -463,7 +463,7 @@ impl DefaultLoader {
                 "PhiForCausalLM" => Phi2::load_config(&cfile, isq)?,
                 "Phi3ForCausalLM" => Phi::load_config(&cfile, isq)?,
                 "Qwen2ForCausalLM" | "Qwen3ForCausalLM" => Qwen::load_config(&cfile, isq)?,
-                "Qwen3MoeForCausalLM" => Qwen3MoE::load_config(&cfile, isq)?,
+                "Qwen2MoeForCausalLM" | "Qwen3MoeForCausalLM" => Qwen3MoE::load_config(&cfile, isq)?,
                 "Gemma2ForCausalLM" => Gemma::load_config(&cfile, isq)?,
                 "Gemma3ForConditionalGeneration" => Gemma3::load_config(&cfile, isq)?,
                 "MistralForCausalLM" => Mistral::load_config(&cfile, isq)?,
@@ -596,7 +596,7 @@ impl DefaultLoader {
                             ),
                             SeparatorStyle::Qwen,
                         ),
-                        "Qwen3MoeForCausalLM" => (
+                        "Qwen2MoeForCausalLM" | "Qwen3MoeForCausalLM" => (
                             LLMModel::Qwen3MoE(
                                 Qwen3MoE::new(
                                     matches!(arch.as_str(), "qwen3moe" | "Qwen3MoeForCausalLM"),


### PR DESCRIPTION
Qwen generations' loaders use shared code in the Mlp and Moe cases with a boolean to determine whether they are Qwen3 require an rms_norm pass prior to embedding.
With the rope scaling work recently done by @guoqingbao, this commit permits loading models such as
`DavidAU/Qwen2.5-8x7B-Vee-Eight-Coder-Instruct-53B-128k-ctx`.

Testing:
  Loaded model above, initial conversation appears to suffer from
issue #280 which impacts both Moe and Mlp models above 3X scale factor. Model does load and respond though.

Ping @guoqingbao and @EricLBuehler for sanity check please