### PR TITLE
Fix indexed moe kernel for topk not equal 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
-candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
+candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 #candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 #candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.2"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
@@ -34,7 +34,7 @@ intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], option
 #cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 cudarc = {git = "https://github.com/guoqingbao/cudarc.git", version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true, rev="cc13092" }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "cf5b1ad" }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "42c9b42" }
 clap = { version = "4.4.7", features = ["derive"] }
 #candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"

--- a/metal-kernels/Cargo.toml
+++ b/metal-kernels/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 metal = { version = "0.27.0", features = ["mps"] }
 thiserror = "1"
 once_cell = "1.20.2"
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cf5b1ad" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 
 [build-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }


### PR DESCRIPTION
The initial indexed moe kernel is developed for qwen3 moe model which has topk experts of 8, while this is not suitable expecially for custom moe models, this PR address the problem by updating undering candle kernels https://github.com/guoqingbao/candle/commit/42c9b42a4856bf0e3af2f40505545a11bbee87fc making it support any topk (while topk < number of experts).