### PR TITLE
Optional multinomial sampling (generation randomness)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -432,7 +432,9 @@ async fn main() -> Result<()> {
         args.prefill_chunk_size,
     )?;
 
-    if (args.top_k.is_some() && args.top_p.is_some()) || pipeline_config.generation_cfg.is_none() {
+    if args.temperature.is_some() || pipeline_config.generation_cfg.is_none() {
+        //overwrite the generation config when temperature (and others) specified in arguments
+        //disable multinomial sampling (generation randomness) by setting `temperature` as 0
         pipeline_config.generation_cfg = Some(GenerationConfig {
             temperature: args.temperature,
             top_k: args.top_k,


### PR DESCRIPTION
Default sampling parameters are loaded from `generation_config.json`, while, sometimes it is useful to disable the generation randomness (multinominal sampling, enabled by temperature, top-p and top-k) for reproducibility, this can be achieved by setting `temperature` argument into 0 in this PR, like:

```
cargo run --release --features cuda,nccl -- --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --isq q4k --d 6,7 --dtype f16 --temperature 0.
```