### PR TITLE
Switch to var_len attention & refactor models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "candle-vllm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 axum = { version = "0.7.4", features = ["tokio"] }
@@ -17,26 +15,21 @@ rayon="1.10.0"
 hyper = { version = "0.14", features = ["full"] }
 candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 candle-examples = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
-#candle-lora = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-#candle-lora-macro = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
-#candle-lora-transformers = { git = "https://github.com/EricLBuehler/candle-lora.git", version = "0.2.0" }
 candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
+candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
+candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "42c9b42" }
 dyn-fmt = "0.4.0"
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = "0.21.2"
 uuid = { version = "1.5.0", features = ["v4"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 hf-hub = "0.4.1"
 serde_json = "1.0.108"
 derive_more = "0.99.17"
 accelerate-src = { version = "0.3.2", optional = true }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], optional = true }
-#cudarc = {version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true }
 cudarc = {git = "https://github.com/guoqingbao/cudarc.git", version = "0.13.9", features = ["f16", "cuda-version-from-build-system"], optional = true, rev="cc13092" }
 half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-candle-flash-attn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", optional = true, rev = "42c9b42" }
 clap = { version = "4.4.7", features = ["derive"] }
-#candle-sampling = { git = "https://github.com/EricLBuehler/candle-sampling.git", version = "0.2.0" }
 futures = "0.3.29"
 tokio = { version = "1.38.0", features = ["sync"] }
 env_logger = "0.10.1"
@@ -47,9 +40,10 @@ dirs = "5.0.1"
 minijinja = { version = "2.10.2", features = ["builtins", "json"] }
 minijinja-contrib = { version = "2.10.2", features = ["pycompat"] }
 thiserror = "1.0.58"
+attention-rs = {git = "https://github.com/guoqingbao/attention.rs", version="0.1.1", rev = "3058c20" }
 metal = { version = "0.27.0", features = ["mps"], optional = true }
-kernels = {path = "./kernels", version="0.1.0", optional = true}
-metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
+#kernels = {path = "./kernels", version="0.1.0", optional = true}
+#metal-kernels = {path = "./metal-kernels", version="0.1.0", optional = true}
 lazy_static = {version = "1.4.0"}
 interprocess = "2.2.2"
 serde-big-array = "0.5.1"
@@ -67,10 +61,10 @@ ahash = "0.8.11"
 
 [features]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:kernels"]
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal-kernels", "dep:metal"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "attention-rs/cuda"]
+metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "dep:metal", "attention-rs/metal"]
 cudnn = ["candle-core/cudnn"]
