### PR TITLE
Use higher precision for MoE gating and q/k norm & simplified scalingvalue

### DIFF
--- a/src/openai/distributed.rs
+++ b/src/openai/distributed.rs
@@ -1,6 +1,6 @@
 use crate::openai::models::linear::{linear_no_bias_x as linear, LinearX as Linear};
-use candle_core::CustomOp1;
 use candle_core::{CpuStorage, Layout, Module, Result, Shape, Tensor};
+use candle_core::{CustomOp1, DType};
 use candle_nn::var_builder::Shard;
 pub use candle_nn::var_builder::ShardedVarBuilder as VarBuilder;
 use candle_nn::{Embedding, LayerNorm, RmsNorm};
@@ -339,6 +339,11 @@ impl TensorParallelRowLinear {
 
 pub fn rms_norm(size: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
     let weight = vb.get_with_hints(size, "weight", shard(0, 0, 1))?;
+    Ok(RmsNorm::new(weight, eps))
+}
+
+pub fn rms_norm_with_dtype(size: usize, eps: f64, vb: VarBuilder, dtype: DType) -> Result<RmsNorm> {
+    let weight = vb.get_with_hints_dtype(size, "weight", shard(0, 0, 1), dtype)?;
     Ok(RmsNorm::new(weight, eps))
 }
 

--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -82,7 +82,7 @@ pub struct OpenAIServerData {
 pub struct TaskData {
     pub seq_id: usize,
     pub group_id: usize,
-    pub prompt: Encoding,
+    pub prompt: Vec<u32>,
     pub request_id: String,
     pub created: SystemTime,
     pub sampling_params: SamplingParams,

--- a/src/openai/models/deepseek.rs
+++ b/src/openai/models/deepseek.rs
@@ -8,6 +8,7 @@ use crate::openai::distributed::{
     embedding, rms_norm, AllReduce, Comm, ReplicatedLinear, TensorParallelColumnLinear,
     TensorParallelRowLinear, VarBuilder,
 };
+use crate::openai::models::DeepSeekMoEConfig;
 use crate::paged_attention::input_metadata::InputMetadata;
 use crate::paged_attention::PagedAttention;
 use candle::{DType, Device, IndexOp, Result, Tensor, D};
@@ -117,7 +118,7 @@ impl DeepSeek {
             None
         };
 
-        let moe_config = MoEConfig {
+        let moe_config = DeepSeekMoEConfig {
             num_experts_per_tok: config.num_experts_per_tok,
             n_routed_experts: config.n_routed_experts.unwrap_or(0),
             moe_intermediate_size: config.moe_intermediate_size,
@@ -189,8 +190,7 @@ impl DeepSeek {
             attn_logit_softcapping: None,
             final_logit_softcapping: None,
             quantization_config: config.quantization_config.clone(),
-            moe_config: Some(moe_config),
-            qwen_moe_config: None,
+            moe_config: Some(MoEConfig::DeepSeekMoE(moe_config)),
             quant,
         };
         Ok(config)
@@ -369,7 +369,7 @@ impl DeepSeekV2RotaryEmbedding {
     }
 }
 
-impl MoEConfig {
+impl DeepSeekMoEConfig {
     pub(crate) fn q_head_dim(&self) -> usize {
         self.qk_rope_head_dim + self.qk_nope_head_dim
     }
@@ -414,10 +414,10 @@ struct Attention {
     kv_b_proj: TensorParallelColumnLinear,
     o_proj: TensorParallelRowLinear,
     rotary_emb: Arc<DeepSeekV2RotaryEmbedding>,
-    cfg: Config,
     q_head_dim: usize,
     num_attention_heads: usize,
     attn: PagedAttention,
+    moe_cfg: DeepSeekMoEConfig,
 }
 
 impl Attention {
@@ -428,7 +428,11 @@ impl Attention {
         comm: Rc<Comm>,
     ) -> Result<Self> {
         let q_head_dim = cfg.q_head_dim();
-        let moe_cfg = cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = if let Some(MoEConfig::DeepSeekMoE(moe_cfg)) = &cfg.moe_config {
+            moe_cfg.clone()
+        } else {
+            candle::bail!("Expected DeepSeekMoEConfig")
+        };
         let attention_bias = cfg.attention_bias.unwrap();
         let q = match moe_cfg.q_lora_rank {
             Some(lora_rank) => {
@@ -506,7 +510,6 @@ impl Attention {
             kv_b_proj,
             o_proj,
             rotary_emb,
-            cfg: cfg.clone(),
             q_head_dim,
             num_attention_heads,
             attn: PagedAttention::new(
@@ -518,6 +521,7 @@ impl Attention {
                 vb.device().clone(),
                 None,
             )?,
+            moe_cfg,
         })
     }
 
@@ -530,12 +534,11 @@ impl Attention {
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
         let (bs, seq_len, _) = xs.dims3()?;
-        let moe_cfg = self.cfg.moe_config.as_ref().unwrap();
         let (q_nope, mut q_pe) = {
             let q = self.q.forward(xs)?;
             let q = q.reshape((bs, seq_len, self.num_attention_heads, self.q_head_dim))?;
             let (q_nope, q_pe) = q.split2(
-                &[moe_cfg.qk_nope_head_dim, moe_cfg.qk_rope_head_dim],
+                &[self.moe_cfg.qk_nope_head_dim, self.moe_cfg.qk_rope_head_dim],
                 D::Minus1,
             )?;
             let q_nope = q_nope.transpose(1, 2)?;
@@ -544,10 +547,12 @@ impl Attention {
         };
 
         let compressed_kv = self.kv_a_proj_with_mqa.forward(xs)?;
-        let (compressed_kv, k_pe) =
-            compressed_kv.split2(&[moe_cfg.kv_lora_rank, moe_cfg.qk_rope_head_dim], D::Minus1)?;
+        let (compressed_kv, k_pe) = compressed_kv.split2(
+            &[self.moe_cfg.kv_lora_rank, self.moe_cfg.qk_rope_head_dim],
+            D::Minus1,
+        )?;
         let mut k_pe = k_pe
-            .reshape((bs, seq_len, 1, moe_cfg.qk_rope_head_dim))?
+            .reshape((bs, seq_len, 1, self.moe_cfg.qk_rope_head_dim))?
             .transpose(1, 2)?;
         let kv = {
             let kv = self
@@ -557,12 +562,15 @@ impl Attention {
                 bs,
                 seq_len,
                 self.num_attention_heads,
-                moe_cfg.qk_nope_head_dim + moe_cfg.v_head_dim,
+                self.moe_cfg.qk_nope_head_dim + self.moe_cfg.v_head_dim,
             ))?
             .transpose(1, 2)?
         };
 
-        let (k_nope, v) = kv.split2(&[moe_cfg.qk_nope_head_dim, moe_cfg.v_head_dim], D::Minus1)?;
+        let (k_nope, v) = kv.split2(
+            &[self.moe_cfg.qk_nope_head_dim, self.moe_cfg.v_head_dim],
+            D::Minus1,
+        )?;
         let mut v = v.contiguous()?;
 
         (q_pe, k_pe) = self.rotary_emb.forward(
@@ -576,9 +584,9 @@ impl Attention {
         let k_pe = k_pe.repeat((1, q.dim(1)?, 1, 1))?;
         let k = Tensor::cat(&[k_nope, k_pe], D::Minus1)?.contiguous()?;
 
-        if self.q_head_dim != moe_cfg.v_head_dim {
+        if self.q_head_dim != self.moe_cfg.v_head_dim {
             v = v
-                .pad_with_zeros(D::Minus1, 0, self.q_head_dim - moe_cfg.v_head_dim)?
+                .pad_with_zeros(D::Minus1, 0, self.q_head_dim - self.moe_cfg.v_head_dim)?
                 .contiguous()?;
         }
 
@@ -593,8 +601,8 @@ impl Attention {
             None,
         )?;
 
-        if self.q_head_dim != moe_cfg.v_head_dim {
-            y = y.narrow(D::Minus1, 0, moe_cfg.v_head_dim)?;
+        if self.q_head_dim != self.moe_cfg.v_head_dim {
+            y = y.narrow(D::Minus1, 0, self.moe_cfg.v_head_dim)?;
         }
 
         y = y.reshape((bs, seq_len, ()))?;
@@ -689,15 +697,19 @@ impl Mlp {
 
 struct MoeGate {
     weight: Tensor,
-    cfg: Config,
     top_k: usize,
     n_routed_experts: usize,
     e_score_correction_bias: Option<Tensor>,
+    moe_cfg: DeepSeekMoEConfig,
 }
 
 impl MoeGate {
     fn new(cfg: &Config, vb: VarBuilder, n_routed_experts: usize) -> Result<Self> {
-        let moe_cfg = cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = if let Some(MoEConfig::DeepSeekMoE(moe_cfg)) = &cfg.moe_config {
+            moe_cfg.clone()
+        } else {
+            candle::bail!("Expected DeepSeekMoEConfig")
+        };
         let weight = vb.get((n_routed_experts, cfg.hidden_size), "weight")?;
         let e_score_correction_bias = if matches!(moe_cfg.topk_method, TopkMethod::NoAuxTc) {
             Some(vb.get_with_hints_dtype(
@@ -711,17 +723,17 @@ impl MoeGate {
         };
         Ok(Self {
             weight: weight.to_dtype(DType::F32)?,
-            cfg: cfg.clone(),
             top_k: moe_cfg.num_experts_per_tok.unwrap(),
             n_routed_experts,
             e_score_correction_bias,
+            moe_cfg,
         })
     }
 
     /// (topk_idx, topk_weight)
     fn forward(&self, xs: &Tensor) -> Result<(Tensor, Tensor)> {
         let (bs, seq_len, h) = xs.dims3()?;
-        let moe_cfg = self.cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = &self.moe_cfg;
         // Compute gating score
         let xs = xs.reshape(((), h))?;
         let logits = xs
@@ -836,7 +848,11 @@ impl Moe {
         n_routed_experts: usize,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let moe_cfg = cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = if let Some(MoEConfig::DeepSeekMoE(moe_cfg)) = &cfg.moe_config {
+            moe_cfg.clone()
+        } else {
+            candle::bail!("Expected DeepSeekMoEConfig")
+        };
         let mut experts = Vec::with_capacity(n_routed_experts);
         let n_local_experts = n_routed_experts / comm.world_size();
         let experts_start_idx = comm.rank() * n_local_experts;
@@ -984,7 +1000,11 @@ impl DecoderLayer {
         layer_idx: usize,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let moe_cfg = cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = if let Some(MoEConfig::DeepSeekMoE(moe_cfg)) = &cfg.moe_config {
+            moe_cfg.clone()
+        } else {
+            candle::bail!("Expected DeepSeekMoEConfig")
+        };
         let attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"), comm.clone())?;
         let input_layernorm =
             rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
@@ -1058,7 +1078,11 @@ impl DeepSeek {
         progress_reporter: Arc<RwLock<ProgressReporter>>,
     ) -> Result<Self> {
         let vb_m = vb.pp("model");
-        let moe_cfg = cfg.moe_config.as_ref().unwrap();
+        let moe_cfg = if let Some(MoEConfig::DeepSeekMoE(moe_cfg)) = &cfg.moe_config {
+            moe_cfg.clone()
+        } else {
+            candle::bail!("Expected DeepSeekMoEConfig")
+        };
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
         let reporter = progress_reporter.clone();
         let lm_head = if !cfg.tie_word_embeddings {

--- a/src/openai/models/mistral.rs
+++ b/src/openai/models/mistral.rs
@@ -141,7 +141,6 @@ impl Mistral {
             final_logit_softcapping: None,
             quantization_config: config.text_config.quantization_config.clone(),
             moe_config: None,
-            qwen_moe_config: None,
             quant,
         };
         Ok(config)

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -1,6 +1,6 @@
 // This implementation is based on:
 // https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py
-use super::{Config, RopeScaling, ScalingValue};
+use super::{Config, ScalingValue};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
 use crate::openai::distributed::{
     embedding, rms_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
@@ -11,7 +11,6 @@ use crate::paged_attention::PagedAttention;
 use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_core as candle;
 use candle_nn::RmsNorm;
-use either::Either;
 use std::iter::zip;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -78,11 +77,11 @@ impl RotaryEmbedding {
                 //insert cfg.original_max_position_embeddings
                 rope_scaling.insert(
                     "original_max_position_embeddings".to_string(),
-                    RopeScaling(Either::Left(ScalingValue(Either::Left(
+                    ScalingValue::Single(
                         cfg.original_max_position_embeddings
                             .unwrap_or(cfg.max_position_embeddings.unwrap_or(8192))
                             as f64,
-                    )))),
+                    ),
                 );
             }
             match (
@@ -92,12 +91,10 @@ impl RotaryEmbedding {
                 &rope_scaling["original_max_position_embeddings"],
             ) {
                 (
-                    RopeScaling(Either::Left(ScalingValue(Either::Right(short_factor)))),
-                    RopeScaling(Either::Left(ScalingValue(Either::Right(long_factor)))),
-                    RopeScaling(Either::Right(tp)),
-                    RopeScaling(Either::Left(ScalingValue(Either::Left(
-                        original_max_position_embeddings,
-                    )))),
+                    ScalingValue::Vec(short_factor),
+                    ScalingValue::Vec(long_factor),
+                    ScalingValue::String(tp),
+                    ScalingValue::Single(original_max_position_embeddings),
                 ) => {
                     let scale = cfg.max_seq_len as f64 / *original_max_position_embeddings;
                     let scaling_factor = if scale <= 1.0 {

--- a/src/openai/models/quantized_glm4.rs
+++ b/src/openai/models/quantized_glm4.rs
@@ -187,7 +187,6 @@ impl GGUFGLM4 {
             final_logit_softcapping: None,
             quantization_config: None,
             moe_config: None,
-            qwen_moe_config: None,
             quant: Some("gguf".to_string()),
         }
     }

--- a/src/openai/models/quantized_llama.rs
+++ b/src/openai/models/quantized_llama.rs
@@ -242,7 +242,6 @@ impl GGUFLLaMa {
             final_logit_softcapping: None,
             quantization_config: None,
             moe_config: None,
-            qwen_moe_config: None,
             quant: Some("gguf".to_string()),
         }
     }

--- a/src/openai/models/quantized_phi3.rs
+++ b/src/openai/models/quantized_phi3.rs
@@ -192,7 +192,6 @@ impl GGUFPhi3 {
             final_logit_softcapping: None,
             quantization_config: None,
             moe_config: None,
-            qwen_moe_config: None,
             quant: Some("gguf".to_string()),
         }
     }

--- a/src/openai/models/quantized_qwen.rs
+++ b/src/openai/models/quantized_qwen.rs
@@ -199,7 +199,6 @@ impl GGUFQWen {
             final_logit_softcapping: None,
             quantization_config: None,
             moe_config: None,
-            qwen_moe_config: None,
             quant: Some("gguf".to_string()),
         }
     }

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -37,7 +37,6 @@ use std::{
     iter::zip,
     sync::Arc,
 };
-use tokenizers::Encoding;
 use tokio::sync::Notify;
 #[allow(unused_imports)]
 use tracing::{debug, info, warn};
@@ -1065,7 +1064,7 @@ impl LLMEngine {
         &mut self,
         seq_id: usize,
         group_id: usize,
-        prompt: &Encoding,
+        prompt: &Vec<u32>,
         request_id: &str,
         created: SystemTime,
         sampling_params: &SamplingParams,
@@ -1073,12 +1072,7 @@ impl LLMEngine {
         sender: Option<Sender<ChatResponse>>,
     ) -> SequenceGroup {
         let seq = Arc::new(Sequence(std::sync::RwLock::new(_Sequence::new(
-            prompt
-                .get_ids()
-                .to_vec()
-                .iter()
-                .map(|x| *x as usize)
-                .collect::<Vec<_>>(),
+            prompt,
             seq_id,
             self.cache_config.block_size,
         ))));
@@ -1096,7 +1090,7 @@ impl LLMEngine {
 
     pub fn add_request(
         &mut self,
-        prompt: Encoding,
+        prompt: Vec<u32>,
         request_id: String,
         created: SystemTime,
         sampling_params: SamplingParams,

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -1123,7 +1123,7 @@ impl DefaultPipeline {
                     Right("stop".to_string())
                 } else {
                     Left(Logprobs {
-                        token: next_token as usize,
+                        token: next_token,
                         logprob: 0.0,
                         top_logprobs: Vec::<TopLogprob>::new(),
                         bytes: text,

--- a/src/openai/sampling_params.rs
+++ b/src/openai/sampling_params.rs
@@ -7,14 +7,14 @@ const SAMPLING_EPS: f32 = 1e-5;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // Top-n logprobs element
 pub struct TopLogprob {
-    pub token: usize,
+    pub token: u32,
     pub logprob: f32,
     pub bytes: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Logprobs {
-    pub token: usize,
+    pub token: u32,
     pub logprob: f32,
     pub bytes: String,
     pub top_logprobs: Vec<TopLogprob>,

--- a/src/scheduler/block_engine.rs
+++ b/src/scheduler/block_engine.rs
@@ -9,7 +9,7 @@ use std::{
 use super::sequence::{Sequence, SequenceGroup};
 
 pub struct LogicalTokenBlock {
-    tokens: Vec<usize>,
+    tokens: Vec<u32>,
     block_size: usize,
     num_tokens: usize,
 }
@@ -31,13 +31,13 @@ impl LogicalTokenBlock {
         self.num_tokens == 0
     }
 
-    pub fn append_token_id(&mut self, token: usize) {
+    pub fn append_token_id(&mut self, token: u32) {
         assert!(!self.is_full());
         self.tokens[self.num_tokens] = token;
         self.num_tokens += 1;
     }
 
-    pub fn append_tokens(&mut self, tokens: &[usize]) {
+    pub fn append_tokens(&mut self, tokens: &[u32]) {
         for token in tokens {
             self.append_token_id(*token);
         }

--- a/src/scheduler/sequence.rs
+++ b/src/scheduler/sequence.rs
@@ -20,7 +20,7 @@ pub enum SequenceStatus {
 }
 
 pub struct SequenceData {
-    prompt_token_ids: Vec<usize>,
+    prompt_token_ids: Vec<u32>,
     output_token_ids: Vec<Logprobs>,
     cumulative_logprob: f32,
     status: SequenceStatus,
@@ -28,7 +28,7 @@ pub struct SequenceData {
 }
 
 impl SequenceData {
-    pub fn new(prompt_token_ids: Vec<usize>) -> Self {
+    pub fn new(prompt_token_ids: Vec<u32>) -> Self {
         Self {
             prompt_token_ids,
             output_token_ids: Vec::new(),
@@ -62,7 +62,7 @@ pub struct _Sequence {
 }
 
 impl _Sequence {
-    pub fn new(prompt_token_ids: Vec<usize>, seq_id: usize, block_size: usize) -> Self {
+    pub fn new(prompt_token_ids: &Vec<u32>, seq_id: usize, block_size: usize) -> Self {
         let mut this = Self {
             data: RwLock::new(SequenceData::new(prompt_token_ids.clone())),
             seq_id,
@@ -109,7 +109,7 @@ impl _Sequence {
         dref.prompt_token_ids.len() + dref.output_token_ids.len()
     }
 
-    pub fn get_token_ids(&self) -> Vec<usize> {
+    pub fn get_token_ids(&self) -> Vec<u32> {
         let mut res = self.deref().prompt_token_ids.clone();
         res.extend(
             self.deref()
@@ -121,7 +121,7 @@ impl _Sequence {
         res
     }
 
-    pub fn get_last_token_id(&self) -> usize {
+    pub fn get_last_token_id(&self) -> u32 {
         if self.deref().output_token_ids.is_empty() {
             *self.deref().prompt_token_ids.last().unwrap()
         } else {
@@ -168,13 +168,13 @@ impl _Sequence {
         self.deref().output_token_ids.clone() // TODO(EricLBuehler): Better way to do this?
     }
 
-    fn append_tokens_to_blocks(&mut self, tokens: Vec<usize>) {
+    fn append_tokens_to_blocks(&mut self, tokens: &Vec<u32>) {
         for tok in tokens {
-            self.append_token_to_blocks(tok);
+            self.append_token_to_blocks(*tok);
         }
     }
 
-    fn append_token_to_blocks(&mut self, token: usize) {
+    fn append_token_to_blocks(&mut self, token: u32) {
         let last = self.logical_token_blocks.last_mut();
         match last {
             Some(last) => {


### PR DESCRIPTION
Lower precision in `MoE gating` and `q/k normalization` can negatively affect generation accuracy, especially on hardware without native BF16 support.

This PR uses `F32` for computing MoE gating and q/k normalization results to ensure higher generation stability.

Additionally, the RoPE ScalingValue struct has been simplified for improved readability.