### PR TITLE
feat: make server deps optional behind `server` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ name = "candle-vllm"
 path = "src/main.rs"
 
 [dependencies]
-axum = { version = "0.7.4", features = ["tokio"] }
-utoipa = { version = "4.2", features = ["axum_extras"] }
-tower-http = { version = "0.6.6", features = ["cors"]}
+axum = { version = "0.7.4", features = ["tokio"], optional = true }
+utoipa = { version = "4.2", features = ["axum_extras"], optional = true }
+tower-http = { version = "0.6.6", features = ["cors"], optional = true }
 flume = "0.10.14"
 #actix-web = "4.8.0"
 anyhow = "1.0.75"
 rand = "0.9.0"
 rayon="1.10.0"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14", features = ["full"], optional = true }
 candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b63bf40" }
 candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "b63bf40" }
 dyn-fmt = "0.4.0"
@@ -62,7 +62,7 @@ itertools = "0.13.0"
 chrono = "0.4.41"
 which = "8.0.0"
 ahash = "0.8.11"
-rustchatui = { git = "https://github.com/guoqingbao/rustchatui.git", rev="68caad9" }
+rustchatui = { git = "https://github.com/guoqingbao/rustchatui.git", rev="68caad9", optional = true }
 base64 = "0.22.1"
 bytes = "1.5"
 reqwest = { version = "0.12.24", features = ["blocking", "json", "rustls-tls"]}
@@ -76,6 +76,8 @@ image = { version = "0.25.6", default-features = false, features = ["bmp", "gif"
 bytemuck = "1.23.2"
 
 [features]
+default = ["server"]
+server = ["dep:axum", "dep:utoipa", "dep:tower-http", "dep:rustchatui", "dep:hyper"]
 accelerate = ["dep:accelerate-src", "candle-core/accelerate", "candle-nn/accelerate"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "attention-rs/cuda"]
 cutlass = ["cuda", "attention-rs/cutlass"]

--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -139,6 +139,7 @@ pub mod conversation;
 pub mod logits_processor;
 pub mod models;
 pub mod multimodal;
+#[cfg(feature = "server")]
 pub mod openai_server;
 pub mod pipelines;
 pub mod utils;

--- a/src/openai/responses.rs
+++ b/src/openai/responses.rs
@@ -1,7 +1,10 @@
 use super::streaming::Streamer;
 use crate::openai::sampling_params::Logprobs;
+#[cfg(feature = "server")]
 use axum::extract::Json;
+#[cfg(feature = "server")]
 use axum::http::{self, StatusCode};
+#[cfg(feature = "server")]
 use axum::response::{IntoResponse, Sse};
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
@@ -113,6 +116,7 @@ pub struct ChatCompletionChunk {
     pub usage: Option<ChatCompletionUsageResponse>,
 }
 
+#[cfg(feature = "server")]
 trait ErrorToResponse: Serialize {
     fn to_response(&self, code: StatusCode) -> axum::response::Response {
         let mut r = Json(self).into_response();
@@ -121,18 +125,22 @@ trait ErrorToResponse: Serialize {
     }
 }
 
+#[cfg(feature = "server")]
 #[derive(Serialize)]
 struct JsonError {
     message: String,
 }
 
+#[cfg(feature = "server")]
 impl JsonError {
     fn new(message: String) -> Self {
         Self { message }
     }
 }
+#[cfg(feature = "server")]
 impl ErrorToResponse for JsonError {}
 
+#[cfg(feature = "server")]
 pub enum ChatResponder {
     Streamer(Sse<Streamer>),
     Completion(ChatCompletionResponse),
@@ -142,6 +150,7 @@ pub enum ChatResponder {
     ValidationError(APIError),
 }
 
+#[cfg(feature = "server")]
 impl IntoResponse for ChatResponder {
     fn into_response(self) -> axum::response::Response {
         match self {

--- a/src/openai/streaming.rs
+++ b/src/openai/streaming.rs
@@ -1,7 +1,9 @@
 use super::responses::{ChatCompletionChunk, EmbeddingResponse};
 use crate::openai::logger::ChatCompletionLogger;
+#[cfg(feature = "server")]
 use axum::response::sse::Event;
 use flume::Receiver;
+#[cfg(feature = "server")]
 use futures::Stream;
 use std::{
     pin::Pin,
@@ -31,6 +33,7 @@ pub struct Streamer {
     pub logger: Option<Arc<ChatCompletionLogger>>,
 }
 
+#[cfg(feature = "server")]
 impl Stream for Streamer {
     type Item = Result<Event, axum::Error>;
 


### PR DESCRIPTION
## Summary

- Makes `axum`, `hyper`, `tower-http`, `utoipa`, and `rustchatui` optional dependencies behind a new `server` feature flag
- The `server` feature is enabled by default, so this is fully backwards-compatible
- Gates server-specific types (`ChatResponder`, `IntoResponse` impl, `Stream` impl for `Streamer`, etc.) behind `#[cfg(feature = "server")]`

## Motivation

This allows candle-vllm to be used as a **library dependency** for embedding/inference workloads without pulling in the HTTP server stack. Useful when candle-vllm is embedded in another application that provides its own API layer.

## Test plan

- [ ] `cargo build` (default features, includes server) — should compile as before
- [ ] `cargo build --no-default-features` — should compile without server deps
- [ ] `cargo build --no-default-features --features cuda` — CUDA without server