### PR TITLE
Support Qwen2 MoE models

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -43,6 +43,8 @@
     | #9 | **DeepSeek V2/V3/R1** |✅|TBD|TBD|~20 tks **(AWQ 671B, tp=8, offloading)**|TBD|
     | #10 | **QwQ-32B** |✅|30 tks/s **(32B, tp=2)**|TBD |36 tks/s **(32B, Q4K, GGUF)**|TBD|
     | #11 | **GLM4** |✅|55 tks/s **(9B)**|TBD |92 tks/s **(9B, Q4K, GGUF)**|TBD|
+    | #12 | **QWen2 MoE** |✅|TBD|TBD |65 tks/s (14B, Q4K)|TBD|
+    | #13 | **QWen3 MoE** |✅|TBD|TBD |71 tks/s **(32B, Q4K)**|TBD|
   </details>
 
 ### 演示视频

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Efficient, easy-to-use platform for inference and serving local LLMs including a
     | #9 | **DeepSeek V2/V3/R1** |✅|TBD|TBD|~20 tks **(AWQ 671B, tp=8, offloading)**|TBD|
     | #10 | **QwQ-32B** |✅|30 tks/s **(32B, tp=2)**|TBD |36 tks/s **(32B, Q4K, GGUF)**|TBD|
     | #11 | **GLM4** |✅|55 tks/s **(9B)**|TBD |92 tks/s **(9B, Q4K, GGUF)**|TBD|
+    | #12 | **QWen2 MoE** |✅|TBD|TBD |65 tks/s (14B, Q4K)|TBD|
+    | #13 | **QWen3 MoE** |✅|TBD|TBD |71 tks/s **(32B, Q4K)** |TBD|
   </details>
 
 ### Demo Video

--- a/src/openai/models/mod.rs
+++ b/src/openai/models/mod.rs
@@ -98,9 +98,11 @@ pub struct DeepSeekMoEConfig {
 #[derive(Deserialize, Debug, Clone)]
 pub struct QwenMoEConfig {
     pub moe_intermediate_size: usize,
+    pub shared_expert_intermediate_size: Option<usize>,
     pub num_experts: Option<usize>,
     pub mlp_only_layers: Option<Vec<usize>>,
     pub decoder_sparse_step: Option<usize>,
+    #[serde(default)]
     pub norm_topk_prob: bool,
     pub num_experts_per_tok: usize,
 }

--- a/src/openai/pipelines/pipeline.rs
+++ b/src/openai/pipelines/pipeline.rs
@@ -362,7 +362,14 @@ impl DefaultLoader {
                     gguf::get_arch_and_num_of_layers(content).map_err(candle_core::Error::wrap)?;
                 if !matches!(
                     arch.as_str(),
-                    "llama" | "llama3" | "phi3" | "qwen2" | "qwen3" | "qwen3moe" | "glm4"
+                    "llama"
+                        | "llama3"
+                        | "phi3"
+                        | "qwen2"
+                        | "qwen3"
+                        | "qwen2moe"
+                        | "qwen3moe"
+                        | "glm4"
                 ) {
                     panic!("Model arch {} not supported!", arch);
                 } else {
@@ -426,7 +433,7 @@ impl DefaultLoader {
                     let cfg = model.get_config().clone();
                     (LLMModel::QWenGGUF(model), cfg, SeparatorStyle::Qwen)
                 }
-                "qwen3moe" => {
+                "qwen2moe" | "qwen3moe" => {
                     let model = GGUFQWenMoE::from_gguf(
                         &content,
                         &mut file,
@@ -463,7 +470,9 @@ impl DefaultLoader {
                 "PhiForCausalLM" => Phi2::load_config(&cfile, isq)?,
                 "Phi3ForCausalLM" => Phi::load_config(&cfile, isq)?,
                 "Qwen2ForCausalLM" | "Qwen3ForCausalLM" => Qwen::load_config(&cfile, isq)?,
-                "Qwen3MoeForCausalLM" => Qwen3MoE::load_config(&cfile, isq)?,
+                "Qwen2MoeForCausalLM" | "Qwen3MoeForCausalLM" => {
+                    Qwen3MoE::load_config(&cfile, isq)?
+                }
                 "Gemma2ForCausalLM" => Gemma::load_config(&cfile, isq)?,
                 "Gemma3ForConditionalGeneration" => Gemma3::load_config(&cfile, isq)?,
                 "MistralForCausalLM" => Mistral::load_config(&cfile, isq)?,
@@ -596,10 +605,16 @@ impl DefaultLoader {
                             ),
                             SeparatorStyle::Qwen,
                         ),
-                        "Qwen3MoeForCausalLM" => (
+                        "Qwen2MoeForCausalLM" | "Qwen3MoeForCausalLM" => (
                             LLMModel::Qwen3MoE(
                                 Qwen3MoE::new(
-                                    matches!(arch.as_str(), "qwen3moe" | "Qwen3MoeForCausalLM"),
+                                    matches!(
+                                        arch.as_str(),
+                                        "qwen2moe"
+                                            | "Qwen2MoeForCausalLM"
+                                            | "qwen3moe"
+                                            | "Qwen3MoeForCausalLM"
+                                    ),
                                     vb,
                                     &config,
                                     dtype,


### PR DESCRIPTION
Qwen2 MoE models share a similar structure with Qwen3 MoE models (including additional shared experts). This PR adds support for Qwen2 MoE by reusing the existing Qwen3 structures, referencing implementation for the shared experts and gating: https://github.com/guoqingbao/vllm.rs/commit/e55ae0700f8959bda6810082a5a07fe31208d2f4

Sample usage:

```shell
cargo run --release --features cuda,nccl -- --m DavidAU/Qwen2.5-MOE-2x-4x-6x-8x__7B__Power-CODER__19B-30B-42B-53B-gguf --f Qwen2.5-2X7B-NemoTron-TwoNemos-Coder-V1-Q4_K_S.gguf --penalty 1.06 --temperature 1.5 --top-k 40 --top-p 0.95
```

Note: This model (`Qwen2.5-2X7B-NemoTron-TwoNemos-Coder-V1`, for testing purposes) is not an official Qwen2 MoE and may suffer from unavoidable repetition.