-flash-attn = ["cuda", "candle-transformers/flash-attn", "dep:candle-flash-attn"]
+flash-attn = ["cuda", "candle-transformers/flash-attn", "dep:candle-flash-attn", "attention-rs/flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]
 nccl = ["cuda", "cudarc/nccl"]
 mpi = ["cuda", "cudarc/nccl", "dep:mpi"]

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cuda")]
+use attention_rs::kernels::ffi::{copy_blocks_bf16, copy_blocks_f16, copy_blocks_f32};
 #[cfg(feature = "metal")]
 use candle_core::{
     backend::BackendStorage, CpuStorage, Device, IndexOp, Layout, MetalDevice, MetalStorage,
@@ -9,8 +11,6 @@ use candle_core::{
     cuda_backend::CudaStorageSlice,
     Device, IndexOp, Result, Storage, Tensor,
 };
-#[cfg(feature = "cuda")]
-use kernels::ffi::{copy_blocks_bf16, copy_blocks_f16, copy_blocks_f32};
 use std::{collections::HashMap, iter::zip};
 
 /// # Safety
@@ -332,10 +332,10 @@ pub fn copy_blocks(
         let command_buffer = dev.command_buffer()?;
         command_buffer.set_label("copy-blocks");
 
-        metal_kernels::call_copy_blocks(
+        attention_rs::metal_kernels::call_copy_blocks(
             dev.device(),
             &command_buffer,
-            metal_kernels::Kernels::default(),
+            attention_rs::metal_kernels::Kernels::default(),
             key_cache.dtype(),
             key_storage.buffer(),
             key_offset * key_storage.dtype().size_in_bytes(),

--- a/src/backend/custom_ops/mod.rs
+++ b/src/backend/custom_ops/mod.rs
@@ -1,3 +1,3 @@
 pub mod moe;
-#[cfg(feature = "cuda")]
-pub mod sort;
+// #[cfg(feature = "cuda")]
+// pub mod sort;

--- a/src/backend/custom_ops/moe.rs
+++ b/src/backend/custom_ops/moe.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cuda")]
-use super::sort::ArgSortOp; //use custom argsort which fixed the bugs on A100
+use attention_rs::sort::ArgSortOp; //use custom argsort which fixed the bugs on A100
 use candle::shape::Dim;
 use candle::{CpuStorage, CustomOp1, Error, Layout, Shape, WithDType};
 use candle::{Result, Tensor, D};

--- a/src/backend/gptq.rs
+++ b/src/backend/gptq.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "cuda")]
+use attention_rs::kernels::ffi::{
+    awq_repack, gemm_half_q_half_alt, gptq_repack, marlin_4bit_bf16, marlin_4bit_f16,
+    marlin_awq_4bit_bf16, marlin_awq_4bit_f16,
+};
 #[allow(unused_imports)]
 use candle::backend::BackendStorage;
 #[cfg(feature = "cuda")]
@@ -5,11 +10,6 @@ use candle::CudaStorage;
 #[allow(unused_imports)]
 use candle::{CpuStorage, DType, Layout, Result, Shape, Storage, Tensor};
 use candle_core as candle;
-#[cfg(feature = "cuda")]
-use kernels::ffi::{
-    awq_repack, gemm_half_q_half_alt, gptq_repack, marlin_4bit_bf16, marlin_4bit_f16,
-    marlin_awq_4bit_bf16, marlin_awq_4bit_f16,
-};
 
 #[allow(unused)]
 struct GPTQMatMul {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,7 @@
 mod cache;
 pub mod gguf;
 pub mod gptq;
-mod paged_attention;
+// mod paged_attention;
 #[cfg(feature = "cuda")]
 pub fn get_or_load_func(
     ptx_file: &'static str,
@@ -37,7 +37,7 @@ pub use cache::*;
 #[cfg(feature = "cuda")]
 use candle_core::{cuda_backend::cudarc::driver::CudaFunction, CudaDevice};
 pub use gptq::*;
-pub use paged_attention::*;
+// pub use paged_attention::*;
 pub use std::ops::Deref;
 pub mod custom_ops;
 #[cfg(feature = "nccl")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 use tracing::warn;
 pub mod backend;
 pub mod openai;
-pub mod paged_attention;
+// pub mod paged_attention;
 pub mod scheduler;
+pub use attention_rs::{InputMetadata, PagedAttention};
 
 pub fn hub_load_local_safetensors(
     path: &String,

--- a/src/openai/logits_processor.rs
+++ b/src/openai/logits_processor.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "cuda")]
-use crate::backend::custom_ops::sort::ArgSortOp; //Use our custom sort kernel, fix kernel crash on A100
 use crate::candle::D;
 use crate::candle::{DType, Error, Result, Tensor};
 use crate::openai::sampling_params::SamplingParams;
+#[cfg(feature = "cuda")]
+use attention_rs::sort::ArgSortOp; //Use our custom sort kernel, fix kernel crash on A100
 use rand::{distr::Distribution, SeedableRng};
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;

--- a/src/openai/models/gemma.rs
+++ b/src/openai/models/gemma.rs
@@ -1,12 +1,12 @@
-use super::{rotary_emb::DefaultRotaryEmbedding, Config};
-use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::openai::distributed::{
-    embedding, Comm, ReplicatedLinear, TensorParallelColumnLinear, TensorParallelRowLinear,
-    VarBuilder,
+use super::{
+    attention::Attention, mlp::Mlp, rotary_emb::DefaultRotaryEmbedding,
+    rotary_emb::ScalingRotaryEmbedding, Config,
 };
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor};
+use crate::backend::progress::{ProgressLike, ProgressReporter};
+use crate::openai::distributed::{embedding, Comm, ReplicatedLinear, VarBuilder};
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::InputMetadata;
+use candle::{DType, Device, Module, Result, Tensor};
 use candle_core as candle;
 use candle_nn::RmsNorm;
 use std::iter::zip;
@@ -49,213 +49,6 @@ fn rms_norm(dim: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
     Ok(RmsNorm::new((weight + 1.0f64)?, eps))
 }
 
-struct Mlp {
-    gate_proj: TensorParallelColumnLinear,
-    up_proj: TensorParallelColumnLinear,
-    down_proj: TensorParallelRowLinear,
-    act_fn: candle_nn::Activation,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("gate_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let up_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("up_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let down_proj = TensorParallelRowLinear::load_with_hints(
-            intermediate_sz,
-            hidden_sz,
-            false,
-            vb.pp("down_proj"),
-            comm,
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap(),
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(&lhs * &rhs)?)
-    }
-}
-
-struct Attention {
-    q_proj: TensorParallelColumnLinear,
-    k_proj: TensorParallelColumnLinear,
-    v_proj: TensorParallelColumnLinear,
-    o_proj: TensorParallelRowLinear,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_emb: Arc<DefaultRotaryEmbedding>,
-    attn: PagedAttention,
-}
-
-impl Attention {
-    fn new(
-        rotary_emb: Arc<DefaultRotaryEmbedding>,
-        cfg: &Config,
-        vb: VarBuilder,
-        comm: Rc<Comm>,
-    ) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let num_heads = cfg.num_attention_heads;
-        let num_kv_heads = cfg.num_key_value_heads.unwrap();
-        let head_dim = cfg.head_dim.unwrap();
-        let bias = cfg.attention_bias.unwrap();
-        let q_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_heads * head_dim,
-            bias,
-            vb.pp("q_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let k_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            bias,
-            vb.pp("k_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let v_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            bias,
-            vb.pp("v_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-
-        let o_proj = TensorParallelRowLinear::load_with_hints(
-            num_heads * head_dim,
-            hidden_sz,
-            bias,
-            vb.pp("o_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let attention_heads = cfg.num_attention_heads / comm.world_size();
-        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
-        Ok(Self {
-            q_proj,
-            k_proj,
-            v_proj,
-            o_proj,
-            num_heads: attention_heads,
-            num_kv_heads: kv_heads,
-            head_dim,
-            rotary_emb,
-            attn: PagedAttention::new(
-                attention_heads,
-                head_dim,
-                1. / ((head_dim as f32).sqrt()),
-                Some(kv_heads),
-                cfg.sliding_window,
-                vb.device().clone(),
-                None,
-            )?,
-        })
-    }
-
-    fn forward(
-        &self,
-        xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
-        cache: Option<(&Tensor, &Tensor)>,
-        input_metadata: &InputMetadata,
-        softcapping: Option<f64>,
-    ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
-
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
-
-        let q = q.to_dtype(v.dtype())?;
-        let k = k.to_dtype(v.dtype())?;
-
-        // No need repeat_kv since we performed broadcasted matmul in the prefiling stage
-        // while, the decoding stage used paged-attention which also does not need kv stacking (to match query dim)
-        // let k = candle_transformers::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
-        // let v =
-        //     candle_transformers::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                attention_mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                softcapping,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.o_proj.forward(&y)?;
-        Ok(y)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
     mlp: Mlp,
@@ -267,12 +60,18 @@ struct DecoderLayer {
 
 impl DecoderLayer {
     fn new(
-        rotary_emb: Arc<DefaultRotaryEmbedding>,
+        rotary_emb: Arc<ScalingRotaryEmbedding>,
         cfg: &Config,
         vb: VarBuilder,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"), comm.clone())?;
+        let self_attn = Attention::new(
+            rotary_emb.clone(),
+            cfg,
+            vb.pp("self_attn"),
+            comm.clone(),
+            cfg.sliding_window,
+        )?;
         let mlp = Mlp::new(cfg, vb.pp("mlp"), comm.clone())?;
         let input_layernorm =
             rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
@@ -315,22 +114,17 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
         softcapping: Option<f64>,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self.self_attn.forward(
-            &xs,
-            attention_mask,
-            input_positions,
-            cache,
-            input_metadata,
-            softcapping,
-        )?;
+        let xs =
+            self.self_attn
+                .forward(&xs, attention_mask, input_positions, cache, input_metadata)?;
 
         if softcapping.is_some() {
             let xs = xs.apply(&self.post_attention_layernorm)?;
@@ -376,12 +170,12 @@ impl Gemma {
     ) -> Result<Self> {
         let vb_m = vb.pp("model");
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(DefaultRotaryEmbedding::new(
-            vb.dtype(),
+        let rotary_emb = Arc::new(ScalingRotaryEmbedding(DefaultRotaryEmbedding::new(
+            DType::F32,
             cfg,
             vb_m.device(),
             true,
-        )?);
+        )?));
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         let reporter = progress_reporter.clone();
@@ -408,23 +202,28 @@ impl Gemma {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
-        let attention_mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_size,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
         let xs = self.embed_tokens.forward(input_ids)?;
         let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
         if let Some(kv_caches) = kv_caches {
@@ -451,14 +250,18 @@ impl Gemma {
             }
         }
 
-        let logits = xs.i((.., seq_len - 1, ..))?.apply(&self.norm)?;
-        let logits = self.lm_head.forward(&logits)?;
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
+        let logits = self.lm_head.forward(&xs)?.to_dtype(DType::F32)?;
 
-        let logits = match self.cfg.final_logit_softcapping {
-            None => logits,
-            Some(sc) => ((logits / sc)?.tanh()? * sc)?,
-        };
-        logits.to_dtype(DType::F32)
+        match self.cfg.final_logit_softcapping {
+            None => Ok(logits),
+            Some(sc) => (logits / sc)?.tanh()? * sc,
+        }
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/gemma3.rs
+++ b/src/openai/models/gemma3.rs
@@ -1,13 +1,14 @@
-use super::{Config, QuantConfig};
-use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::openai::distributed::{
-    embedding, Comm, ReplicatedLinear, TensorParallelColumnLinear, TensorParallelRowLinear,
-    VarBuilder,
+use super::{
+    attention::Attention, mlp::Mlp, rotary_emb::ScalingRotaryEmbedding, Config, QuantConfig,
 };
+use crate::backend::progress::{ProgressLike, ProgressReporter};
+use crate::openai::distributed::{embedding, Comm, ReplicatedLinear, VarBuilder};
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::openai::models::rotary_emb::DefaultRotaryEmbedding;
 use crate::openai::models::ScalingValue;
 use crate::openai::models::TokenID;
-use crate::paged_attention::input_metadata::InputMetadata;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor};
+use crate::InputMetadata;
+use candle::{DType, Device, Module, Result, Tensor};
 use candle_core as candle;
 use candle_nn::{Activation, RmsNorm};
 use either::Either;
@@ -200,22 +201,14 @@ fn rms_norm(dim: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
     Ok(RmsNorm::new((weight + 1.0f64)?, eps))
 }
 
-#[derive(Debug, Clone)]
-struct RotaryEmbedding {
-    sin: Tensor,
-    cos: Tensor,
-    sin_sliding: Option<Tensor>,
-    cos_sliding: Option<Tensor>,
-}
-
-impl RotaryEmbedding {
-    pub fn create_cache(
-        _dtype: DType,
-        local_sliding_window: Option<usize>,
+impl ScalingRotaryEmbedding {
+    pub fn new_sliding(
+        dtype: DType,
+        sliding_window: Option<usize>,
         cfg: &Config,
         dev: &Device,
-    ) -> Result<(Tensor, Tensor)> {
-        let rope_freq = local_sliding_window
+    ) -> Result<ScalingRotaryEmbedding> {
+        let rope_freq = sliding_window
             .and(cfg.rope_local_base_freq)
             .unwrap_or(cfg.rope_theta);
 
@@ -236,273 +229,14 @@ impl RotaryEmbedding {
             .reshape((t_len as usize, 1))?;
         let t = (t / factor)?;
         let freqs = t.matmul(&inv_freq)?;
-        Ok((freqs.sin()?, freqs.cos()?))
-    }
-
-    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
-        let (sin, cos) = RotaryEmbedding::create_cache(dtype, None, cfg, dev)?;
-        let (sin_sliding, cos_sliding) = if cfg.sliding_window.is_some() {
-            let (sin, cos) = RotaryEmbedding::create_cache(dtype, cfg.sliding_window, cfg, dev)?;
-            (Some(sin), Some(cos))
-        } else {
-            (None, None)
-        };
-
-        Ok(Self {
-            sin,
+        let sin = freqs.sin()?.to_dtype(dtype)?;
+        let cos = freqs.cos()?.to_dtype(dtype)?;
+        Ok(ScalingRotaryEmbedding(DefaultRotaryEmbedding {
             cos,
-            sin_sliding,
-            cos_sliding,
-        })
-    }
-
-    fn apply_rotary_emb_qkv(
-        &self,
-        q: &Tensor,
-        k: &Tensor,
-        input_positions: &[Vec<usize>],
-        is_sliding: bool,
-    ) -> Result<(Tensor, Tensor)> {
-        let (b_sz, _h, seq_len, _n_embd) = q.dims4()?;
-        let mut q_embeds = Vec::new();
-        let mut k_embeds = Vec::new();
-        for (b, seqlen_offset) in zip(0..b_sz, input_positions) {
-            let (cos, sin) =
-                if is_sliding && self.sin_sliding.is_some() && self.cos_sliding.is_some() {
-                    let cos =
-                        self.cos_sliding
-                            .as_ref()
-                            .unwrap()
-                            .narrow(0, seqlen_offset[0], seq_len)?;
-                    let sin =
-                        self.sin_sliding
-                            .as_ref()
-                            .unwrap()
-                            .narrow(0, seqlen_offset[0], seq_len)?;
-                    (cos, sin)
-                } else {
-                    let cos = self.cos.narrow(0, seqlen_offset[0], seq_len)?;
-                    let sin = self.sin.narrow(0, seqlen_offset[0], seq_len)?;
-                    (cos, sin)
-                };
-
-            let x_q = q.narrow(0, b, 1)?;
-            let x_k = k.narrow(0, b, 1)?;
-            let q_embed = candle_nn::rotary_emb::rope(&x_q, &cos, &sin)?;
-            let k_embed = candle_nn::rotary_emb::rope(&x_k, &cos, &sin)?;
-            q_embeds.push(q_embed);
-            k_embeds.push(k_embed);
-        }
-        Ok((Tensor::cat(&q_embeds, 0)?, Tensor::cat(&k_embeds, 0)?))
-    }
-}
-
-struct Mlp {
-    gate_proj: TensorParallelColumnLinear,
-    up_proj: TensorParallelColumnLinear,
-    down_proj: TensorParallelRowLinear,
-    act_fn: candle_nn::Activation,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("gate_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let up_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("up_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let down_proj = TensorParallelRowLinear::load_with_hints(
-            intermediate_sz,
-            hidden_sz,
-            false,
-            vb.pp("down_proj"),
-            comm,
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap(),
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(&lhs * &rhs)?)
-    }
-}
-
-struct Attention {
-    q_proj: TensorParallelColumnLinear,
-    k_proj: TensorParallelColumnLinear,
-    v_proj: TensorParallelColumnLinear,
-    o_proj: TensorParallelRowLinear,
-    q_norm: RmsNorm,
-    k_norm: RmsNorm,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_emb: Arc<RotaryEmbedding>,
-    attn: super::AttentionSelect,
-    local_sliding_window: Option<usize>,
-}
-
-impl Attention {
-    fn new(
-        cfg: &Config,
-        vb: VarBuilder,
-        comm: Rc<Comm>,
-        rotary_emb: Arc<RotaryEmbedding>,
-        local_sliding_window: Option<usize>,
-    ) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let num_heads = cfg.num_attention_heads;
-        let num_kv_heads = cfg.num_key_value_heads.unwrap();
-        let head_dim = cfg.head_dim.unwrap();
-        let bias = cfg.attention_bias.unwrap();
-
-        let q_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_heads * head_dim,
-            bias,
-            vb.pp("q_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let k_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            bias,
-            vb.pp("k_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let v_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            bias,
-            vb.pp("v_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-
-        let o_proj = TensorParallelRowLinear::load_with_hints(
-            num_heads * head_dim,
-            hidden_sz,
-            bias,
-            vb.pp("o_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-
-        let q_norm = rms_norm(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
-        let k_norm = rms_norm(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
-
-        let attention_heads = cfg.num_attention_heads / comm.world_size();
-        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
-        Ok(Self {
-            q_proj,
-            k_proj,
-            v_proj,
-            o_proj,
-            q_norm,
-            k_norm,
-            num_heads: attention_heads,
-            num_kv_heads: kv_heads,
-            head_dim,
-            rotary_emb: rotary_emb.clone(),
-            local_sliding_window,
-            attn: super::AttentionSelect::new(
-                cfg,
-                local_sliding_window,
-                comm.clone(),
-                vb.device(),
-                true,
-            ),
-        })
-    }
-
-    fn forward(
-        &self,
-        xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
-        cache: Option<(&Tensor, &Tensor)>,
-        input_metadata: &InputMetadata,
-        softcapping: Option<f64>,
-    ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
-
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
-
-        let q = self.q_norm.forward(&q)?;
-        let k = self.k_norm.forward(&k)?;
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-            self.local_sliding_window.is_some(),
-        )?;
-
-        let (q, k) = (q.to_dtype(v.dtype())?, k.to_dtype(v.dtype())?);
-        let y = self.attn.forward(
-            &q,
-            &k,
-            &v,
-            attention_mask,
-            cache,
-            input_metadata,
-            softcapping,
-        )?;
-
-        let y = self.o_proj.forward(&y)?;
-        Ok(y)
+            sin,
+            is_gpt_neox: true,
+            rotary_dim: None,
+        }))
     }
 }
 
@@ -521,14 +255,14 @@ impl DecoderLayer {
         cfg: &Config,
         vb: VarBuilder,
         comm: Rc<Comm>,
-        rotary_emb: Arc<RotaryEmbedding>,
+        rotary_emb: Arc<ScalingRotaryEmbedding>,
         sliding_window: Option<usize>,
     ) -> Result<Self> {
         let self_attn = Attention::new(
+            rotary_emb.clone(),
             cfg,
             vb.pp("self_attn"),
             comm.clone(),
-            rotary_emb.clone(),
             sliding_window,
         )?;
         let mlp = Mlp::new(cfg, vb.pp("mlp"), comm.clone())?;
@@ -566,22 +300,16 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
-        softcapping: Option<f64>,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self.self_attn.forward(
-            &xs,
-            attention_mask,
-            input_positions,
-            cache,
-            input_metadata,
-            softcapping,
-        )?;
+        let xs =
+            self.self_attn
+                .forward(&xs, attention_mask, input_positions, cache, input_metadata)?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;
@@ -614,7 +342,19 @@ impl Gemma3 {
     ) -> Result<Self> {
         let vb_m = vb.pp("language_model.model");
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(RotaryEmbedding::new(vb.dtype(), cfg, vb.device())?);
+        let rotary_emb = Arc::new(ScalingRotaryEmbedding::new_sliding(
+            DType::F32,
+            None,
+            cfg,
+            device,
+        )?);
+        let sliding_emb = Arc::new(ScalingRotaryEmbedding::new_sliding(
+            DType::F32,
+            cfg.sliding_window,
+            cfg,
+            device,
+        )?);
+
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         let reporter = progress_reporter.clone();
@@ -629,7 +369,11 @@ impl Gemma3 {
                 cfg,
                 vb_l.pp(layer_idx),
                 comm.clone(),
-                rotary_emb.clone(),
+                if is_sliding_window {
+                    rotary_emb.clone()
+                } else {
+                    sliding_emb.clone()
+                },
                 is_sliding_window.then_some(cfg.sliding_window.unwrap()),
             )?;
             layers.push(layer);
@@ -651,30 +395,28 @@ impl Gemma3 {
 
     fn create_attention_masks(
         &self,
-        batch_size: usize,
-        seq_len: usize,
-        input_positions: &[Vec<usize>],
-    ) -> Result<(Option<Tensor>, Option<Tensor>)> {
-        if seq_len <= 1 {
-            return Ok((None, None));
-        }
+        seqlens: &Vec<u32>,
+        input_positions: &Tensor,
+        is_prefill: bool,
+    ) -> Result<(Option<Vec<Tensor>>, Option<Vec<Tensor>>)> {
         //normal mask
-        let mask = super::get_attention_casual_mask(
+        let mask = get_attention_casual_mask(
             &self.device,
             self.dtype,
-            batch_size,
-            seq_len,
             input_positions,
+            seqlens,
             None,
+            is_prefill,
         );
 
-        let sliding_mask = super::get_attention_casual_mask(
+        //sliding_mask
+        let sliding_mask = get_attention_casual_mask(
             &self.device,
             self.dtype,
-            batch_size,
-            seq_len,
             input_positions,
+            seqlens,
             self.cfg.sliding_window,
+            is_prefill,
         );
 
         Ok((mask, sliding_mask))
@@ -683,13 +425,22 @@ impl Gemma3 {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
+        } else {
+            Vec::new()
+        };
         let (attention_mask, sliding_attention_mask) =
-            self.create_attention_masks(b_size, seq_len, input_positions)?;
+            self.create_attention_masks(&seqlens, input_positions, input_metadata.is_prefill)?;
 
         let xs = self.embed_tokens.forward(input_ids)?;
         let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
@@ -707,7 +458,6 @@ impl Gemma3 {
                     input_positions,
                     Some((k_cache, v_cache)),
                     input_metadata,
-                    self.cfg.attn_logit_softcapping,
                 )?
             }
         } else {
@@ -717,28 +467,22 @@ impl Gemma3 {
                 } else {
                     &attention_mask
                 };
-                xs = layer.forward(
-                    &xs,
-                    mask.as_ref(),
-                    input_positions,
-                    None,
-                    input_metadata,
-                    self.cfg.attn_logit_softcapping,
-                )?
+                xs = layer.forward(&xs, mask.as_ref(), input_positions, None, input_metadata)?
             }
         }
 
-        let logits = xs
-            .i((.., seq_len - 1, ..))?
-            .contiguous()?
-            .apply(&self.norm)?;
-        let logits = self.lm_head.forward(&logits)?;
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
+        let logits = self.lm_head.forward(&xs)?.to_dtype(DType::F32)?;
 
-        let logits = match self.cfg.final_logit_softcapping {
-            None => logits,
-            Some(sc) => ((logits / sc)?.tanh()? * sc)?,
-        };
-        logits.to_dtype(DType::F32)
+        match self.cfg.final_logit_softcapping {
+            None => Ok(logits),
+            Some(sc) => (logits / sc)?.tanh()? * sc,
+        }
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/layers/attention.rs
+++ b/src/openai/models/layers/attention.rs
@@ -1,0 +1,408 @@
+use super::rotary_emb::ScalingRotaryEmbedding;
+use crate::openai::distributed::{
+    rms_norm_with_dtype, Comm, TensorParallelColumnLinear, TensorParallelRowLinear, VarBuilder,
+};
+use crate::openai::models::Config;
+use crate::{InputMetadata, PagedAttention};
+use candle_core::quantized::{gguf_file, QMatMul};
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn::RmsNorm;
+use candle_transformers::quantized_nn::RmsNorm as QRmsNorm;
+use std::rc::Rc;
+use std::sync::Arc;
+
+pub struct Attention {
+    q_proj: TensorParallelColumnLinear,
+    k_proj: TensorParallelColumnLinear,
+    v_proj: TensorParallelColumnLinear,
+    o_proj: TensorParallelRowLinear,
+    q_norm: Option<RmsNorm>,
+    k_norm: Option<RmsNorm>,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_emb: Arc<ScalingRotaryEmbedding>,
+    attn: PagedAttention,
+    softcapping: Option<f64>,
+    dtype: DType,
+}
+
+impl Attention {
+    pub fn new(
+        rotary_emb: Arc<ScalingRotaryEmbedding>,
+        cfg: &Config,
+        vb: VarBuilder,
+        comm: Rc<Comm>,
+        sliding_window: Option<usize>,
+    ) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads.unwrap();
+        let head_dim = cfg.head_dim.unwrap_or(hidden_sz / num_heads);
+        let attention_bias = cfg.attention_bias.unwrap_or(false);
+
+        let q_proj = TensorParallelColumnLinear::load_with_hints(
+            hidden_sz,
+            num_heads * head_dim,
+            attention_bias,
+            vb.pp("q_proj"),
+            comm.clone(),
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+        let k_proj = TensorParallelColumnLinear::load_with_hints(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            attention_bias,
+            vb.pp("k_proj"),
+            comm.clone(),
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+        //v_proj requires higher precision
+        let q8_0_quant = Some("q8_0".to_string());
+        let v_proj = TensorParallelColumnLinear::load_with_hints(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            attention_bias,
+            vb.pp("v_proj"),
+            comm.clone(),
+            if cfg.quant.is_some()
+                && !matches!(
+                    cfg.quant.as_ref().unwrap().as_str(),
+                    "gptq" | "awq" | "marlin"
+                )
+            {
+                &q8_0_quant
+            } else {
+                &cfg.quant
+            },
+            &cfg.quantization_config,
+        )?;
+
+        let o_proj = TensorParallelRowLinear::load_with_hints(
+            num_heads * head_dim,
+            hidden_sz,
+            false,
+            vb.pp("o_proj"),
+            comm.clone(),
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+
+        //we use higher precision for q/k norm
+        let q_norm =
+            rms_norm_with_dtype(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"), DType::F32).ok();
+        let k_norm =
+            rms_norm_with_dtype(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"), DType::F32).ok();
+
+        assert!(cfg.num_attention_heads >= comm.world_size());
+        assert!(cfg.num_attention_heads % comm.world_size() == 0);
+
+        assert!(cfg.num_key_value_heads.unwrap() >= comm.world_size());
+        assert!(cfg.num_key_value_heads.unwrap() % comm.world_size() == 0);
+
+        let attention_heads = cfg.num_attention_heads / comm.world_size();
+        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads: attention_heads,
+            num_kv_heads: kv_heads,
+            head_dim,
+            rotary_emb,
+            attn: PagedAttention::new(
+                attention_heads,
+                head_dim,
+                1. / ((head_dim as f32).sqrt()),
+                Some(kv_heads),
+                sliding_window,
+                vb.device().clone(),
+                None,
+            )?,
+            softcapping: cfg.attn_logit_softcapping,
+            dtype: vb.dtype(),
+        })
+    }
+
+    pub fn forward(
+        &self,
+        xs: &Tensor,
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &InputMetadata,
+    ) -> Result<Tensor> {
+        let (seq_len, _) = xs.dims2()?;
+
+        let query_states = self.q_proj.forward(xs)?;
+        let key_states = self.k_proj.forward(xs)?;
+        let value_states = self.v_proj.forward(xs)?;
+
+        let q = query_states
+            .reshape((1, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = key_states
+            .reshape((1, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = value_states
+            .reshape((1, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let (q, k) = if q.dtype() != DType::F32 {
+            (q.to_dtype(DType::F32)?, k.to_dtype(DType::F32)?)
+        } else {
+            (q, k)
+        };
+
+        let (q, k) = if let (Some(q_norm), Some(k_norm)) = (&self.q_norm, &self.k_norm) {
+            // Per‑head RMSNorm in qwen3
+            let q_flat = q.flatten(0, 2)?; // (B*H, L, D) -> (BHL, D) after transpose later
+            let k_flat = k.flatten(0, 2)?;
+
+            // q_norm and k_norm weights stored in f32 format in qwen3 gguf
+            let q_flat = q_norm.forward(&q_flat)?;
+            let k_flat = k_norm.forward(&k_flat)?;
+
+            let q = q_flat.reshape((1, self.num_heads, seq_len, self.head_dim))?;
+            let k = k_flat.reshape((1, self.num_kv_heads, seq_len, self.head_dim))?;
+
+            (q, k)
+        } else {
+            (q, k)
+        };
+
+        let (q, k) = self.rotary_emb.apply_rotary_emb(&q, &k, input_positions)?;
+        let (q, k) = (q.to_dtype(self.dtype)?, k.to_dtype(self.dtype)?);
+
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                attention_mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                self.softcapping,
+            )?
+            .reshape((seq_len, ()))?;
+
+        let y = self.o_proj.forward(&y)?;
+        Ok(y)
+    }
+}
+
+pub struct QuantizedAttention {
+    attention_wq: QMatMul,
+    attention_wk: QMatMul,
+    attention_wv: QMatMul,
+    attention_bq: Option<Tensor>,
+    attention_bk: Option<Tensor>,
+    attention_bv: Option<Tensor>,
+    attention_wo: QMatMul,
+    q_norm: Option<QRmsNorm>,
+    k_norm: Option<QRmsNorm>,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    attn: PagedAttention,
+    rotary_emb: Arc<ScalingRotaryEmbedding>,
+    dtype: DType,
+}
+
+impl QuantizedAttention {
+    pub fn new<R: std::io::Seek + std::io::Read>(
+        config: &Config,
+        ct: &gguf_file::Content,
+        reader: &mut R,
+        prefix: &str,
+        device: &Device,
+        dtype: DType,
+        rotary_emb: Arc<ScalingRotaryEmbedding>,
+        sliding_window: Option<usize>,
+    ) -> Result<Self> {
+        let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
+        let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
+        let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
+
+        let attention_bq = ct.tensor(reader, &format!("{prefix}.attn_q.bias"), device);
+        let attention_bk = ct.tensor(reader, &format!("{prefix}.attn_k.bias"), device);
+        let attention_bv = ct.tensor(reader, &format!("{prefix}.attn_v.bias"), device);
+
+        let attention_bq = if attention_bq.is_ok() {
+            Some(
+                attention_bq
+                    .unwrap()
+                    .dequantize(device)?
+                    .to_dtype(DType::F32)?,
+            )
+        } else {
+            None
+        };
+
+        let attention_bk = if attention_bk.is_ok() {
+            Some(
+                attention_bk
+                    .unwrap()
+                    .dequantize(device)?
+                    .to_dtype(DType::F32)?,
+            )
+        } else {
+            None
+        };
+
+        let attention_bv = if attention_bv.is_ok() {
+            Some(
+                attention_bv
+                    .unwrap()
+                    .dequantize(device)?
+                    .to_dtype(DType::F32)?,
+            )
+        } else {
+            None
+        };
+
+        let attention_wo = ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
+
+        let (q_norm, k_norm) = {
+            let q_norm = ct.tensor(reader, &format!("{prefix}.attn_q_norm.weight"), device);
+            let k_norm = ct.tensor(reader, &format!("{prefix}.attn_k_norm.weight"), device);
+            let (q_norm, k_norm) = match (q_norm, k_norm) {
+                (Ok(q_norm), Ok(k_norm)) => {
+                    let q_norm = QRmsNorm::from_qtensor(q_norm, config.rms_norm_eps)?;
+                    let k_norm = QRmsNorm::from_qtensor(k_norm, config.rms_norm_eps)?;
+                    (Some(q_norm), Some(k_norm))
+                }
+                _ => (None, None),
+            };
+            (q_norm, k_norm)
+        };
+
+        let head_dim = config
+            .head_dim
+            .unwrap_or(config.hidden_size / config.num_attention_heads);
+        Ok(QuantizedAttention {
+            attention_wq: QMatMul::from_qtensor(attention_wq)?,
+            attention_wk: QMatMul::from_qtensor(attention_wk)?,
+            attention_wv: QMatMul::from_qtensor(attention_wv)?,
+            attention_bq,
+            attention_bk,
+            attention_bv,
+            attention_wo: QMatMul::from_qtensor(attention_wo)?,
+            q_norm,
+            k_norm,
+            n_head: config.num_attention_heads,
+            n_kv_head: config
+                .num_key_value_heads
+                .unwrap_or(config.num_attention_heads),
+            head_dim,
+            attn: PagedAttention::new(
+                config.num_attention_heads,
+                head_dim,
+                1. / ((head_dim as f32).sqrt()),
+                config.num_key_value_heads,
+                sliding_window,
+                device.clone(),
+                None,
+            )?,
+            rotary_emb: rotary_emb.clone(),
+            dtype,
+        })
+    }
+
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
+        cache: Option<(&Tensor, &Tensor)>,
+        input_metadata: &InputMetadata,
+    ) -> Result<Tensor> {
+        let (seq_len, _) = x.dims2()?;
+
+        let q = self.attention_wq.forward(x)?;
+        let k = self.attention_wk.forward(x)?;
+        let v = self.attention_wv.forward(x)?;
+
+        let q = if self.attention_bq.is_some() {
+            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
+        } else {
+            q
+        };
+
+        let k = if self.attention_bk.is_some() {
+            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
+        } else {
+            k
+        };
+
+        let v = if self.attention_bv.is_some() {
+            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
+        } else {
+            v
+        };
+
+        let q = q
+            .reshape((1, seq_len, self.n_head, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((1, seq_len, self.n_kv_head, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((1, seq_len, self.n_kv_head, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let (q, k) = if let (Some(q_norm), Some(k_norm)) = (&self.q_norm, &self.k_norm) {
+            // Per‑head RMSNorm in qwen3
+            let q_flat = q.flatten(0, 2)?; // (B*H, L, D) -> (BHL, D) after transpose later
+            let k_flat = k.flatten(0, 2)?;
+
+            // q_norm and k_norm weights stored in f32 format in qwen3 gguf
+            let q_flat = q_norm.forward(&q_flat)?;
+            let k_flat = k_norm.forward(&k_flat)?;
+
+            let q = q_flat.reshape((1, self.n_head, seq_len, self.head_dim))?;
+            let k = k_flat.reshape((1, self.n_kv_head, seq_len, self.head_dim))?;
+
+            (q, k)
+        } else {
+            (q, k)
+        };
+
+        let (q, k) = self.rotary_emb.apply_rotary_emb(&q, &k, input_positions)?;
+        let (q, k, v) = (
+            q.to_dtype(self.dtype)?,
+            k.to_dtype(self.dtype)?,
+            v.to_dtype(self.dtype)?,
+        );
+
+        let y = self
+            .attn
+            .forward(
+                &q,
+                &k,
+                &v,
+                mask,
+                cache.map(|(k_, _)| k_.clone()),
+                cache.map(|(_, v_)| v_.clone()),
+                input_metadata,
+                None,
+            )?
+            .reshape((seq_len, ()))?;
+
+        let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
+        Ok(y)
+    }
+}

--- a/src/openai/models/layers/mask.rs
+++ b/src/openai/models/layers/mask.rs
@@ -1,0 +1,85 @@
+use candle_core::{DType, Device, Tensor};
+
+#[cfg(feature = "flash-attn")] // If flash-attn or metal is enabled, we don't implement this function.
+                               // The actual implementation would be embedded in the flash or metal attention kernel.
+pub fn get_attention_casual_mask(
+    _: &Device,
+    _: DType,
+    _: &Tensor,
+    _: &Vec<u32>,
+    _: Option<usize>,
+    _: bool,
+) -> Option<Vec<Tensor>> {
+    None
+}
+
+#[cfg(not(feature = "flash-attn"))]
+fn get_casual_mask_internal(
+    device: &Device,
+    dtype: DType,
+    tgt_len: usize,
+    seqlen_offset: usize,
+    sliding_window: Option<usize>,
+) -> candle_core::Result<Tensor> {
+    use candle_core::D;
+    let mask: Vec<_> = if let Some(sliding_window) = sliding_window {
+        (0..tgt_len)
+            .flat_map(|i| {
+                (0..tgt_len).map(move |j| {
+                    if i < j || j + sliding_window < i {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.
+                    }
+                })
+            })
+            .collect()
+    } else {
+        (0..tgt_len)
+            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0f32 }))
+            .collect()
+    };
+    let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), device)?;
+    let mask = if seqlen_offset > 0 {
+        let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, device)?;
+        Tensor::cat(&[&mask0, &mask], D::Minus1)?
+    } else {
+        mask
+    };
+    mask.expand((1, 1, tgt_len, tgt_len + seqlen_offset))?
+        .to_dtype(dtype)
+}
+
+#[cfg(not(feature = "flash-attn"))]
+pub fn get_attention_casual_mask(
+    device: &Device,
+    dtype: DType,
+    _: &Tensor,
+    seqlens: &Vec<u32>,
+    sliding_window: Option<usize>,
+    is_prefill: bool,
+) -> Option<Vec<Tensor>> {
+    if !is_prefill {
+        return None;
+    }
+    // let vec_positions = positions.to_vec1::<i64>().unwrap();
+    let mut offsets = vec![0u32];
+    offsets.extend(seqlens.clone());
+    let mut vec_mask = Vec::new();
+    let mut start = 0;
+    for (_, seq_offset) in seqlens.iter().enumerate() {
+        let seq_len = seq_offset - start;
+        let mask = get_casual_mask_internal(
+            device,
+            dtype,
+            seq_len as usize,
+            0,
+            // vec_positions[offsets[i] as usize] as usize,
+            sliding_window,
+        )
+        .unwrap();
+        vec_mask.push(mask);
+        start = *seq_offset;
+    }
+    Some(vec_mask)
+}

--- a/src/openai/models/layers/mlp.rs
+++ b/src/openai/models/layers/mlp.rs
@@ -1,0 +1,62 @@
+use crate::openai::distributed::{
+    Comm, TensorParallelColumnLinear, TensorParallelRowLinear, VarBuilder,
+};
+use crate::openai::models::Config;
+use candle::{Module, Result, Tensor};
+use candle_core as candle;
+pub use std::rc::Rc;
+pub struct Mlp {
+    gate_proj: TensorParallelColumnLinear,
+    up_proj: TensorParallelColumnLinear,
+    down_proj: TensorParallelRowLinear,
+    act_fn: candle_nn::Activation,
+}
+
+impl Mlp {
+    pub fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let intermediate_sz = cfg.intermediate_size;
+
+        let gate_proj = TensorParallelColumnLinear::load_with_hints(
+            hidden_sz,
+            intermediate_sz,
+            false,
+            vb.pp("gate_proj"),
+            comm.clone(),
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+        let up_proj = TensorParallelColumnLinear::load_with_hints(
+            hidden_sz,
+            intermediate_sz,
+            false,
+            vb.pp("up_proj"),
+            comm.clone(),
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+        let down_proj = TensorParallelRowLinear::load_with_hints(
+            intermediate_sz,
+            hidden_sz,
+            false,
+            vb.pp("down_proj"),
+            comm,
+            &cfg.quant,
+            &cfg.quantization_config,
+        )?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn: cfg.hidden_act.unwrap(),
+        })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
+        let rhs = self.up_proj.forward(xs)?;
+        self.down_proj.forward(&(&lhs * &rhs)?)
+    }
+}

--- a/src/openai/models/layers/mod.rs
+++ b/src/openai/models/layers/mod.rs
@@ -1,0 +1,4 @@
+pub mod attention;
+pub mod mask;
+pub mod mlp;
+pub mod rotary_emb;

--- a/src/openai/models/mistral.rs
+++ b/src/openai/models/mistral.rs
@@ -1,14 +1,11 @@
-use super::{rotary_emb::ScalingRotaryEmbedding, Config};
+use super::{attention::Attention, mlp::Mlp, rotary_emb::ScalingRotaryEmbedding, Config};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::openai::distributed::{
-    embedding, rms_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
-    TensorParallelRowLinear, VarBuilder,
-};
+use crate::openai::distributed::{embedding, rms_norm, Comm, ReplicatedLinear, VarBuilder};
+use crate::openai::models::mask::get_attention_casual_mask;
 use crate::openai::models::QuantConfig;
 use crate::openai::models::TokenID;
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
-use candle_core::{DType, Device, IndexOp, Module, Result, Tensor};
+use crate::InputMetadata;
+use candle_core::{DType, Device, Module, Result, Tensor};
 use candle_nn::{Activation, RmsNorm};
 use either::Either;
 use std::iter::zip;
@@ -147,215 +144,6 @@ impl Mistral {
     }
 }
 
-struct Mlp {
-    gate_proj: TensorParallelColumnLinear,
-    up_proj: TensorParallelColumnLinear,
-    down_proj: TensorParallelRowLinear,
-    act_fn: Activation,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("gate_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let up_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("up_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let down_proj = TensorParallelRowLinear::load_with_hints(
-            intermediate_sz,
-            hidden_sz,
-            false,
-            vb.pp("down_proj"),
-            comm,
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap_or(Activation::Silu),
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(&lhs * &rhs)?)
-    }
-}
-
-struct Attention {
-    q_proj: TensorParallelColumnLinear,
-    k_proj: TensorParallelColumnLinear,
-    v_proj: TensorParallelColumnLinear,
-    o_proj: TensorParallelRowLinear,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_emb: Arc<ScalingRotaryEmbedding>,
-    attn: PagedAttention,
-}
-
-impl Attention {
-    fn new(
-        rotary_emb: Arc<ScalingRotaryEmbedding>,
-        cfg: &Config,
-        vb: VarBuilder,
-        comm: Rc<Comm>,
-    ) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let num_heads = cfg.num_attention_heads;
-        let num_kv_heads = cfg.num_key_value_heads.unwrap();
-        let head_dim = hidden_sz / num_heads;
-        let q_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_heads * head_dim,
-            false,
-            vb.pp("q_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let k_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            false,
-            vb.pp("k_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let q8_0_quant = Some("q8_0".to_string());
-        let v_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            false,
-            vb.pp("v_proj"),
-            comm.clone(),
-            if cfg.quant.is_some()
-                && !matches!(
-                    cfg.quant.as_ref().unwrap().as_str(),
-                    "gptq" | "awq" | "marlin"
-                )
-            {
-                &q8_0_quant
-            } else {
-                &cfg.quant
-            },
-            &cfg.quantization_config,
-        )?;
-
-        let o_proj = TensorParallelRowLinear::load_with_hints(
-            num_heads * head_dim,
-            hidden_sz,
-            false,
-            vb.pp("o_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let attention_heads = cfg.num_attention_heads / comm.world_size();
-        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
-        Ok(Self {
-            q_proj,
-            k_proj,
-            v_proj,
-            o_proj,
-            num_heads: attention_heads,
-            num_kv_heads: kv_heads,
-            head_dim,
-            rotary_emb,
-            attn: PagedAttention::new(
-                attention_heads,
-                head_dim,
-                1. / ((head_dim as f32).sqrt()),
-                Some(kv_heads),
-                cfg.sliding_window,
-                vb.device().clone(),
-                None,
-            )?,
-        })
-    }
-
-    fn forward(
-        &self,
-        xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
-        cache: Option<(&Tensor, &Tensor)>,
-        input_metadata: &InputMetadata,
-    ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
-
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
-
-        let q = q.to_dtype(v.dtype())?;
-        let k = k.to_dtype(v.dtype())?;
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                attention_mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                None,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.o_proj.forward(&y)?;
-        Ok(y)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
     mlp: Mlp,
@@ -370,7 +158,13 @@ impl DecoderLayer {
         vb: VarBuilder,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"), comm.clone())?;
+        let self_attn = Attention::new(
+            rotary_emb,
+            cfg,
+            vb.pp("self_attn"),
+            comm.clone(),
+            cfg.sliding_window,
+        )?;
         let mlp = Mlp::new(cfg, vb.pp("mlp"), comm.clone())?;
         let input_layernorm =
             rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
@@ -390,8 +184,8 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
@@ -474,23 +268,28 @@ impl Mistral {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
-        let attention_mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_size,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
         let mut xs = self.embed_tokens.forward(input_ids)?;
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
@@ -513,8 +312,13 @@ impl Mistral {
                 )?
             }
         }
-        let logits = xs.i((.., seq_len - 1, ..))?.apply(&self.norm)?;
-        self.lm_head.forward(&logits)?.to_dtype(DType::F32)
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
+        self.lm_head.forward(&xs)?.to_dtype(DType::F32)
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/phi3.rs
+++ b/src/openai/models/phi3.rs
@@ -6,9 +6,10 @@ use crate::openai::distributed::{
     embedding, rms_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
     TensorParallelRowLinear, VarBuilder,
 };
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::openai::models::rotary_emb::DefaultRotaryEmbedding;
+use crate::{InputMetadata, PagedAttention};
+use candle::{DType, Device, Module, Result, Tensor, D};
 use candle_core as candle;
 use candle_nn::RmsNorm;
 use std::iter::zip;
@@ -48,15 +49,12 @@ impl Phi {
 
 #[derive(Debug, Clone)]
 struct RotaryEmbedding {
-    sin: Tensor,
-    cos: Tensor,
-    sin_long: Option<Tensor>,
-    cos_long: Option<Tensor>,
-    original_max_position_embeddings: Option<usize>,
+    normal_emb: DefaultRotaryEmbedding,
+    long_emb: Option<DefaultRotaryEmbedding>,
 }
 
 impl RotaryEmbedding {
-    fn new(_dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
         let dim = cfg.hidden_size / cfg.num_attention_heads;
         let max_seq_len = cfg.max_seq_len;
         let rope_theta = cfg.rope_theta;
@@ -145,14 +143,23 @@ impl RotaryEmbedding {
                     let short_sin = (freqs_short.sin()? * scaling_factor)?;
                     let short_cos = (freqs_short.cos()? * scaling_factor)?;
 
+                    let normal_emb = DefaultRotaryEmbedding {
+                        cos: short_sin.to_dtype(dtype)?,
+                        sin: short_cos.to_dtype(dtype)?,
+                        is_gpt_neox: true,
+                        rotary_dim: None,
+                    };
+
+                    let long_emb = Some(DefaultRotaryEmbedding {
+                        cos: long_sin.to_dtype(dtype)?,
+                        sin: long_cos.to_dtype(dtype)?,
+                        is_gpt_neox: true,
+                        rotary_dim: None,
+                    });
+
                     return Ok(Self {
-                        sin: short_sin,
-                        cos: short_cos,
-                        sin_long: Some(long_sin),
-                        cos_long: Some(long_cos),
-                        original_max_position_embeddings: Some(
-                            *original_max_position_embeddings as usize,
-                        ),
+                        normal_emb,
+                        long_emb,
                     });
                 }
                 _ => {
@@ -160,13 +167,15 @@ impl RotaryEmbedding {
                 }
             }
         }
-
+        let normal_emb = DefaultRotaryEmbedding {
+            cos: freqs.cos()?.to_dtype(dtype)?,
+            sin: freqs.sin()?.to_dtype(dtype)?,
+            is_gpt_neox: true,
+            rotary_dim: None,
+        };
         Ok(Self {
-            sin: freqs.sin()?,
-            cos: freqs.cos()?,
-            sin_long: None,
-            cos_long: None,
-            original_max_position_embeddings: None,
+            normal_emb,
+            long_emb: None,
         })
     }
 
@@ -174,42 +183,16 @@ impl RotaryEmbedding {
         &self,
         q: &Tensor,
         k: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
-        let (b_size, _h, seq_len, _n_embd) = q.dims4()?;
-
-        let mut q_embeds = Vec::new();
-        let mut k_embeds = Vec::new();
-
-        for (b, seqlen_offset) in zip(0..b_size, input_positions) {
-            let (cos, sin) = if self.sin_long.as_ref().is_some()
-                && self.cos_long.as_ref().is_some()
-                && seqlen_offset[0] > self.original_max_position_embeddings.unwrap()
-            {
-                let cos = self
-                    .cos_long
-                    .as_ref()
-                    .unwrap()
-                    .narrow(0, seqlen_offset[0], seq_len)?;
-                let sin = self
-                    .sin_long
-                    .as_ref()
-                    .unwrap()
-                    .narrow(0, seqlen_offset[0], seq_len)?;
-                (cos, sin)
-            } else {
-                let cos = self.cos.narrow(0, seqlen_offset[0], seq_len)?;
-                let sin = self.sin.narrow(0, seqlen_offset[0], seq_len)?;
-                (cos, sin)
-            };
-            let x_q = q.narrow(0, b, 1)?;
-            let x_k = k.narrow(0, b, 1)?;
-            let q_embed = candle_nn::rotary_emb::rope(&x_q, &cos, &sin)?;
-            let k_embed = candle_nn::rotary_emb::rope(&x_k, &cos, &sin)?;
-            q_embeds.push(q_embed);
-            k_embeds.push(k_embed);
+        if self.long_emb.is_some() {
+            self.long_emb
+                .as_ref()
+                .unwrap()
+                .apply_rotary_emb(q, k, input_positions)
+        } else {
+            self.normal_emb.apply_rotary_emb(q, k, input_positions)
         }
-        Ok((Tensor::cat(&q_embeds, 0)?, Tensor::cat(&k_embeds, 0)?))
     }
 }
 
@@ -277,17 +260,19 @@ impl Attention {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
+        let (seq_len, _) = xs.dims2()?;
 
         let qkv = self.qkv_proj.forward(xs)?;
         let query_pos = self.num_heads * self.head_dim;
-        let query_states = qkv.narrow(D::Minus1, 0, query_pos)?;
-        let key_states = qkv.narrow(D::Minus1, query_pos, self.num_kv_heads * self.head_dim)?;
+        let query_states = qkv.narrow(D::Minus1, 0, query_pos)?.to_dtype(DType::F32)?;
+        let key_states = qkv
+            .narrow(D::Minus1, query_pos, self.num_kv_heads * self.head_dim)?
+            .to_dtype(DType::F32)?;
         let value_states = qkv
             .narrow(
                 D::Minus1,
@@ -296,31 +281,23 @@ impl Attention {
             )?
             .contiguous()?;
 
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
+        let q = query_states
+            .reshape((1, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = key_states
+            .reshape((1, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = value_states
+            .reshape((1, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
 
         //preserve the precision with F32 type
-        let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
+        let (q, k) = self
+            .rotary_emb
+            .apply_rotary_emb_qkv(&q, &k, input_positions)?;
         let q = q.to_dtype(v.dtype())?;
         let k = k.to_dtype(v.dtype())?;
 
@@ -336,7 +313,7 @@ impl Attention {
                 input_metadata,
                 None,
             )?
-            .reshape((b_sz, seq_len, ()))?;
+            .reshape((seq_len, ()))?;
 
         let y = self.o_proj.forward(&y)?;
         Ok(y)
@@ -425,8 +402,8 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
@@ -463,7 +440,7 @@ impl Phi {
     ) -> Result<Self> {
         let vb_m = vb.pp("model");
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
-        let rotary_emb = Arc::new(RotaryEmbedding::new(dtype, cfg, vb_m.device())?);
+        let rotary_emb = Arc::new(RotaryEmbedding::new(DType::F32, cfg, vb_m.device())?);
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
         let reporter = progress_reporter.clone();
@@ -496,23 +473,28 @@ impl Phi {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
-        let attention_mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_size,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
         let mut xs = self.embed_tokens.forward(input_ids)?;
 
         if let Some(kv_caches) = kv_caches {
@@ -536,7 +518,12 @@ impl Phi {
                 )?
             }
         }
-        let xs = xs.i((.., seq_len - 1, ..))?.apply(&self.norm)?;
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
         self.lm_head.forward(&xs)?.to_dtype(DType::F32)
     }
 

--- a/src/openai/models/quantized_glm4.rs
+++ b/src/openai/models/quantized_glm4.rs
@@ -1,10 +1,9 @@
-use super::rotary_emb::ScalingRotaryEmbedding;
-use super::Config;
+use super::{attention::QuantizedAttention, rotary_emb::ScalingRotaryEmbedding, Config};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::InputMetadata;
 use candle_core::quantized::{gguf_file, QMatMul};
-use candle_core::{DType, Device, IndexOp, Result, Tensor};
+use candle_core::{DType, Device, Result, Tensor};
 use candle_nn::{Embedding, Module};
 use candle_transformers::quantized_nn::RmsNorm;
 use either::Either;
@@ -30,105 +29,25 @@ impl Module for Mlp {
 }
 
 struct LayerWeights {
-    attention_wq: QMatMul,
-    attention_wk: QMatMul,
-    attention_wv: QMatMul,
-    attention_bq: Option<Tensor>,
-    attention_bk: Option<Tensor>,
-    attention_bv: Option<Tensor>,
-    attention_wo: QMatMul,
+    self_attn: QuantizedAttention,
     attention_norm: RmsNorm,
     post_ffw_norm: RmsNorm,
     post_attention_norm: RmsNorm,
-    rotary_emb: Arc<ScalingRotaryEmbedding>,
     mlp: Mlp,
     ffn_norm: RmsNorm,
-    n_head: usize,
-    n_kv_head: usize,
-    head_dim: usize,
-    attn: PagedAttention,
-    dtype: DType,
 }
 
 impl LayerWeights {
     fn forward_attn(
         &self,
         x: &Tensor,
-        mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = x.dims3()?;
-
-        let q = self.attention_wq.forward(x)?;
-        let k = self.attention_wk.forward(x)?;
-        let v = self.attention_wv.forward(x)?;
-
-        let q = if self.attention_bq.is_some() {
-            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
-        } else {
-            q
-        };
-
-        let k = if self.attention_bk.is_some() {
-            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
-        } else {
-            k
-        };
-
-        let v = if self.attention_bv.is_some() {
-            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
-        } else {
-            v
-        };
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
-            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
-            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = q
-                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = k
-                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = v
-                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
-                .transpose(1, 2)?;
-            (q.contiguous()?, k.contiguous()?, v.contiguous()?)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
-        let (q, k, v) = (
-            q.to_dtype(self.dtype)?,
-            k.to_dtype(self.dtype)?,
-            v.to_dtype(self.dtype)?,
-        );
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                None,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
-        Ok(y)
+        self.self_attn
+            .forward(x, mask, input_positions, cache, input_metadata)
     }
 }
 
@@ -275,50 +194,6 @@ impl GGUFGLM4 {
         let mut layers = Vec::with_capacity(block_count);
         for layer_idx in 0..block_count {
             let prefix = format!("blk.{layer_idx}");
-            let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
-            let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
-            let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
-
-            let attention_bq = ct.tensor(reader, &format!("{prefix}.attn_q.bias"), device);
-            let attention_bk = ct.tensor(reader, &format!("{prefix}.attn_k.bias"), device);
-            let attention_bv = ct.tensor(reader, &format!("{prefix}.attn_v.bias"), device);
-
-            let attention_bq = if attention_bq.is_ok() {
-                Some(
-                    attention_bq
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_bk = if attention_bk.is_ok() {
-                Some(
-                    attention_bk
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_bv = if attention_bv.is_ok() {
-                Some(
-                    attention_bv
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_wo =
-                ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
-
             let mlp = {
                 let ffn_gate_up = ct.tensor(reader, &format!("{prefix}.ffn_up.weight"), device)?;
                 let ffn_down = ct.tensor(reader, &format!("{prefix}.ffn_down.weight"), device)?;
@@ -340,34 +215,24 @@ impl GGUFGLM4 {
             )?;
             let post_ffw_norm = RmsNorm::from_qtensor(post_ffw_norm, rms_norm_eps)?;
             let post_attention_norm = RmsNorm::from_qtensor(post_attention_norm, rms_norm_eps)?;
+            let self_attn = QuantizedAttention::new(
+                &cfg,
+                ct,
+                reader,
+                &prefix,
+                device,
+                dtype,
+                rotary_emb.clone(),
+                cfg.sliding_window,
+            )?;
 
             layers.push(LayerWeights {
-                attention_wq: QMatMul::from_qtensor(attention_wq)?,
-                attention_wk: QMatMul::from_qtensor(attention_wk)?,
-                attention_wv: QMatMul::from_qtensor(attention_wv)?,
-                attention_bq,
-                attention_bk,
-                attention_bv,
-                attention_wo: QMatMul::from_qtensor(attention_wo)?,
+                self_attn,
                 attention_norm: RmsNorm::from_qtensor(attention_norm, rms_norm_eps)?,
                 post_ffw_norm,
                 post_attention_norm,
                 mlp,
                 ffn_norm: RmsNorm::from_qtensor(ffn_norm, rms_norm_eps)?,
-                n_head: head_count,
-                n_kv_head: head_count_kv,
-                head_dim,
-                rotary_emb: rotary_emb.clone(),
-                attn: PagedAttention::new(
-                    head_count,
-                    head_dim,
-                    1. / ((head_dim as f32).sqrt()),
-                    Some(head_count_kv),
-                    None,
-                    device.clone(),
-                    None,
-                )?,
-                dtype,
             });
             reporter.write().unwrap().set_progress(layer_idx + 1);
         }
@@ -386,36 +251,37 @@ impl GGUFGLM4 {
     pub fn forward(
         &self,
         x: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_sz, seq_len) = x.dims2()?;
-        assert!(
-            seq_len < self.cfg.max_seq_len,
-            "Input token length exceed maximum context allowed for this model."
-        );
-        let mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_sz,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
-        let mut layer_in = self.tok_embeddings.forward(x)?;
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
+        let mut xs = self.tok_embeddings.forward(x)?;
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
-                let x = layer_in;
+                let x = xs;
                 let residual = &x;
                 let x = layer.attention_norm.forward(&x)?;
                 let attn = layer.forward_attn(
                     &x,
-                    mask.as_ref(),
+                    attention_mask.as_ref(),
                     input_positions,
                     Some((k_cache, v_cache)),
                     input_metadata,
@@ -429,15 +295,20 @@ impl GGUFGLM4 {
                 let x = layer.mlp.forward(&x)?;
                 let x = layer.post_ffw_norm.forward(&x)?;
                 let x = (x + residual)?;
-                layer_in = x
+                xs = x
             }
         } else {
             for layer in self.layers.iter() {
-                let x = layer_in;
+                let x = xs;
                 let residual = &x;
                 let x = layer.ffn_norm.forward(&x)?;
-                let attn =
-                    layer.forward_attn(&x, mask.as_ref(), input_positions, None, input_metadata)?;
+                let attn = layer.forward_attn(
+                    &x,
+                    attention_mask.as_ref(),
+                    input_positions,
+                    None,
+                    input_metadata,
+                )?;
                 let attn = layer.attention_norm.forward(&attn)?;
                 let x = (attn + residual)?;
 
@@ -447,14 +318,16 @@ impl GGUFGLM4 {
                 let x = layer.mlp.forward(&x)?;
                 let x = layer.post_ffw_norm.forward(&x)?;
                 let x = (x + residual)?;
-                layer_in = x
+                xs = x
             }
         }
-        let x = layer_in
-            .i((.., seq_len - 1, ..))?
-            .contiguous()?
-            .apply(&self.norm)?;
-        self.output.forward(&x)
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
+        self.output.forward(&xs)?.to_dtype(DType::F32)
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/quantized_qwen3_moe.rs
+++ b/src/openai/models/quantized_qwen3_moe.rs
@@ -1,11 +1,11 @@
 use super::rotary_emb::ScalingRotaryEmbedding;
-use super::{Config, MoEConfig, QwenMoEConfig};
+use super::{attention::QuantizedAttention, Config, MoEConfig, QwenMoEConfig};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
 use crate::openai::models::linear::Linear;
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::InputMetadata;
 use candle_core::quantized::{gguf_file, QMatMul};
-use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_core::{DType, Device, Result, Tensor, D};
 use candle_nn::{Embedding, Module};
 use candle_transformers::quantized_nn::RmsNorm;
 use either::Either;
@@ -40,10 +40,8 @@ struct FusedMoe {
 
 impl FusedMoe {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let (batch, seq_len, hidden_dim) = xs.dims3()?;
-        let xs = xs.reshape(((), hidden_dim))?;
-        let original_dtype = xs.dtype();
         let (num_tokens, hidden_dim) = xs.dims2()?;
+        let original_dtype = xs.dtype();
         let xs = xs.to_dtype(DType::F32)?;
         let router_logits = self.gate.forward(&xs)?;
         let routing_weights = candle_nn::ops::softmax_last_dim(&router_logits)?;
@@ -71,7 +69,7 @@ impl FusedMoe {
         };
         ys.broadcast_mul(&scores.unsqueeze(D::Minus1)?)?
             .sum(D::Minus2)?
-            .reshape((batch, seq_len, hidden_dim))?
+            .reshape((num_tokens, hidden_dim))?
             .to_dtype(original_dtype)
     }
 }
@@ -91,120 +89,25 @@ impl MoeOrMlp {
 }
 
 struct LayerWeights {
-    attention_wq: QMatMul,
-    attention_wk: QMatMul,
-    attention_wv: QMatMul,
-    attention_bq: Option<Tensor>,
-    attention_bk: Option<Tensor>,
-    attention_bv: Option<Tensor>,
-    attention_wo: QMatMul,
+    self_attn: QuantizedAttention,
     attention_norm: RmsNorm,
-    q_norm: Option<RmsNorm>,
-    k_norm: Option<RmsNorm>,
     mlp: MoeOrMlp,
     shared_gate: Option<Linear>,
     shared_expert: Option<Mlp>,
     ffn_norm: RmsNorm,
-    n_head: usize,
-    n_kv_head: usize,
-    head_dim: usize,
-    attn: PagedAttention,
-    rotary_emb: Arc<ScalingRotaryEmbedding>,
-    dtype: DType,
 }
 
 impl LayerWeights {
     fn forward_attn(
         &self,
         x: &Tensor,
-        mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = x.dims3()?;
-
-        let q = self.attention_wq.forward(x)?;
-        let k = self.attention_wk.forward(x)?;
-        let v = self.attention_wv.forward(x)?;
-
-        let q = if self.attention_bq.is_some() {
-            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
-        } else {
-            q
-        };
-
-        let k = if self.attention_bk.is_some() {
-            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
-        } else {
-            k
-        };
-
-        let v = if self.attention_bv.is_some() {
-            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
-        } else {
-            v
-        };
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
-            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
-            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = q
-                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = k
-                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = v
-                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
-                .transpose(1, 2)?;
-            (q.contiguous()?, k.contiguous()?, v.contiguous()?)
-        };
-
-        let (q, k) = if let (Some(q_norm), Some(k_norm)) = (&self.q_norm, &self.k_norm) {
-            // Per‑head RMSNorm in qwen3
-            let q_flat = q.flatten(0, 2)?; // (B*H, L, D) -> (BHL, D) after transpose later
-            let k_flat = k.flatten(0, 2)?;
-
-            // q_norm and k_norm weights stored in f32 format in qwen3 gguf
-            let q_flat = q_norm.forward(&q_flat)?;
-            let k_flat = k_norm.forward(&k_flat)?;
-
-            let q = q_flat.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
-            let k = k_flat.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
-
-            (q, k)
-        } else {
-            (q, k)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(&q, &k, input_positions)?;
-        let (q, k, v) = (
-            q.to_dtype(self.dtype)?,
-            k.to_dtype(self.dtype)?,
-            v.to_dtype(self.dtype)?,
-        );
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                None,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.attention_wo.forward(&y.to_dtype(x.dtype())?)?;
-        Ok(y)
+        self.self_attn
+            .forward(x, mask, input_positions, cache, input_metadata)
     }
 }
 
@@ -382,50 +285,6 @@ impl GGUFQWenMoE {
         let mut layers = Vec::with_capacity(block_count);
         for layer_idx in 0..block_count {
             let prefix = format!("blk.{layer_idx}");
-            let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
-            let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
-            let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
-
-            let attention_bq = ct.tensor(reader, &format!("{prefix}.attn_q.bias"), device);
-            let attention_bk = ct.tensor(reader, &format!("{prefix}.attn_k.bias"), device);
-            let attention_bv = ct.tensor(reader, &format!("{prefix}.attn_v.bias"), device);
-
-            let attention_bq = if attention_bq.is_ok() {
-                Some(
-                    attention_bq
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_bk = if attention_bk.is_ok() {
-                Some(
-                    attention_bk
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_bv = if attention_bv.is_ok() {
-                Some(
-                    attention_bv
-                        .unwrap()
-                        .dequantize(device)?
-                        .to_dtype(DType::F32)?,
-                )
-            } else {
-                None
-            };
-
-            let attention_wo =
-                ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
-
             let mlp = if !moe_cfg
                 .mlp_only_layers
                 .as_ref()
@@ -472,19 +331,6 @@ impl GGUFQWenMoE {
             let attention_norm =
                 ct.tensor(reader, &format!("{prefix}.attn_norm.weight"), device)?;
             let ffn_norm = ct.tensor(reader, &format!("{prefix}.ffn_norm.weight"), device)?;
-            let (q_norm, k_norm) = {
-                let q_norm = ct.tensor(reader, &format!("{prefix}.attn_q_norm.weight"), device);
-                let k_norm = ct.tensor(reader, &format!("{prefix}.attn_k_norm.weight"), device);
-                let (q_norm, k_norm) = match (q_norm, k_norm) {
-                    (Ok(q_norm), Ok(k_norm)) => {
-                        let q_norm = RmsNorm::from_qtensor(q_norm, rms_norm_eps)?;
-                        let k_norm = RmsNorm::from_qtensor(k_norm, rms_norm_eps)?;
-                        (Some(q_norm), Some(k_norm))
-                    }
-                    _ => (None, None),
-                };
-                (q_norm, k_norm)
-            };
 
             //shared experts weights in Qwen2 MoE models
             let (shared_gate, shared_expert) =
@@ -519,35 +365,23 @@ impl GGUFQWenMoE {
                     (None, None)
                 };
 
+            let self_attn = QuantizedAttention::new(
+                &cfg,
+                ct,
+                reader,
+                &prefix,
+                device,
+                dtype,
+                rotary_emb.clone(),
+                cfg.sliding_window,
+            )?;
             layers.push(LayerWeights {
-                attention_wq: QMatMul::from_qtensor(attention_wq)?,
-                attention_wk: QMatMul::from_qtensor(attention_wk)?,
-                attention_wv: QMatMul::from_qtensor(attention_wv)?,
-                attention_bq,
-                attention_bk,
-                attention_bv,
-                attention_wo: QMatMul::from_qtensor(attention_wo)?,
+                self_attn,
                 attention_norm: RmsNorm::from_qtensor(attention_norm, rms_norm_eps)?,
-                q_norm,
-                k_norm,
                 mlp,
                 shared_gate,
                 shared_expert,
                 ffn_norm: RmsNorm::from_qtensor(ffn_norm, rms_norm_eps)?,
-                n_head: head_count,
-                n_kv_head: head_count_kv,
-                head_dim,
-                attn: PagedAttention::new(
-                    head_count,
-                    head_dim,
-                    1. / ((head_dim as f32).sqrt()),
-                    Some(head_count_kv),
-                    None,
-                    device.clone(),
-                    None,
-                )?,
-                rotary_emb: rotary_emb.clone(),
-                dtype,
             });
             reporter.write().unwrap().set_progress(layer_idx + 1);
         }
@@ -566,36 +400,37 @@ impl GGUFQWenMoE {
     pub fn forward(
         &self,
         x: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_sz, seq_len) = x.dims2()?;
-        assert!(
-            seq_len < self.cfg.max_seq_len,
-            "Input token length exceed maximum context allowed for this model."
-        );
-        let mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_sz,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
-        let mut layer_in = self.tok_embeddings.forward(x)?;
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
+        let mut xs = self.tok_embeddings.forward(x)?;
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
-                let x = layer_in;
+                let x = xs;
                 let residual = &x;
                 let x = layer.attention_norm.forward(&x)?;
                 let attn = layer.forward_attn(
                     &x,
-                    mask.as_ref(),
+                    attention_mask.as_ref(),
                     input_positions,
                     Some((k_cache, v_cache)),
                     input_metadata,
@@ -621,15 +456,20 @@ impl GGUFQWenMoE {
                 } else {
                     (x + residual)?
                 };
-                layer_in = x
+                xs = x
             }
         } else {
             for layer in self.layers.iter() {
-                let x = layer_in;
+                let x = xs;
                 let residual = &x;
                 let x = layer.attention_norm.forward(&x)?;
-                let attn =
-                    layer.forward_attn(&x, mask.as_ref(), input_positions, None, input_metadata)?;
+                let attn = layer.forward_attn(
+                    &x,
+                    attention_mask.as_ref(),
+                    input_positions,
+                    None,
+                    input_metadata,
+                )?;
                 let x = (attn + residual)?;
 
                 // MLP
@@ -650,14 +490,17 @@ impl GGUFQWenMoE {
                 } else {
                     (x + residual)?
                 };
-                layer_in = x
+                xs = x
             }
         }
-        let x = layer_in
-            .i((.., seq_len - 1, ..))?
-            .contiguous()?
-            .apply(&self.norm)?;
-        self.output.forward(&x)
+
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
+        self.output.forward(&xs)?.to_dtype(DType::F32)
     }
 
     pub fn get_config(&self) -> &Config {

--- a/src/openai/models/stable_lm.rs
+++ b/src/openai/models/stable_lm.rs
@@ -1,14 +1,10 @@
-use super::rotary_emb::ScalingRotaryEmbedding;
-use super::Config;
+use super::{attention::Attention, mlp::Mlp, rotary_emb::ScalingRotaryEmbedding, Config};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::openai::distributed::{
-    embedding, layer_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
-    TensorParallelRowLinear, VarBuilder,
-};
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
-use candle_core::{DType, Device, IndexOp, Module, Result, Tensor};
-use candle_nn::{Activation, LayerNorm};
+use crate::openai::distributed::{embedding, layer_norm, Comm, ReplicatedLinear, VarBuilder};
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::InputMetadata;
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn::LayerNorm;
 use std::iter::zip;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -46,210 +42,9 @@ impl StableLM {
     }
 }
 
-struct MLP {
-    gate_proj: TensorParallelColumnLinear,
-    up_proj: TensorParallelColumnLinear,
-    down_proj: TensorParallelRowLinear,
-    act_fn: Activation,
-}
-
-impl MLP {
-    fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-
-        let gate_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("gate_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let up_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("up_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let down_proj = TensorParallelRowLinear::load_with_hints(
-            intermediate_sz,
-            hidden_sz,
-            false,
-            vb.pp("down_proj"),
-            comm,
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap_or(Activation::Silu),
-        })
-    }
-}
-
-impl Module for MLP {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(&lhs * &rhs)?)
-    }
-}
-
-struct Attention {
-    q_proj: TensorParallelColumnLinear,
-    k_proj: TensorParallelColumnLinear,
-    v_proj: TensorParallelColumnLinear,
-    o_proj: TensorParallelRowLinear,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_emb: Arc<ScalingRotaryEmbedding>,
-    attn: PagedAttention,
-}
-
-impl Attention {
-    fn new(
-        rotary_emb: Arc<ScalingRotaryEmbedding>,
-        cfg: &Config,
-        vb: VarBuilder,
-        comm: Rc<Comm>,
-    ) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let num_heads = cfg.num_attention_heads;
-        let num_kv_heads = cfg.num_key_value_heads.unwrap();
-        let head_dim = hidden_sz / num_heads;
-
-        let q_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_heads * head_dim,
-            cfg.use_qkv_bias.unwrap_or(false),
-            vb.pp("q_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let k_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            cfg.use_qkv_bias.unwrap_or(false),
-            vb.pp("k_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let v_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            cfg.use_qkv_bias.unwrap_or(false),
-            vb.pp("v_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-
-        let o_proj = TensorParallelRowLinear::load_with_hints(
-            num_heads * head_dim,
-            hidden_sz,
-            false,
-            vb.pp("o_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let attention_heads = cfg.num_attention_heads / comm.world_size();
-        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
-        Ok(Self {
-            q_proj,
-            k_proj,
-            v_proj,
-            o_proj,
-            num_heads: attention_heads,
-            num_kv_heads: kv_heads,
-            head_dim,
-            rotary_emb,
-            attn: PagedAttention::new(
-                attention_heads,
-                head_dim,
-                1. / ((head_dim as f32).sqrt()),
-                Some(kv_heads),
-                cfg.sliding_window,
-                vb.device().clone(),
-                None,
-            )?,
-        })
-    }
-
-    fn forward(
-        &self,
-        xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
-        cache: Option<(&Tensor, &Tensor)>,
-        input_metadata: &InputMetadata,
-    ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
-
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
-
-        let q = q.to_dtype(v.dtype())?;
-        let k = k.to_dtype(v.dtype())?;
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                attention_mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                None,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.o_proj.forward(&y)?;
-        Ok(y)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
-    mlp: MLP,
+    mlp: Mlp,
     input_layernorm: LayerNorm,
     post_attention_layernorm: LayerNorm,
 }
@@ -261,8 +56,14 @@ impl DecoderLayer {
         vb: VarBuilder,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"), comm.clone())?;
-        let mlp = MLP::new(cfg, vb.pp("mlp"), comm.clone())?;
+        let self_attn = Attention::new(
+            rotary_emb,
+            cfg,
+            vb.pp("self_attn"),
+            comm.clone(),
+            cfg.sliding_window,
+        )?;
+        let mlp = Mlp::new(cfg, vb.pp("mlp"), comm.clone())?;
         let input_layernorm = layer_norm(
             cfg.hidden_size,
             cfg.rms_norm_eps,
@@ -286,8 +87,8 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
@@ -361,23 +162,28 @@ impl StableLM {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
-        let attention_mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_size,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
         let mut xs = self.embed_tokens.forward(input_ids)?;
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
@@ -400,7 +206,12 @@ impl StableLM {
                 )?
             }
         }
-        let xs = xs.i((.., seq_len - 1, ..))?.apply(&self.norm)?;
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
         self.lm_head.forward(&xs)?.to_dtype(DType::F32)
     }
 

--- a/src/openai/models/yi.rs
+++ b/src/openai/models/yi.rs
@@ -1,13 +1,10 @@
-use super::{rotary_emb::ScalingRotaryEmbedding, Config};
+use super::{attention::Attention, mlp::Mlp, rotary_emb::ScalingRotaryEmbedding, Config};
 use crate::backend::progress::{ProgressLike, ProgressReporter};
-use crate::openai::distributed::{
-    embedding, rms_norm, Comm, ReplicatedLinear, TensorParallelColumnLinear,
-    TensorParallelRowLinear, VarBuilder,
-};
-use crate::paged_attention::input_metadata::InputMetadata;
-use crate::paged_attention::PagedAttention;
-use candle_core::{DType, Device, IndexOp, Module, Result, Tensor};
-use candle_nn::{Activation, RmsNorm};
+use crate::openai::distributed::{embedding, rms_norm, Comm, ReplicatedLinear, VarBuilder};
+use crate::openai::models::mask::get_attention_casual_mask;
+use crate::InputMetadata;
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn::RmsNorm;
 use std::iter::zip;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -44,206 +41,6 @@ impl Yi {
     }
 }
 
-struct Mlp {
-    gate_proj: TensorParallelColumnLinear,
-    up_proj: TensorParallelColumnLinear,
-    down_proj: TensorParallelRowLinear,
-    act_fn: Activation,
-}
-
-impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder, comm: Rc<Comm>) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("gate_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let up_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            intermediate_sz,
-            false,
-            vb.pp("up_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let down_proj = TensorParallelRowLinear::load_with_hints(
-            intermediate_sz,
-            hidden_sz,
-            false,
-            vb.pp("down_proj"),
-            comm,
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act.unwrap_or(Activation::Silu),
-        })
-    }
-}
-
-impl Module for Mlp {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.act_fn.forward(&self.gate_proj.forward(xs)?)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(&lhs * &rhs)?)
-    }
-}
-
-struct Attention {
-    q_proj: TensorParallelColumnLinear,
-    k_proj: TensorParallelColumnLinear,
-    v_proj: TensorParallelColumnLinear,
-    o_proj: TensorParallelRowLinear,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_emb: Arc<ScalingRotaryEmbedding>,
-    attn: PagedAttention,
-}
-
-impl Attention {
-    fn new(
-        rotary_emb: Arc<ScalingRotaryEmbedding>,
-        cfg: &Config,
-        vb: VarBuilder,
-        comm: Rc<Comm>,
-    ) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let num_heads = cfg.num_attention_heads;
-        let num_kv_heads = cfg.num_key_value_heads.unwrap();
-        let head_dim = hidden_sz / num_heads;
-
-        let q_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_heads * head_dim,
-            false,
-            vb.pp("q_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let k_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            false,
-            vb.pp("k_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let v_proj = TensorParallelColumnLinear::load_with_hints(
-            hidden_sz,
-            num_kv_heads * head_dim,
-            false,
-            vb.pp("v_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-
-        let o_proj = TensorParallelRowLinear::load_with_hints(
-            num_heads * head_dim,
-            hidden_sz,
-            false,
-            vb.pp("o_proj"),
-            comm.clone(),
-            &cfg.quant,
-            &cfg.quantization_config,
-        )?;
-        let attention_heads = cfg.num_attention_heads / comm.world_size();
-        let kv_heads = cfg.num_key_value_heads.unwrap() / comm.world_size();
-        Ok(Self {
-            q_proj,
-            k_proj,
-            v_proj,
-            o_proj,
-            num_heads: attention_heads,
-            num_kv_heads: kv_heads,
-            head_dim,
-            rotary_emb,
-            attn: PagedAttention::new(
-                attention_heads,
-                head_dim,
-                1. / ((head_dim as f32).sqrt()),
-                Some(kv_heads),
-                cfg.sliding_window,
-                vb.device().clone(),
-                None,
-            )?,
-        })
-    }
-
-    fn forward(
-        &self,
-        xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
-        cache: Option<(&Tensor, &Tensor)>,
-        input_metadata: &InputMetadata,
-    ) -> Result<Tensor> {
-        let (b_sz, seq_len, _) = xs.dims3()?;
-
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
-
-        let (q, k, v) = if seq_len == 1 {
-            //no need transpose for seq_len == 1, change reshape dim
-            let q = query_states.reshape((b_sz, self.num_heads, seq_len, self.head_dim))?;
-            let k = key_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            let v = value_states.reshape((b_sz, self.num_kv_heads, seq_len, self.head_dim))?;
-            (q, k, v)
-        } else {
-            let q = query_states
-                .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let k = key_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            let v = value_states
-                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
-                .transpose(1, 2)?;
-            (q, k, v.contiguous()?)
-        };
-
-        let (q, k) = self.rotary_emb.apply_rotary_emb(
-            &q.to_dtype(DType::F32)?,
-            &k.to_dtype(DType::F32)?,
-            input_positions,
-        )?;
-
-        let q = q.to_dtype(v.dtype())?;
-        let k = k.to_dtype(v.dtype())?;
-
-        let y = self
-            .attn
-            .forward(
-                &q,
-                &k,
-                &v,
-                attention_mask,
-                cache.map(|(k_, _)| k_.clone()),
-                cache.map(|(_, v_)| v_.clone()),
-                input_metadata,
-                None,
-            )?
-            .reshape((b_sz, seq_len, ()))?;
-
-        let y = self.o_proj.forward(&y)?;
-        Ok(y)
-    }
-}
-
 struct DecoderLayer {
     self_attn: Attention,
     mlp: Mlp,
@@ -258,7 +55,13 @@ impl DecoderLayer {
         vb: VarBuilder,
         comm: Rc<Comm>,
     ) -> Result<Self> {
-        let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"), comm.clone())?;
+        let self_attn = Attention::new(
+            rotary_emb,
+            cfg,
+            vb.pp("self_attn"),
+            comm.clone(),
+            cfg.sliding_window,
+        )?;
         let mlp = Mlp::new(cfg, vb.pp("mlp"), comm.clone())?;
         let ln1 = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let ln2 = rms_norm(
@@ -277,8 +80,8 @@ impl DecoderLayer {
     fn forward(
         &self,
         xs: &Tensor,
-        attention_mask: Option<&Tensor>,
-        input_positions: &[Vec<usize>],
+        attention_mask: Option<&Vec<Tensor>>,
+        input_positions: &Tensor,
         cache: Option<(&Tensor, &Tensor)>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
@@ -354,23 +157,28 @@ impl Yi {
     pub fn forward(
         &self,
         input_ids: &Tensor,
-        input_positions: &[Vec<usize>],
+        input_positions: &Tensor,
         kv_caches: Option<&Vec<(Tensor, Tensor)>>,
         input_metadata: &InputMetadata,
     ) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
-        let attention_mask = if seq_len <= 1 {
-            None
+        let seqlens = if input_metadata.cu_seqlens_q.is_some() {
+            input_metadata
+                .cu_seqlens_q
+                .as_ref()
+                .unwrap()
+                .to_vec1::<u32>()?[1..]
+                .into()
         } else {
-            super::get_attention_casual_mask(
-                &self.device,
-                self.dtype,
-                b_size,
-                seq_len,
-                input_positions,
-                self.cfg.sliding_window,
-            )
+            Vec::new()
         };
+        let attention_mask = get_attention_casual_mask(
+            &self.device,
+            self.dtype,
+            input_positions,
+            &seqlens,
+            self.cfg.sliding_window,
+            input_metadata.is_prefill,
+        );
         let mut xs = self.embed_tokens.forward(input_ids)?;
         if let Some(kv_caches) = kv_caches {
             for ((k_cache, v_cache), layer) in zip(kv_caches.iter(), self.layers.iter()) {
@@ -394,7 +202,12 @@ impl Yi {
             }
         }
 
-        let xs = xs.i((.., seq_len - 1, ..))?.apply(&self.norm)?;
+        if !seqlens.is_empty() {
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
+            let batch = indices.len();
+            xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
+        }
+        let xs = self.norm.forward(&xs)?;
         self.lm_head.forward(&xs)?.to_dtype(DType::F32)
     }
 

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -1,4 +1,4 @@
-use super::{DefaultPipeline, _make_tensor_with_pad};
+use super::DefaultPipeline;
 #[cfg(feature = "nccl")]
 use crate::openai::communicator::{DaemonManager, MessageType, TaskSampleData};
 #[cfg(feature = "nccl")]
@@ -16,12 +16,12 @@ use crate::{
         sampling_params::SamplingParams,
         utils::get_created_time_secs,
     },
-    paged_attention::input_metadata::InputMetadata,
     scheduler::{
         cache_engine::{CacheConfig, CacheEngine},
         sequence::{Sequence, SequenceGroup, _Sequence},
         SchedulerConfig, SchedulerOutput,
     },
+    InputMetadata,
 };
 use candle_core::{Device, Result, Tensor};
 use either::Either;
@@ -43,7 +43,7 @@ use tracing::{debug, info, warn};
 #[allow(dead_code)]
 struct PreparedInputs {
     tokens: Tensor,
-    positions: Vec<Vec<usize>>,
+    positions: Tensor,
     metadata: InputMetadata,
 }
 
@@ -491,6 +491,10 @@ impl LLMEngine {
                     positions,
                     metadata,
                 } = if seqs.values().nth(0).unwrap().deref().is_prompt() {
+                    assert!(
+                        scheduled.len() == 1,
+                        "only one prompt can be schedule at same time!"
+                    );
                     e.prepare_prompt(&scheduled, device)
                 } else {
                     e.prepare_decode(&scheduled, device)
@@ -503,7 +507,7 @@ impl LLMEngine {
                     &metadata,
                 )?;
 
-                (x, metadata.is_prompt)
+                (x, metadata.is_prefill)
             };
 
             if is_prompt {
@@ -854,211 +858,248 @@ impl LLMEngine {
         Ok(())
     }
 
+    fn prepare_block_tables(
+        &self,
+        groups: &VecDeque<Arc<SequenceGroup>>,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let len = groups.len();
+
+        let mut max_len = 0;
+        for group in groups {
+            let seq = group.get_seqs().values().nth(0).unwrap();
+            let table = self
+                .scheduler
+                .block_engine
+                .block_tables
+                .get(&seq.deref().get_id())
+                .unwrap();
+            if table.len() > max_len {
+                max_len = table.len();
+            }
+        }
+
+        let mut flat: Vec<u32> = Vec::with_capacity(len * max_len);
+        for group in groups {
+            let seq = group.get_seqs().values().nth(0).unwrap();
+            let table = self
+                .scheduler
+                .block_engine
+                .block_tables
+                .get(&seq.deref().get_id())
+                .unwrap();
+            let table = table
+                .iter()
+                .map(|block| block.deref_mut().block_id as u32)
+                .collect::<Vec<_>>();
+            let table_len = table.len();
+            flat.extend(table);
+            flat.extend(std::iter::repeat(0).take(max_len - table_len));
+        }
+
+        Tensor::from_vec(flat, (len, max_len), device)
+    }
+
+    //Revised based on https://github.com/guoqingbao/vllm.rs/blob/main/src/core/runner.rs#L392
     fn prepare_prompt(
         &self,
         groups: &VecDeque<Arc<SequenceGroup>>,
         device: &Device,
     ) -> Result<PreparedInputs> {
-        let mut prompt_lens = Vec::new();
-        let mut input_tokens = Vec::new();
-        let mut input_positions = Vec::new();
-        let mut slot_mappings = Vec::new();
+        let mut input_ids: Vec<u32> = Vec::new();
+        let mut positions = Vec::new();
+        let mut cu_seqlens_q = vec![0];
+        let mut cu_seqlens_k = vec![0];
+        let mut max_seqlen_q = 0;
+        let mut max_seqlen_k = 0;
+        let mut slot_mapping = Vec::new();
+        let chunk_size = self.prefill_chunk_size.unwrap_or(PREFILL_CHUNK_SIZE);
+
+        // let flash_context = self.config.flash_context.unwrap_or(false);
+        let flash_context = false; //TODO
+
+        let mut context_lens = Vec::<u32>::new();
         for group in groups {
-            for seq in group.get_seqs().values() {
-                let prompt_ids = seq.deref_mut().get_token_ids();
-                let prompt_len = prompt_ids.len();
-                let num_cached_tokens = seq.deref().get_num_cached_tokens();
-                let chunk_size = self.prefill_chunk_size.unwrap_or(PREFILL_CHUNK_SIZE);
-                let num_tokens = if chunk_size > 0 {
-                    std::cmp::min(chunk_size, prompt_len - num_cached_tokens)
+            let seq = group.get_seqs().values().nth(0).unwrap();
+            let prompt_ids = seq.deref_mut().get_token_ids();
+            let seqlen = seq.deref().get_len();
+            context_lens.push(seqlen as u32);
+            let num_cached_tokens = seq.deref().get_num_cached_tokens();
+
+            let num_tokens = std::cmp::min(chunk_size, seqlen - num_cached_tokens);
+            input_ids.extend(&prompt_ids[num_cached_tokens..num_cached_tokens + num_tokens]);
+            positions.extend(
+                (num_cached_tokens as i64..(num_cached_tokens + num_tokens) as i64)
+                    .collect::<Vec<_>>(),
+            );
+
+            let seqlen_q = num_tokens; //seqlen - seq.num_cached_tokens;
+            let seqlen_k = if flash_context {
+                num_cached_tokens + num_tokens
+            } else {
+                num_tokens
+            };
+            cu_seqlens_q.push(cu_seqlens_q.last().unwrap() + seqlen_q as u32);
+            cu_seqlens_k.push(cu_seqlens_k.last().unwrap() + seqlen_k as u32);
+            max_seqlen_q = std::cmp::max(max_seqlen_q, seqlen_q);
+            max_seqlen_k = std::cmp::max(max_seqlen_k, seqlen_k);
+
+            let mut slot_mapping_tokens: i64 = 0;
+
+            let table = self
+                .scheduler
+                .block_engine
+                .block_tables
+                .get(&seq.deref().get_id())
+                .unwrap();
+            let table = table
+                .iter()
+                .map(|block| block.deref_mut().block_id as u32)
+                .collect::<Vec<_>>();
+
+            let num_cached_blocks = num_cached_tokens / self.cache_config.block_size;
+            let num_blocks = seqlen.div_ceil(self.cache_config.block_size);
+
+            for i in num_cached_blocks..num_blocks {
+                let start = (table[i] * self.cache_config.block_size as u32) as i64;
+                let start = if i == num_cached_blocks {
+                    start + (num_cached_tokens as i64 % self.cache_config.block_size as i64)
                 } else {
-                    prompt_len - num_cached_tokens
+                    start
                 };
-
-                prompt_lens.push(num_tokens);
-
-                input_tokens
-                    .push(prompt_ids[num_cached_tokens..num_cached_tokens + num_tokens].to_vec());
-                input_positions
-                    .push((num_cached_tokens..num_cached_tokens + num_tokens).collect::<Vec<_>>());
-                let table = self
-                    .scheduler
-                    .block_engine
-                    .block_tables
-                    .get(&seq.deref_mut().get_id());
-                if table.is_none() {
-                    // Will be None during profiling.
-                    slot_mappings.push([_PAD_SLOT_ID].repeat(prompt_len));
-                    continue;
+                let end = start
+                    + std::cmp::min(
+                        num_tokens as i64 - slot_mapping_tokens,
+                        self.cache_config.block_size as i64,
+                    );
+                slot_mapping.extend((start..end).collect::<Vec<i64>>());
+                slot_mapping_tokens += end - start;
+                if slot_mapping_tokens >= num_tokens as i64 {
+                    break;
                 }
-                let table = table
-                    .unwrap()
-                    .iter()
-                    .map(|block| block.deref_mut().block_id)
-                    .collect::<Vec<_>>();
-
-                let start_idx = if let Some(sliding_window) = self.config.sliding_window {
-                    if prompt_len > sliding_window {
-                        0.min(prompt_len - sliding_window)
-                    } else {
-                        0
-                    }
-                } else {
-                    0
-                };
-
-                let mut slot_mapping = Vec::new();
-                for i in num_cached_tokens..num_cached_tokens + num_tokens {
-                    if i < start_idx {
-                        // Pad [0,start_idx) with _PAD_TOKEN_ID
-                        slot_mapping.push(_PAD_SLOT_ID);
-                    }
-
-                    let block_number = if i / self.cache_config.block_size >= table.len() {
-                        panic!(
-                            "Block table is too small (prompt)! i={} block_size={} table_len={}",
-                            i,
-                            self.cache_config.block_size,
-                            table.len()
-                        );
-                    } else {
-                        table.get(i / self.cache_config.block_size).unwrap()
-                    };
-                    let block_offset = i % self.cache_config.block_size;
-                    let slot = block_number * self.cache_config.block_size + block_offset;
-                    slot_mapping.push(slot.try_into().unwrap());
-                }
-                slot_mappings.push(slot_mapping);
             }
         }
 
-        let max_prompt_len = prompt_lens.iter().max().unwrap();
-        let input_tokens = _make_tensor_with_pad(
-            input_tokens
-                .iter()
-                .map(|x| x.iter().map(|x| *x as i64).collect::<Vec<_>>())
-                .collect::<Vec<_>>(),
-            *max_prompt_len,
-            0,
-            device,
-        )?;
-        let slot_mapping =
-            _make_tensor_with_pad(slot_mappings, *max_prompt_len, _PAD_SLOT_ID, device)?;
+        assert!(
+            input_ids.len() > 0 && positions.len() > 0 && slot_mapping.len() > 0,
+            "Invalid inputs!"
+        );
+        // Validate lengths
+        if input_ids.len() != slot_mapping.len() {
+            candle_core::bail!(
+                "input_ids and slot_mapping must have same length: {}, {}",
+                input_ids.len(),
+                slot_mapping.len()
+            );
+        }
+        if input_ids.len() != *cu_seqlens_q.last().unwrap() as usize {
+            candle_core::bail!("input_ids length must match last cu_seqlens_q",);
+        }
+        // crate::log_info!("input_ids {:?}, positions {:?}, slot_mapping {:?}", input_ids, positions, slot_mapping);
+
+        // Create tensors
+        let length = input_ids.len();
+        let input_ids = Tensor::from_vec(input_ids, (length,), device)?;
+        let positions = Tensor::from_vec(positions, (length,), device)?;
+        let q_len = cu_seqlens_q.len();
+        let k_len = cu_seqlens_k.len();
+        let s_len = slot_mapping.len();
+
+        let slot_mapping = Tensor::from_vec(slot_mapping, (s_len,), device)?;
+
+        // Handle context cache
+        let (context_lens, block_tables) = if cu_seqlens_k.last() > cu_seqlens_q.last() {
+            let ctx_len = context_lens.len();
+            let context_lens_t = Tensor::from_vec(context_lens, ctx_len, device)?;
+            let block_tables_t = self.prepare_block_tables(groups, device)?;
+            (Some(context_lens_t), Some(block_tables_t))
+        } else {
+            (None, None)
+        };
+        let cu_seqlens_q = Tensor::from_vec(cu_seqlens_q, (q_len,), device)?;
+        let cu_seqlens_k = Tensor::from_vec(cu_seqlens_k, (k_len,), device)?;
+
+        let input_metadata = InputMetadata {
+            is_prefill: true,
+            slot_mapping,
+            block_tables,
+            context_lens,
+            cu_seqlens_q: Some(cu_seqlens_q),
+            cu_seqlens_k: Some(cu_seqlens_k),
+            max_seqlen_q,
+            max_seqlen_k,
+            max_context_len: self.config.max_seq_len,
+        };
 
         Ok(PreparedInputs {
-            tokens: input_tokens,
-            positions: input_positions,
-            metadata: InputMetadata {
-                prompt_lens,
-                slot_mapping,
-                max_context_len: None,
-                context_lens: None,
-                block_tables: None,
-                is_prompt: true,
-            },
+            tokens: input_ids,
+            positions: positions,
+            metadata: input_metadata,
         })
     }
 
+    //Revised based on https://github.com/guoqingbao/vllm.rs/blob/main/src/core/runner.rs#L498
     fn prepare_decode(
         &self,
         groups: &VecDeque<Arc<SequenceGroup>>,
         device: &Device,
     ) -> Result<PreparedInputs> {
-        let mut input_tokens = Vec::new();
-        let mut input_positions = Vec::new();
+        let mut input_ids = Vec::new();
+        let mut positions = Vec::new();
+        let mut slot_mapping = Vec::new();
         let mut context_lens = Vec::new();
-        let mut slot_mappings = Vec::new();
-        let mut block_tables = Vec::new();
+
         for group in groups {
-            for seq in group.get_seqs().values() {
-                let last_token_id = seq.deref_mut().get_last_token_id();
-                input_tokens.push(vec![last_token_id]);
+            let seq = group.get_seqs().values().nth(0).unwrap();
+            let last_token_id = seq.deref().get_last_token_id();
+            let seqlen = seq.deref().get_len();
+            input_ids.push(last_token_id);
+            positions.push(seqlen as i64);
+            context_lens.push(seqlen as u32);
 
-                let position = seq.deref_mut().get_len() - 1;
-                input_positions.push(vec![position]);
-
-                let context_len = if let Some(sliding_window) = self.config.sliding_window {
-                    seq.deref_mut().get_len().min(sliding_window)
-                } else {
-                    seq.deref_mut().get_len()
-                };
-                context_lens.push(context_len);
-
-                let table = self
-                    .scheduler
-                    .block_engine
-                    .block_tables
-                    .get(&seq.deref_mut().get_id())
-                    .unwrap();
-                let table = table
-                    .iter()
-                    .map(|block| block.deref_mut().block_id)
-                    .collect::<Vec<_>>();
-
-                let block_number = if position / self.cache_config.block_size >= table.len() {
-                    panic!("Block table is too small (completion)! start_pos={} block_size={} table_len={}", position, self.cache_config.block_size, table.len());
-                } else {
-                    table.get(position / self.cache_config.block_size).unwrap()
-                };
-                let block_offset = position % self.cache_config.block_size;
-                let slot = block_number * self.cache_config.block_size + block_offset;
-                let slot = slot.try_into().unwrap();
-                slot_mappings.push(vec![slot]);
-
-                if let Some(sliding_window) = self.config.sliding_window {
-                    let sliding_window_blocks = sliding_window / self.cache_config.block_size;
-                    let slide_idx = if table.len() > sliding_window_blocks {
-                        table.len() - sliding_window_blocks
-                    } else {
-                        0
-                    };
-                    block_tables.push(table.get(slide_idx..).unwrap().to_vec());
-                } else {
-                    block_tables.push(table);
-                }
-            }
+            let table = self
+                .scheduler
+                .block_engine
+                .block_tables
+                .get(&seq.deref().get_id())
+                .unwrap();
+            let block_table_last = table.back().unwrap().deref_mut().block_id as u32;
+            let last_block_tokens = seqlen
+                - (seqlen.div_ceil(self.cache_config.block_size) - 1)
+                    * self.cache_config.block_size;
+            let slot = block_table_last * self.cache_config.block_size as u32
+                + last_block_tokens as u32
+                - 1;
+            slot_mapping.push(slot as i64);
         }
 
-        let input_tokens = _make_tensor_with_pad(
-            input_tokens
-                .iter()
-                .map(|x| x.iter().map(|x| *x as i64).collect::<Vec<_>>())
-                .collect::<Vec<_>>(),
-            1,
-            0,
-            device,
-        )?;
-        let slot_mapping = _make_tensor_with_pad(slot_mappings, 1, _PAD_SLOT_ID, device)?;
+        // Create tensors
+        let length = positions.len();
+        let input_ids = Tensor::from_vec(input_ids, (length,), device)?;
+        let positions = Tensor::from_vec(positions, (length,), device)?;
+        let s_len = slot_mapping.len();
+        let c_len = context_lens.len();
 
-        let max_context_len = context_lens.iter().max().unwrap();
-        let context_lens = Tensor::from_vec(
-            context_lens.iter().map(|x| *x as u32).collect::<Vec<_>>(),
-            (context_lens.len(),),
-            device,
-        )?;
+        let slot_mapping = Tensor::from_vec(slot_mapping, (s_len,), device)?;
+        let context_lens = Tensor::from_vec(context_lens, (c_len,), device)?;
+        let block_tables = self.prepare_block_tables(groups, device)?;
 
-        let max_block_table_len = block_tables.iter().map(|x| x.len()).max().unwrap();
-        let block_tables = _make_tensor_with_pad(
-            block_tables
-                .iter()
-                .map(|x| x.iter().map(|x| *x as u32).collect::<Vec<_>>())
-                .collect::<Vec<_>>(),
-            max_block_table_len,
-            0,
-            device,
-        )?;
-        let block_tables = block_tables.reshape(((), max_block_table_len))?;
+        let input_metadata = InputMetadata {
+            is_prefill: false,
+            slot_mapping,
+            block_tables: Some(block_tables),
+            context_lens: Some(context_lens),
+            cu_seqlens_q: None,
+            cu_seqlens_k: None,
+            max_seqlen_q: 0,
+            max_seqlen_k: 0,
+            max_context_len: self.config.max_seq_len,
+        };
+
         Ok(PreparedInputs {
-            tokens: input_tokens,
-            positions: input_positions,
-            metadata: InputMetadata {
-                prompt_lens: vec![],
-                slot_mapping,
-                max_context_len: Some(*max_context_len),
-                context_lens: Some(context_lens),
-                block_tables: Some(block_tables),
-                is_prompt: false,
-            },
+            tokens: input_ids,
+            positions: positions,
+            metadata: input_metadata,
         })
     }
 

--- a/src/openai/pipelines/llm_engine.rs
+++ b/src/openai/pipelines/llm_engine.rs
@@ -491,10 +491,6 @@ impl LLMEngine {
                     positions,
                     metadata,
                 } = if seqs.values().nth(0).unwrap().deref().is_prompt() {
-                    assert!(
-                        scheduled.len() == 1,
-                        "only one prompt can be schedule at same time!"
-                    );
                     e.prepare_prompt(&scheduled, device)
                 } else {
                     e.prepare_decode(&scheduled, device)

--- a/src/openai/pipelines/mod.rs
+++ b/src/openai/pipelines/mod.rs
@@ -1,5 +1,5 @@
 use crate::openai::sampling_params::Logprobs;
-use candle_core::{Device, Result, Tensor, WithDType};
+use candle_core::Result;
 use dirs;
 use either::Either;
 use std::collections::HashMap;
@@ -10,27 +10,6 @@ pub mod llm_engine;
 pub mod pipeline;
 type TokenOrFinishReason = Either<Logprobs, String>;
 use crate::openai::pipelines::pipeline::DefaultPipeline;
-
-fn _make_tensor_with_pad<D: WithDType>(
-    x: Vec<Vec<D>>,
-    max_len: usize,
-    pad: D,
-    device: &Device,
-) -> Result<Tensor> {
-    let mut padded_x = Vec::new();
-    for mut x_i in x {
-        if x_i.len() < max_len {
-            x_i.extend([pad].repeat(max_len - x_i.len()));
-        }
-        padded_x.push(x_i);
-    }
-    let flattened: Vec<_> = padded_x
-        .iter()
-        .flat_map(|slice| slice.iter())
-        .map(|&xx| xx)
-        .collect();
-    Tensor::from_vec(flattened, (padded_x.len(), max_len), device)
-}
 
 pub(crate) fn get_token(hf_token: Option<String>, hf_token_path: Option<String>) -> Result<String> {
     Ok(match (hf_token, hf_token_path) {


### PR DESCRIPTION

This PR introduces a major migration in **candle-vllm** to align the attention mechanism with the community’s latest approach — `variable-length (var_len) attention`. This method, also used in [vllm.rs](https://github.com/guoqingbao/attention.rs/blob/main/src/lib.rs#L72), treats multiple requests as a single sequence of tokens, eliminating padding in batched processing and making prefill and decoding follow a more unified flow.

Key changes include:

* Varlen metadata construction for prefill and decoding.
* Updated attention logic (chunked prefill with kvcache, var_len attention, etc.)

are largely adapted from **vllm.rs** such as [vllm.rs](https://github.com/guoqingbao/vllm.rs/blob/main/src/core/runner.rs#L392).

This work also lays the foundation for the upcoming **context-cache** feature, which has proven effective for faster prefilling (**even without flash-attn**), for example, [prefill_paged_attn](https://github.com/guoqingbao/attention.rs/blob/main/src/kernels/src/prefill_paged_attn.cu), making context-cache can be used on older devices.

Since this reuses attention components from vllm.rs, @sempervictus — would you be able to test it on a V100?


I will add **context-cache** feature for V100 if this PR workable on CUDA_ARC < 800.