### PR TITLE
Allow binding to any host address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ struct Args {
     hf_token_path: Option<String>,
 
     /// Host address to bind to, to serve on host:port
-    #[arg(long = "h")]
-    host: Option<String>,
+    #[arg(long = "h", default_value = "0.0.0.0")]
+    host: String,
 
     /// Port to serve on (host:port)
     #[arg(long = "p", default_value_t = 2000)]
@@ -311,7 +311,7 @@ async fn main() -> Result<()> {
     }
 
     let logger: ftail::Ftail = ftail::Ftail::new();
-    let host = args.host.unwrap_or("0.0.0.0".to_string());
+    let host = args.host;
     let mut port = args.port;
     #[cfg(feature = "nccl")]
     let (pipelines, global_rank, daemon_manager) = if multi_process {


### PR DESCRIPTION
Currently, binding works by default to only be on `0.0.0.0`. Depending on the setup, this can be a security issue and requires additional firewalls to protect from direct connections to candle vllm. 

This PR adds the option to specify the host to bind to. The default behavior is preserved, so this PR is 100% backwards compatible for users using candle vllm.